### PR TITLE
.gitignore: add build/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ config.h
 *.o
 *~
 arch/this
+build/
+


### PR DESCRIPTION
Everyone who follows the official build instructions will have a
build/.

Makes `git status` cleaner.