### PR TITLE
imrove LIBDIR detection in binreloc

### DIFF
--- a/config.h.cmake
+++ b/config.h.cmake
@@ -10,6 +10,7 @@
 #define HOSTNAME		""
 #define ARCH_@HARDINFO_ARCH@
 
+#define LIBDIR			"@CMAKE_INSTALL_LIBDIR@"
 #define LIBPREFIX		"@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_LIBDIR@/hardinfo"
 #define PREFIX			"@CMAKE_INSTALL_PREFIX@/share/hardinfo"
 

--- a/hardinfo/binreloc.c
+++ b/hardinfo/binreloc.c
@@ -593,11 +593,7 @@ gchar *gbr_find_lib_dir(const gchar * default_lib_dir)
 	    return NULL;
     }
 
-#ifdef ARCH_x86_64
-    dir = g_build_filename(prefix, "lib64", NULL);
-#else
-    dir = g_build_filename(prefix, "lib", NULL);
-#endif
+    dir = g_build_filename(prefix, LIBDIR, NULL);
 
     g_free(prefix);
     return dir;


### PR DESCRIPTION
use the LIBDIR we get from GNUInstallDirs module instead of this ifdef,
it should be more robust and is distro dependant

cmake also allows to pass a custom libdir which would not be respected by the current binreloc logic
