### PR TITLE
Updated URL's to HTTPS

### DIFF
--- a/cmake/GNUInstallDirs.cmake
+++ b/cmake/GNUInstallDirs.cmake
@@ -1,6 +1,6 @@
 # - Define GNU standard installation directories
 # Provides install directory variables as defined for GNU software:
-#  http://www.gnu.org/prep/standards/html_node/Directory-Variables.html
+#  https://www.gnu.org/prep/standards/html_node/Directory-Variables.html
 # Inclusion of this module defines the following variables:
 #  CMAKE_INSTALL_<dir>      - destination for files of a given type
 #  CMAKE_INSTALL_FULL_<dir> - corresponding absolute path
@@ -76,7 +76,7 @@ if(NOT DEFINED CMAKE_INSTALL_LIBDIR)
   #  - we are on a 64 bits system
   # reason is: amd64 ABI: http://www.x86-64.org/documentation/abi.pdf
   # Note that the future of multi-arch handling may be even
-  # more complicated than that: http://wiki.debian.org/Multiarch
+  # more complicated than that: https://wiki.debian.org/Multiarch
   if(CMAKE_SYSTEM_NAME MATCHES "Linux"
       AND NOT CMAKE_CROSSCOMPILING
       AND NOT EXISTS "/etc/debian_version")

--- a/doc/index.hlp
+++ b/doc/index.hlp
@@ -31,5 +31,5 @@ HardInfo can gather information about your system's hardware and operating syste
 
 ## Following
 
-* [http://twitter.com/hardinfo Twitter] (for GitHub commits)
+* [https://twitter.com/hardinfo Twitter] (for GitHub commits)
 * [http://lists.hardinfo.org Mailing Lists]

--- a/modules/benchmark/fbench.c
+++ b/modules/benchmark/fbench.c
@@ -7,7 +7,7 @@
 				     John Walker   December 1980
 
 	By John Walker
-	   http://www.fourmilab.ch/
+	   https://www.fourmilab.ch/
 
 	This  program may be used, distributed, and modified freely as
 	long as the origin information is preserved.
@@ -214,7 +214,7 @@
     0.1129     0.2119	Dell Dimension XPS P133c, Pentium 133 MHz,
 			Windows 95, Microsoft Visual C 5.0.
 
-    0.0883     0.2166	Silicon Graphics Indigo², MIPS R4400,
+    0.0883     0.2166	Silicon Graphics IndigoÂ², MIPS R4400,
                         175 Mhz, "-O3".
 
     0.0351     0.0561	Dell Dimension XPS R100, Pentium II 400 MHz,

--- a/modules/benchmark/fftbench.c
+++ b/modules/benchmark/fftbench.c
@@ -16,7 +16,7 @@
     transform to the seat, too.
 
     Actual benchmark results can be found at:
-            http://www.coyotegulch.com
+            http://scottrobertladd.net/coyotegulch/
 
     Please do not use this information or algorithm in any way that might
     upset the balance of the universe or otherwise cause a disturbance in

--- a/shell/callbacks.c
+++ b/shell/callbacks.c
@@ -80,7 +80,7 @@ void cb_open_web_page()
 
 void cb_report_bug()
 {
-    open_url("http://github.com/lpereira/hardinfo");
+    open_url("https://github.com/lpereira/hardinfo");
 }
 
 void cb_refresh()

--- a/shell/report.c
+++ b/shell/report.c
@@ -93,7 +93,7 @@ void report_context_configure(ReportContext * ctx, GKeyFile * keyfile)
        flag will be set if we should support that.
 
        so i don't forget how to encode the images inside the html files:
-       http://en.wikipedia.org/wiki/Data:_URI_scheme */
+       https://en.wikipedia.org/wiki/Data:_URI_scheme */
 
     ctx->is_image_enabled = (g_key_file_get_boolean(keyfile,
 						    group,


### PR DESCRIPTION
Note: http://www.x86-64.org/documentation/abi.pdf (/cmake/GNUInstallDirs.cmake), http://www.erlenstar.demon.co.uk/unix/faq_3.html#SEC26 (/hardinfo/socket.c), http://www.krugle.org/examples/p-OZYzuisV6gyQIaTu/iwconfig.c (/modules/network/net.c) and http://gentoo-wiki.com/Cpuinfo (/modules/devices/x86/processor.c) don't work.