### PR TITLE
Fixed compile warning in benchmark.c

### DIFF
--- a/modules/benchmark.c
+++ b/modules/benchmark.c
@@ -566,7 +566,7 @@ static gchar *get_benchmark_results()
 				    "machine=%s\n"
 				    "machineclock=%s\n"
 				    "machineram=%s\n"
-				    "nbenchmarks=%d\n",
+				    "nbenchmarks=%zu\n",
 				    machine,
 				    machineclock,
 				    machineram,


### PR DESCRIPTION
Fixed compile warning in benchmark.c:

> Scanning dependencies of target benchmark
> [ 48%] Building C object CMakeFiles/benchmark.dir/modules/benchmark.c.o
> /home/maxpayne/hardinfo/modules/benchmark.c: In function ‘get_benchmark_results’:
> /home/maxpayne/hardinfo/modules/benchmark.c:565:37: warning: format ‘%d’ expects argument of type ‘int’, but argument 5 has type ‘long unsigned int’ [-Wformat=]
>      gchar *result = g_strdup_printf("[param]\n"
>                                      ^