### PR TITLE
Fixed compile warning in computer.c

### DIFF
--- a/modules/computer.c
+++ b/modules/computer.c
@@ -444,8 +444,8 @@ gchar *callback_os()
 			   computer->os->hostname,
 			   computer->os->username,
 			   computer->os->language,
-			   computer->os->homedir, computer->os->desktop,
-			   computer->os->entropy_avail);
+			   computer->os->homedir,
+			   computer->os->desktop);
 }
 
 gchar *callback_modules()


### PR DESCRIPTION
Fixed compile warning in computer.c:

> [ 70%] Building C object CMakeFiles/computer.dir/modules/computer.c.o
> In file included from /home/maxpayne/hardinfo/modules/computer.c:27:0:
> /home/maxpayne/hardinfo/modules/computer.c: In function ‘callback_os’:
> /home/maxpayne/hardinfo/modules/computer.c:421:30: warning: too many arguments for format [-Wformat-extra-args]
>      return g_strdup_printf(_("[$ShellParam$]\n"
>                               ^
> /home/maxpayne/hardinfo/includes/hardinfo.h:28:30: note: in definition of macro ‘_’
>  #define _(STRING)    gettext(STRING)
>                               ^