### PR TITLE
Fixed French translation

### DIFF
--- a/po/fr.po
+++ b/po/fr.po
@@ -407,7 +407,7 @@ msgstr ""
 #: shell//syncmanager.c:518
 #, c-format
 msgid "Failed while performing \"%s\". Please file a bug report if this problem persists. (Use the Help→Report bug option.)"
-msgstr "Échec lors de l'exécution de \"%s\". S'il vous plaît remplissez un rapport de bug si ce problème persiste. (Utilisez l'option Aide → Rapport de Bug.) \n"
+msgstr "Échec lors de l'exécution de \"%s\". S'il vous plaît remplissez un rapport de bug si ce problème persiste. (Utilisez l'option Aide → Rapport de Bug.)"
 
 #: shell//syncmanager.c:646
 msgid "Network Updater"


### PR DESCRIPTION
There was the message after compiling:

> [100%] Built target network
> /hardinfo/po/fr.po:410: 'msgid' and 'msgstr' entries do not both end with '\n'
> /usr/bin/msgfmt: found 1 fatal error
> po/CMakeFiles/i18n.dir/build.make:57: recipe for target 'i18n' failed
> make[2]: *** [i18n] Error 1
> CMakeFiles/Makefile2:308: recipe for target 'po/CMakeFiles/i18n.dir/all' failed
> make[1]: *** [po/CMakeFiles/i18n.dir/all] Error 2
> Makefile:127: recipe for target 'all' failed
> make: *** [all] Error 2

@yolateng0, please, be careful.