### PR TITLE
Added GTK3 support (unfinished, need help)

### DIFF
--- a/includes/loadgraph.h
+++ b/includes/loadgraph.h
@@ -40,12 +40,28 @@ typedef enum {
 } LoadGraphColor;
 
 struct _LoadGraph {
+#if GTK_CHECK_VERSION(3, 0, 0)
+    cairo_surface_t *buf;
+#else
     GdkPixmap     *buf;
+#endif
     GtkWidget     *area;
 
+#if GTK_CHECK_VERSION(3, 0, 0)
+    cairo_t       *grid;
+#else
     GdkGC         *grid;
+#endif
+#if GTK_CHECK_VERSION(3, 0, 0)
+    cairo_t       *trace;
+#else
     GdkGC         *trace;
-    GdkGC	  *fill;
+#endif
+#if GTK_CHECK_VERSION(3, 0, 0)
+    cairo_t       *fill;
+#else
+    GdkGC	      *fill;
+#endif
 
     gint     	  *data;
     gfloat         scale;

--- a/shell/callbacks.c
+++ b/shell/callbacks.c
@@ -44,6 +44,15 @@ void cb_save_graphic()
     gchar *filename;
 
     /* save the pixbuf to a png file */
+#if GTK_CHECK_VERSION(3, 0, 0)
+    dialog = gtk_file_chooser_dialog_new(_("Save Image"),
+					 NULL,
+					 GTK_FILE_CHOOSER_ACTION_SAVE,
+					 "_Cancel",
+					 GTK_RESPONSE_CANCEL,
+					 "_Save",
+					 GTK_RESPONSE_ACCEPT, NULL);
+#else
     dialog = gtk_file_chooser_dialog_new(_("Save Image"),
 					 NULL,
 					 GTK_FILE_CHOOSER_ACTION_SAVE,
@@ -51,6 +60,7 @@ void cb_save_graphic()
 					 GTK_RESPONSE_CANCEL,
 					 GTK_STOCK_SAVE,
 					 GTK_RESPONSE_ACCEPT, NULL);
+#endif
 
     filename = g_strconcat(shell->selected->name, ".png", NULL);
     gtk_file_chooser_set_current_name(GTK_FILE_CHOOSER(dialog), filename);

--- a/shell/report.c
+++ b/shell/report.c
@@ -490,6 +490,15 @@ static gchar *report_get_filename(void)
     GtkWidget *dialog;
     gchar *filename = NULL;
 
+#if GTK_CHECK_VERSION(3, 0, 0)
+    dialog = gtk_file_chooser_dialog_new(_("Save File"),
+					 NULL,
+					 GTK_FILE_CHOOSER_ACTION_SAVE,
+					 "_Cancel",
+					 GTK_RESPONSE_CANCEL,
+					 "_Save",
+					 GTK_RESPONSE_ACCEPT, NULL);
+#else
     dialog = gtk_file_chooser_dialog_new(_("Save File"),
 					 NULL,
 					 GTK_FILE_CHOOSER_ACTION_SAVE,
@@ -497,6 +506,7 @@ static gchar *report_get_filename(void)
 					 GTK_RESPONSE_CANCEL,
 					 GTK_STOCK_SAVE,
 					 GTK_RESPONSE_ACCEPT, NULL);
+#endif
 
     gtk_file_chooser_set_current_name(GTK_FILE_CHOOSER(dialog),
 				      "hardinfo_report");
@@ -636,9 +646,15 @@ static gboolean report_generate(ReportDialog * rd)
 					GTK_MESSAGE_QUESTION,
 					GTK_BUTTONS_NONE,
 					_("Open the report with your web browser?"));
+#if GTK_CHECK_VERSION(3, 0, 0)
+    gtk_dialog_add_buttons(GTK_DIALOG(dialog),
+			       "_No", GTK_RESPONSE_REJECT,
+			       "_Open", GTK_RESPONSE_ACCEPT, NULL);
+#else
 	gtk_dialog_add_buttons(GTK_DIALOG(dialog),
 			       GTK_STOCK_NO, GTK_RESPONSE_REJECT,
 			       GTK_STOCK_OPEN, GTK_RESPONSE_ACCEPT, NULL);
+#endif
 	if (gtk_dialog_run(GTK_DIALOG(dialog)) == GTK_RESPONSE_ACCEPT) {
 	    gchar *temp;
 	    
@@ -786,12 +802,21 @@ static ReportDialog
     gtk_window_set_type_hint(GTK_WINDOW(dialog),
 			     GDK_WINDOW_TYPE_HINT_DIALOG);
 
+#if GTK_CHECK_VERSION(3, 0, 0)
+    /*dialog1_vbox = GTK_BOX(GTK_DIALOG(dialog)->vbox);*/
+    dialog1_vbox = GTK_DIALOG(dialog)/*->vbox*/;
+#else
     dialog1_vbox = GTK_DIALOG(dialog)->vbox;
+#endif
     gtk_box_set_spacing(GTK_BOX(dialog1_vbox), 5);
     gtk_container_set_border_width(GTK_CONTAINER(dialog1_vbox), 4);
     gtk_widget_show(dialog1_vbox);
 
+#if GTK_CHECK_VERSION(3, 0, 0)
+    hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 5);
+#else
     hbox = gtk_hbox_new(FALSE, 5);
+#endif
     gtk_box_pack_start(GTK_BOX(dialog1_vbox), hbox, FALSE, FALSE, 0);
 
     label = gtk_label_new(_("<big><b>Generate Report</b></big>\n"
@@ -799,15 +824,23 @@ static ReportDialog
 			  "to view in your report:"));
     gtk_label_set_line_wrap(GTK_LABEL(label), TRUE);
     gtk_label_set_use_markup(GTK_LABEL(label), TRUE);
+#if GTK_CHECK_VERSION(3, 0, 0)
+    gtk_widget_set_valign(GTK_LABEL(label), GTK_ALIGN_CENTER);
+#else
     gtk_misc_set_alignment(GTK_MISC(label), 0.0, 0.5);
+#endif
 
     gtk_box_pack_start(GTK_BOX(hbox),
 		       icon_cache_get_image("report-large.png"),
 		       FALSE, FALSE, 0);
     gtk_box_pack_start(GTK_BOX(hbox), label, FALSE, TRUE, 0);
     gtk_widget_show_all(hbox);
-    
+
+#if GTK_CHECK_VERSION(3, 0, 0)
+    hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 5);
+#else
     hbox = gtk_hbox_new(FALSE, 5);
+#endif
     gtk_box_pack_start(GTK_BOX(dialog1_vbox), hbox, TRUE, TRUE, 0);
     gtk_widget_show(hbox);
 
@@ -847,7 +880,11 @@ static ReportDialog
     gtk_tree_view_column_add_attribute(column, cr_text, "markup",
 				       TREE_COL_NAME);
 
+#if GTK_CHECK_VERSION(3, 0, 0)
+    vbuttonbox3 = gtk_button_box_new(GTK_ORIENTATION_VERTICAL);
+#else
     vbuttonbox3 = gtk_vbutton_box_new();
+#endif
     gtk_widget_show(vbuttonbox3);
     gtk_box_pack_start(GTK_BOX(hbox), vbuttonbox3, FALSE, TRUE, 0);
     gtk_box_set_spacing(GTK_BOX(vbuttonbox3), 5);
@@ -857,33 +894,57 @@ static ReportDialog
     button3 = gtk_button_new_with_mnemonic(_("Select _None"));
     gtk_widget_show(button3);
     gtk_container_add(GTK_CONTAINER(vbuttonbox3), button3);
+#if GTK_CHECK_VERSION(3, 0, 0)
+    gtk_widget_set_can_default(button3, TRUE);
+#else
     GTK_WIDGET_SET_FLAGS(button3, GTK_CAN_DEFAULT);
+#endif
     g_signal_connect(button3, "clicked",
 		     G_CALLBACK(report_dialog_sel_none), rd);
 
     button6 = gtk_button_new_with_mnemonic(_("Select _All"));
     gtk_widget_show(button6);
     gtk_container_add(GTK_CONTAINER(vbuttonbox3), button6);
+#if GTK_CHECK_VERSION(3, 0, 0)
+    gtk_widget_set_can_default(button6, TRUE);
+#else
     GTK_WIDGET_SET_FLAGS(button6, GTK_CAN_DEFAULT);
+#endif
     g_signal_connect(button6, "clicked", G_CALLBACK(report_dialog_sel_all),
 		     rd);
 
+#if GTK_CHECK_VERSION(3, 0, 0)
+    dialog1_action_area = GTK_DIALOG(dialog)/*->action_area*/;
+#else
     dialog1_action_area = GTK_DIALOG(dialog)->action_area;
+#endif
     gtk_widget_show(dialog1_action_area);
     gtk_button_box_set_layout(GTK_BUTTON_BOX(dialog1_action_area),
 			      GTK_BUTTONBOX_END);
 
+#if GTK_CHECK_VERSION(3, 0, 0)
+    button8 = gtk_button_new_with_label("_Cancel");
+#else
     button8 = gtk_button_new_from_stock(GTK_STOCK_CANCEL);
+#endif
     gtk_widget_show(button8);
     gtk_dialog_add_action_widget(GTK_DIALOG(dialog), button8,
 				 GTK_RESPONSE_CANCEL);
+#if GTK_CHECK_VERSION(3, 0, 0)
+    gtk_widget_set_can_default(button8, TRUE);
+#else
     GTK_WIDGET_SET_FLAGS(button8, GTK_CAN_DEFAULT);
+#endif
 
     button7 = gtk_button_new_with_mnemonic(_("_Generate"));
     gtk_widget_show(button7);
     gtk_dialog_add_action_widget(GTK_DIALOG(dialog), button7,
 				 GTK_RESPONSE_ACCEPT);
+#if GTK_CHECK_VERSION(3, 0, 0)
+    gtk_widget_set_can_default(button7, TRUE);
+#else
     GTK_WIDGET_SET_FLAGS(button7, GTK_CAN_DEFAULT);
+#endif
 
     rd->dialog = dialog;
     rd->btn_cancel = button8;

--- a/shell/shell.c
+++ b/shell/shell.c
@@ -358,14 +358,19 @@ static ShellNote *note_new(void)
     note->label = gtk_label_new("");
     note->event_box = gtk_event_box_new();
     button = gtk_button_new();
-    
+
     border_box = gtk_event_box_new();
     gtk_container_set_border_width(GTK_CONTAINER(border_box), 1);
     gtk_container_add(GTK_CONTAINER(note->event_box), border_box);
     gtk_widget_show(border_box);
-    
+
+#if GTK_CHECK_VERSION(3, 0, 0)
+    gtk_widget_override_background_color(border_box, GTK_STATE_NORMAL, &info_default_fill_color);
+    gtk_widget_override_background_color(note->event_box, GTK_STATE_NORMAL, &info_default_border_color);
+#else
     gtk_widget_modify_bg(border_box, GTK_STATE_NORMAL, &info_default_fill_color);
     gtk_widget_modify_bg(note->event_box, GTK_STATE_NORMAL, &info_default_border_color);
+#endif
 
     icon = icon_cache_get_image("close.png");
     gtk_widget_show(icon);
@@ -374,7 +379,11 @@ static ShellNote *note_new(void)
     g_signal_connect(G_OBJECT(button), "clicked", (GCallback) close_note,
 		     NULL);
 
+#if GTK_CHECK_VERSION(3, 0, 0)
+    hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 3);
+#else
     hbox = gtk_hbox_new(FALSE, 3);
+#endif
     icon = icon_cache_get_image("dialog-information.png");
 
     gtk_box_pack_start(GTK_BOX(hbox), icon, FALSE, FALSE, 0);
@@ -415,14 +424,22 @@ static void create_window(void)
     gtk_window_set_default_size(GTK_WINDOW(shell->window), 800, 600);
     g_signal_connect(G_OBJECT(shell->window), "destroy", destroy_me, NULL);
 
+#if GTK_CHECK_VERSION(3, 0, 0)
+    vbox = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
+#else
     vbox = gtk_vbox_new(FALSE, 0);
+#endif
     gtk_widget_show(vbox);
     gtk_container_add(GTK_CONTAINER(shell->window), vbox);
     shell->vbox = vbox;
 
     menu_init(shell);
 
+#if GTK_CHECK_VERSION(3, 0, 0)
+    hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 5);
+#else
     hbox = gtk_hbox_new(FALSE, 5);
+#endif
     gtk_widget_show(hbox);
     gtk_box_pack_end(GTK_BOX(vbox), hbox, FALSE, FALSE, 3);
 
@@ -432,23 +449,39 @@ static void create_window(void)
     gtk_box_pack_end(GTK_BOX(hbox), shell->progress, FALSE, FALSE, 5);
 
     shell->status = gtk_label_new("");
+#if GTK_CHECK_VERSION(3, 0, 0)
+    gtk_widget_set_valign(GTK_MISC(shell->status), GTK_ALIGN_CENTER);
+#else
     gtk_misc_set_alignment(GTK_MISC(shell->status), 0.0, 0.5);
+#endif
     gtk_widget_show(shell->status);
     gtk_box_pack_start(GTK_BOX(hbox), shell->status, FALSE, FALSE, 5);
 
+#if GTK_CHECK_VERSION(3, 0, 0)
+    shell->hpaned = gtk_paned_new(GTK_ORIENTATION_HORIZONTAL);
+#else
     shell->hpaned = gtk_hpaned_new();
+#endif
     gtk_widget_show(shell->hpaned);
     gtk_box_pack_end(GTK_BOX(vbox), shell->hpaned, TRUE, TRUE, 0);
     gtk_paned_set_position(GTK_PANED(shell->hpaned), 210);
 
+#if GTK_CHECK_VERSION(3, 0, 0)
+    vbox = gtk_box_new(GTK_ORIENTATION_VERTICAL, 5);
+#else
     vbox = gtk_vbox_new(FALSE, 5);
+#endif
     gtk_widget_show(vbox);
     gtk_paned_add2(GTK_PANED(shell->hpaned), vbox);
 
     shell->note = note_new();
     gtk_box_pack_end(GTK_BOX(vbox), shell->note->event_box, FALSE, FALSE, 0);
 
+#if GTK_CHECK_VERSION(3, 0, 0)
+    shell->vpaned = gtk_paned_new(GTK_ORIENTATION_VERTICAL);
+#else
     shell->vpaned = gtk_vpaned_new();
+#endif
     gtk_box_pack_start(GTK_BOX(vbox), shell->vpaned, TRUE, TRUE, 0);
     gtk_widget_show(shell->vpaned);
 
@@ -648,15 +681,24 @@ ShellSummary *summary_new(void)
     
     summary = g_new0(ShellSummary, 1);
     summary->scroll = gtk_scrolled_window_new(NULL, NULL);
+#if GTK_CHECK_VERSION(3, 0, 0)
+    summary->view = gtk_box_new(GTK_ORIENTATION_VERTICAL, 5);
+#else
     summary->view = gtk_vbox_new(FALSE, 5);
+#endif
     summary->items = NULL;
 
     gtk_container_set_border_width(GTK_CONTAINER(summary->view), 6);
     gtk_scrolled_window_set_policy(GTK_SCROLLED_WINDOW(summary->scroll),
                                    GTK_POLICY_AUTOMATIC,
                                    GTK_POLICY_AUTOMATIC);
+#if GTK_CHECK_VERSION(3, 0, 0)
+    gtk_container_add(GTK_SCROLLED_WINDOW(summary->scroll),
+                                          summary->view);
+#else
     gtk_scrolled_window_add_with_viewport(GTK_SCROLLED_WINDOW(summary->scroll),
                                           summary->view);
+#endif
     gtk_widget_show_all(summary->scroll);    
 
     return summary;
@@ -810,11 +852,17 @@ static gboolean reload_section(gpointer data)
 	double pos_info_scroll, pos_more_scroll;
 	
 	/* save current position */
+#if GTK_CHECK_VERSION(2, 0, 0)
 	pos_info_scroll = RANGE_GET_VALUE(info, vscrollbar);
 	pos_more_scroll = RANGE_GET_VALUE(moreinfo, vscrollbar);
+#endif
 	
 	/* avoid drawing the window while we reload */
+#if GTK_CHECK_VERSION(3, 0, 0)
+    gdk_window_freeze_updates(shell->window/*->window*/);
+#else
 	gdk_window_freeze_updates(shell->window->window);
+#endif
 	
 	/* gets the current selected path */
 	if (gtk_tree_selection_get_selected
@@ -840,7 +888,11 @@ static gboolean reload_section(gpointer data)
         }
         	
 	/* make the window drawable again */
+#if GTK_CHECK_VERSION(3, 0, 0)
+    gdk_window_thaw_updates(shell->window/*->window*/);
+#else
 	gdk_window_thaw_updates(shell->window->window);
+#endif
     }
 
     /* destroy the timeout: it'll be set up again */
@@ -934,8 +986,13 @@ static void set_view_type(ShellViewType viewtype, gboolean reload)
 	gtk_notebook_set_page(GTK_NOTEBOOK(shell->notebook), 0);
 	gtk_widget_show(shell->notebook);
 
+#if GTK_CHECK_VERSION(3, 0, 0)
 	gtk_paned_set_position(GTK_PANED(shell->vpaned),
+			       shell->hpaned/*->allocation.height / 2*/);
+#else
+    gtk_paned_set_position(GTK_PANED(shell->vpaned),
 			       shell->hpaned->allocation.height / 2);
+#endif
 	break;
     case SHELL_VIEW_LOAD_GRAPH:
         gtk_widget_show(shell->info->scroll);
@@ -943,9 +1000,16 @@ static void set_view_type(ShellViewType viewtype, gboolean reload)
 	gtk_widget_show(shell->notebook);
 	load_graph_clear(shell->loadgraph);
 
+#if GTK_CHECK_VERSION(3, 0, 0)
 	gtk_paned_set_position(GTK_PANED(shell->vpaned),
+			       shell->hpaned/*->allocation.height*/ -
+			       shell->loadgraph->height - 16);
+#else
+    gtk_paned_set_position(GTK_PANED(shell->vpaned),
 			       shell->hpaned->allocation.height -
 			       shell->loadgraph->height - 16);
+#endif
+	
 	break;
     case SHELL_VIEW_PROGRESS_DUAL:
 	gtk_widget_show(shell->notebook);
@@ -1313,7 +1377,11 @@ module_selected_show_info(ShellModuleEntry * entry, gboolean reload)
     key_data = module_entry_function(entry);
 
     /* */
+#if GTK_CHECK_VERSION(3, 0, 0)
+	gdk_window_freeze_updates(shell->info->view/*->window*/);
+#else
     gdk_window_freeze_updates(shell->info->view->window);
+#endif
 
     g_object_ref(shell->info->model);
     gtk_tree_view_set_model(GTK_TREE_VIEW(shell->info->view), NULL);
@@ -1364,7 +1432,11 @@ module_selected_show_info(ShellModuleEntry * entry, gboolean reload)
     gtk_tree_view_set_model(GTK_TREE_VIEW(shell->info->view), shell->info->model);
     gtk_tree_view_expand_all(GTK_TREE_VIEW(shell->info->view));
 
+#if GTK_CHECK_VERSION(3, 0, 0)
+	gdk_window_thaw_updates(shell->info->view/*->window*/);
+#else
     gdk_window_thaw_updates(shell->info->view->window);
+#endif
     shell_set_note_from_entry(entry);
 
     if (shell->view_type == SHELL_VIEW_PROGRESS || shell->view_type == SHELL_VIEW_PROGRESS_DUAL) {
@@ -1492,20 +1564,40 @@ static void shell_summary_add_item(ShellSummary *summary,
      gtk_frame_set_shadow_type(GTK_FRAME(frame),
                                GTK_SHADOW_NONE);
 
+#if GTK_CHECK_VERSION(3, 0, 0)
+     frame_label_box = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 5);
+#else
      frame_label_box = gtk_hbox_new(FALSE, 5);
+#endif
      frame_image = icon_cache_get_image(icon);
      frame_label = gtk_label_new(name);
      gtk_label_set_use_markup(GTK_LABEL(frame_label), TRUE);
      gtk_box_pack_start(GTK_BOX(frame_label_box), frame_image, FALSE, FALSE, 0);
      gtk_box_pack_start(GTK_BOX(frame_label_box), frame_label, FALSE, FALSE, 0);
 
+#if GTK_CHECK_VERSION(3, 0, 0)
+     gtk_widget_set_halign(alignment, GTK_ALIGN_CENTER);
+     gtk_widget_set_valign(alignment, GTK_ALIGN_CENTER);
+#else
      alignment = gtk_alignment_new(0.5, 0.5, 1, 1);
+#endif
      gtk_widget_show(alignment);
      gtk_container_add(GTK_CONTAINER(frame), alignment);
+#if GTK_CHECK_VERSION(3, 0, 0)
+     gtk_widget_set_margin_top(alignment, 0);
+     gtk_widget_set_margin_bottom(alignment, 0);
+     gtk_widget_set_margin_start(alignment, 48);
+     gtk_widget_set_margin_end(alignment, 0);
+#else
      gtk_alignment_set_padding(GTK_ALIGNMENT(alignment), 0, 0, 48, 0);
+#endif
 
      content = gtk_label_new(temp);
+#if GTK_CHECK_VERSION(3, 0, 0)
+     gtk_widget_set_valign(GTK_MISC(content), GTK_ALIGN_CENTER);
+#else
      gtk_misc_set_alignment(GTK_MISC(content), 0.0, 0.5);
+#endif
      gtk_container_add(GTK_CONTAINER(alignment), content);
 
      gtk_widget_show_all(frame);
@@ -1619,6 +1711,7 @@ static void module_selected(gpointer data)
     ShellModuleEntry *entry;
     static ShellModuleEntry *current = NULL;
     static gboolean updating = FALSE;
+    GtkScrollbar		*hscrollbar, *vscrollbar;
 
     /* Gets the currently selected item on the left-side TreeView; if there is no
        selection, silently return */
@@ -1660,10 +1753,17 @@ static void module_selected(gpointer data)
 	gtk_tree_view_columns_autosize(GTK_TREE_VIEW(shell->info->view));
 
 	/* urgh. why don't GTK do this when the model is cleared? */
+#if GTK_CHECK_VERSION(3, 0, 0)
         RANGE_SET_VALUE(info, vscrollbar, 0.0);
         RANGE_SET_VALUE(info, hscrollbar, 0.0);
         RANGE_SET_VALUE(moreinfo, vscrollbar, 0.0);
         RANGE_SET_VALUE(moreinfo, hscrollbar, 0.0);
+#else
+        RANGE_SET_VALUE(info, vscrollbar, 0.0);
+        RANGE_SET_VALUE(info, hscrollbar, 0.0);
+        RANGE_SET_VALUE(moreinfo, vscrollbar, 0.0);
+        RANGE_SET_VALUE(moreinfo, hscrollbar, 0.0);
+#endif
 
 	title = g_strdup_printf("%s - %s", shell->selected_module->name, entry->name);
 	shell_set_title(shell, title);


### PR DESCRIPTION
OK, here is my sketches of adding GTK3 support to HardInfo. After compiling with gtk3, there are error messages something like this:

>/home/maxpayne/hardinfo/shell/shell.c:841:51: error: ‘GtkScrolledWindow {aka struct _GtkScrolledWindow}’ has no member named ‘vscrollbar’
          (GTK_SCROLLED_WINDOW(shell->tree->scroll)-> \
                                                   ^
/usr/include/glib-2.0/gobject/gtype.h:2207:57: note: in definition of macro ‘_G_TYPE_CIC’
     ((ct*) g_type_check_instance_cast ((GTypeInstance*) ip, gt))
                                                         ^
/usr/include/gtk-3.0/gtk/gtkrange.h:40:36: note: in expansion of macro ‘G_TYPE_CHECK_INSTANCE_CAST’
 #define GTK_RANGE(obj)            (G_TYPE_CHECK_INSTANCE_CAST ((obj), GTK_TYPE_RANGE, GtkRange))
                                    ^
/home/maxpayne/hardinfo/shell/shell.c:840:26: note: in expansion of macro ‘GTK_RANGE’
      gtk_range_get_value(GTK_RANGE \
                          ^
/home/maxpayne/hardinfo/shell/shell.c:856:23: note: in expansion of macro ‘RANGE_GET_VALUE’
     pos_info_scroll = RANGE_GET_VALUE(info, vscrollbar);
                       ^

I don't know how to solve them, so I hope that it may be some starting point for further implementing of GTK3.