### PR TITLE
Fixed compile warning in utils.c

### DIFF
--- a/hardinfo/util.c
+++ b/hardinfo/util.c
@@ -97,17 +97,20 @@ gchar *seconds_to_string(unsigned int seconds)
     minutes %= 60;
     days = hours / 24;
     hours %= 24;
+    
+    gchar *wminutes;
+    gchar *whours;
+    gchar *wdays;
 
+    wdays = ngettext("%d day, ", "%d days, ", days);
+    whours = ngettext("%d hour, ", "%d hours, ", hours);
+    wminutes = ngettext("%d minute", "%d minutes", minutes);
     if (days < 1) {
 	if (hours < 1)
 	    return g_strdup_printf(ngettext("%d minute", "%d minutes", minutes), minutes);
-
-	return g_strdup_printf(ngettext("%d hour, ", "%d hours, ", hours), hours,
-			       ngettext("%d minute", "%d minutes", minutes), minutes);
+	return g_strdup_printf(whours, wminutes);
     }
-    return g_strdup_printf(ngettext("%d day, ", "%d days, ", days), days,
-			   ngettext("%d hour and ", "%d hours and ", hours), hours,
-			   ngettext("%d minute", "%d minutes", minutes), minutes);
+    return g_strdup_printf(wdays, whours, wminutes);
 }
 
 inline gchar *size_human_readable(gfloat size)


### PR DESCRIPTION
Fixed compile warning in utils.c:

> [ 37%] Building C object CMakeFiles/hardinfo.dir/hardinfo/util.c.o
> /home/maxpayne/hardinfo/hardinfo/util.c: In function ‘seconds_to_string’:
> /home/maxpayne/hardinfo/hardinfo/util.c:105:34: warning: too many arguments for format [-Wformat-extra-args]
>   return g_strdup_printf(ngettext("%d hour, ", "%d hours, ", hours), hours,
>                                   ^
> /home/maxpayne/hardinfo/hardinfo/util.c:108:37: warning: too many arguments for format [-Wformat-extra-args]
>      return g_strdup_printf(ngettext("%d day, ", "%d days, ", days), days,
>                                      ^