### PR TITLE
Get board information for Raspberry Pis

### DIFF
--- a/includes/arm/processor-platform.h
+++ b/includes/arm/processor-platform.h
@@ -21,6 +21,7 @@
 
 struct _Processor {
     gchar *model_name;
+    gchar *decoded_name;
     gchar *flags;
     gfloat bogomips;
 

--- a/includes/arm/processor-platform.h
+++ b/includes/arm/processor-platform.h
@@ -27,6 +27,14 @@ struct _Processor {
     gfloat cpu_mhz; /* for devices.c, identical to cpukhz_max/1000 */
     gint cpukhz_max, cpukhz_min, cpukhz_cur; /* for arm/processor.c */
     gint id;
+
+    gchar *cpu_implementer;
+    gchar *cpu_architecture;
+    gchar *cpu_variant;
+    gchar *cpu_part;
+    gchar *cpu_revision;
+
+    gint mode;
 };
 
 #endif	/* __PROCESSOR_PLATFORM_H__ */

--- a/includes/arm/processor-platform.h
+++ b/includes/arm/processor-platform.h
@@ -22,9 +22,11 @@
 struct _Processor {
     gchar *model_name;
     gchar *flags;
-    gfloat bogomips, cpu_mhz;
+    gfloat bogomips;
 
-    gchar *has_fpu;
+    gfloat cpu_mhz; /* for devices.c, identical to cpukhz_max/1000 */
+    gint cpukhz_max, cpukhz_min, cpukhz_cur; /* for arm/processor.c */
+    gint id;
 };
 
 #endif	/* __PROCESSOR_PLATFORM_H__ */

--- a/modules/devices.c
+++ b/modules/devices.c
@@ -195,12 +195,105 @@ gchar *get_memory_total(void)
     return moreinfo_lookup ("DEV:Total Memory"); //hi_more_info(N_("Total Memory"));
 }
 
+/* from: http://elinux.org/RPi_HardwareHistory */
+static struct {
+    char *value, *intro, *model, *pcb, *mem, *mfg;
+} rpi_boardinfo[] = {
+/*  Value        Introduction  Model Name             PCB rev.  Memory       Manufacturer  *
+ *                             Raspberry Pi %s                                            */
+  { "Beta",      "Q1 2012",    "B (Beta)",            "?",      "256MB",    "(Beta board)" },
+  { "0002",      "Q1 2012",    "B",                   "1.0",    "256MB",    "" },
+  { "0003",      "Q3 2012",    "B (ECN0001)",         "1.0",    "256MB",    "(Fuses mod and D14 removed)" },
+  { "0004",      "Q3 2012",    "B",                   "2.0",    "256MB",    "Sony"    },
+  { "0005",      "Q4 2012",    "B",                   "2.0",    "256MB",    "Qisda"   },
+  { "0006",      "Q4 2012",    "B",                   "2.0",    "256MB",    "Egoman"  },
+  { "0007",      "Q1 2013",    "A",                   "2.0",    "256MB",    "Egoman"  },
+  { "0008",      "Q1 2013",    "A",                   "2.0",    "256MB",    "Sony"    },
+  { "0009",      "Q1 2013",    "A",                   "2.0",    "256MB",    "Qisda"   },
+  { "000d",      "Q4 2012",    "B",                   "2.0",    "512MB",    "Egoman" },
+  { "000e",      "Q4 2012",    "B",                   "2.0",    "512MB",    "Sony" },
+  { "000f",      "Q4 2012",    "B",                   "2.0",    "512MB",    "Qisda" },
+  { "0010",      "Q3 2014",    "B+",                  "1.0",    "512MB",    "Sony" },
+  { "0011",      "Q2 2014",    "Compute Module 1",    "1.0",    "512MB",    "Sony" },
+  { "0012",      "Q4 2014",    "A+",                  "1.1",    "256MB",    "Sony" },
+  { "0013",      "Q1 2015",    "B+",                  "1.2",    "512MB",    "?" },
+  { "0014",      "Q2 2014",    "Compute Module 1",    "1.0",    "512MB",    "Embest" },
+  { "0015",      "?",          "A+",                  "1.1",    "256MB/512MB",    "Embest" },
+  { "a01040",    "Unknown",    "2 Model B",           "1.0",    "1GB",      "Sony" },
+  { "a01041",    "Q1 2015",    "2 Model B",           "1.1",    "1GB",      "Sony" },
+  { "a21041",    "Q1 2015",    "2 Model B",           "1.1",    "1GB",      "Embest" },
+  { "a22042",    "Q3 2016",    "2 Model B (with BCM2837)",    "1.2",    "1GB",    "Embest" },
+  { "900021",    "Q3 2016",    "A+",                  "1.1",    "512MB",    "Sony" },
+  { "900032",    "Q2 2016?",    "B+",                 "1.2",    "512MB",    "Sony" },
+  { "900092",    "Q4 2015",    "Zero",                "1.2",    "512MB",    "Sony" },
+  { "900093",    "Q2 2016",    "Zero",                "1.3",    "512MB",    "Sony" },
+  { "920093",    "Q4 2016?",    "Zero",               "1.3",    "512MB",    "Embest" },
+  { "9000c1",    "Q1 2017",    "Zero W",              "1.1",    "512MB",    "Sony" },
+  { "a02082",    "Q1 2016",    "3 Model B",           "1.2",    "1GB",      "Sony" },
+  { "a020a0",    "Q1 2017",    "Compute Module 3 (and CM3 Lite)",    "1.0",    "1GB",    "Sony" },
+  { "a22082",    "Q1 2016",    "3 Model B",           "1.2",    "1GB",    "Embest" },
+  { "a32082",    "Q4 2016",    "3 Model B",           "1.2",    "1GB",    "Sony Japan" },
+  { NULL, NULL, NULL, NULL, NULL, NULL }
+};
+
+gchar *rpi_get_boardname(void) {
+    int i = 0, c = 0;
+    gchar *ret = NULL;
+    gchar *soc = NULL;
+    gchar *revision = NULL;
+    int overvolt = 0;
+    FILE *cpuinfo;
+    gchar buffer[128];
+
+    cpuinfo = fopen("/proc/cpuinfo", "r");
+    if (!cpuinfo)
+    return NULL;
+    while (fgets(buffer, 128, cpuinfo)) {
+        gchar **tmp = g_strsplit(buffer, ":", 2);
+        tmp[0] = g_strstrip(tmp[0]);
+        tmp[1] = g_strstrip(tmp[1]);
+        get_str("Revision", revision);
+        get_str("Hardware", soc);
+    }
+    fclose(cpuinfo);
+
+    if (revision == NULL || soc == NULL) {
+        g_free(soc);
+        g_free(revision);
+        return NULL;
+    }
+
+    if (g_str_has_prefix(revision, "1000"))
+        overvolt = 1;
+
+    while (rpi_boardinfo[i].value != NULL) {
+        if (overvolt)
+            /* +4 to ignore the 1000 prefix */
+            c = g_strcmp0(revision+4, rpi_boardinfo[i].value);
+        else
+            c = g_strcmp0(revision, rpi_boardinfo[i].value);
+
+        if (c == 0) {
+            ret = g_strdup_printf("Raspberry Pi %s (%s) pcb-rev:%s soc:%s mem:%s mfg-by:%s%s",
+                rpi_boardinfo[i].model, rpi_boardinfo[i].intro,
+                rpi_boardinfo[i].pcb, soc,
+                rpi_boardinfo[i].mem, rpi_boardinfo[i].mfg,
+                (overvolt) ? " (over-volted)" : "" );
+            break;
+        }
+        i++;
+    }
+    g_free(soc);
+    g_free(revision);
+    return ret;
+}
+
 gchar *get_motherboard(void)
 {
     char *board_name, *board_vendor;
 #if defined(ARCH_x86) || defined(ARCH_x86_64)
     scan_dmi(FALSE);
-#endif
+
     board_name = moreinfo_lookup("DEV:DMI:Board:Name");
     board_vendor = moreinfo_lookup("DEV:DMI:Board:Vendor");
     
@@ -210,7 +303,13 @@ gchar *get_motherboard(void)
        return g_strconcat(board_name, _(" (vendor unknown)"), NULL);
     else if (board_vendor && *board_vendor)
        return g_strconcat(board_vendor, _(" (model unknown)"), NULL);
-    
+#else
+    /* maybe it is an rpi */
+    board_name = rpi_get_boardname();
+    if (board_name != NULL)
+        return board_name;
+#endif
+
     return g_strdup(_("Unknown"));
 }
 

--- a/modules/devices.c
+++ b/modules/devices.c
@@ -195,14 +195,14 @@ gchar *get_memory_total(void)
     return moreinfo_lookup ("DEV:Total Memory"); //hi_more_info(N_("Total Memory"));
 }
 
-/* from: http://elinux.org/RPi_HardwareHistory */
+/* information table from: http://elinux.org/RPi_HardwareHistory */
 static struct {
     char *value, *intro, *model, *pcb, *mem, *mfg;
 } rpi_boardinfo[] = {
 /*  Value        Introduction  Model Name             PCB rev.  Memory       Manufacturer  *
  *                             Raspberry Pi %s                                            */
   { "Beta",      "Q1 2012",    "B (Beta)",            "?",      "256MB",    "(Beta board)" },
-  { "0002",      "Q1 2012",    "B",                   "1.0",    "256MB",    "" },
+  { "0002",      "Q1 2012",    "B",                   "1.0",    "256MB",    "?" },
   { "0003",      "Q3 2012",    "B (ECN0001)",         "1.0",    "256MB",    "(Fuses mod and D14 removed)" },
   { "0004",      "Q3 2012",    "B",                   "2.0",    "256MB",    "Sony"    },
   { "0005",      "Q4 2012",    "B",                   "2.0",    "256MB",    "Qisda"   },
@@ -222,15 +222,15 @@ static struct {
   { "a01040",    "Unknown",    "2 Model B",           "1.0",    "1GB",      "Sony" },
   { "a01041",    "Q1 2015",    "2 Model B",           "1.1",    "1GB",      "Sony" },
   { "a21041",    "Q1 2015",    "2 Model B",           "1.1",    "1GB",      "Embest" },
-  { "a22042",    "Q3 2016",    "2 Model B (with BCM2837)",    "1.2",    "1GB",    "Embest" },
+  { "a22042",    "Q3 2016",    "2 Model B",           "1.2",    "1GB",    "Embest" },  /* (with BCM2837) */
   { "900021",    "Q3 2016",    "A+",                  "1.1",    "512MB",    "Sony" },
   { "900032",    "Q2 2016?",    "B+",                 "1.2",    "512MB",    "Sony" },
   { "900092",    "Q4 2015",    "Zero",                "1.2",    "512MB",    "Sony" },
   { "900093",    "Q2 2016",    "Zero",                "1.3",    "512MB",    "Sony" },
-  { "920093",    "Q4 2016?",    "Zero",               "1.3",    "512MB",    "Embest" },
+  { "920093",    "Q4 2016?",   "Zero",                "1.3",    "512MB",    "Embest" },
   { "9000c1",    "Q1 2017",    "Zero W",              "1.1",    "512MB",    "Sony" },
   { "a02082",    "Q1 2016",    "3 Model B",           "1.2",    "1GB",      "Sony" },
-  { "a020a0",    "Q1 2017",    "Compute Module 3 (and CM3 Lite)",    "1.0",    "1GB",    "Sony" },
+  { "a020a0",    "Q1 2017",    "Compute Module 3 or CM3 Lite",    "1.0",    "1GB",    "Sony" },
   { "a22082",    "Q1 2016",    "3 Model B",           "1.2",    "1GB",    "Embest" },
   { "a32082",    "Q4 2016",    "3 Model B",           "1.2",    "1GB",    "Sony Japan" },
   { NULL, NULL, NULL, NULL, NULL, NULL }

--- a/modules/devices/arm/arm_data.c
+++ b/modules/devices/arm/arm_data.c
@@ -1,0 +1,215 @@
+/*
+ * rpiz - https://github.com/bp0/rpiz
+ * Copyright (C) 2017  Burt P. <pburt0@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ */
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include "arm_data.h"
+
+/* sources:
+ *   https://unix.stackexchange.com/a/43563
+ *   git:linux/arch/arm/kernel/setup.c
+ *   git:linux/arch/arm64/kernel/cpuinfo.c
+ */
+static struct {
+    char *name, *meaning;
+} tab_flag_meaning[] = {
+    /* arm/hw_cap */
+    { "swp",	"SWP instruction (atomic read-modify-write)" },
+    { "half",	"Half-word loads and stores" },
+    { "thumb",	"Thumb (16-bit instruction set)" },
+    { "26bit",	"26-Bit Model (Processor status register folded into program counter)" },
+    { "fastmult",	"32x32->64-bit multiplication" },
+    { "fpa",	"Floating point accelerator" },
+    { "vfp",	"VFP (early SIMD vector floating point instructions)" },
+    { "edsp",	"DSP extensions (the 'e' variant of the ARM9 CPUs, and all others above)" },
+    { "java",	"Jazelle (Java bytecode accelerator)" },
+    { "iwmmxt",	"SIMD instructions similar to Intel MMX" },
+    { "crunch",	"MaverickCrunch coprocessor (if kernel support enabled)" },
+    { "thumbee",	"ThumbEE" },
+    { "neon",	"Advanced SIMD/NEON on AArch32" },
+    { "evtstrm",	"kernel event stream using generic architected timer" },
+    { "vfpv3",	"VFP version 3" },
+    { "vfpv3d16",	"VFP version 3 with 16 D-registers" },
+    { "vfpv4",	"VFP version 4 with fast context switching" },
+    { "vfpd32",	"VFP with 32 D-registers" },
+    { "tls",	"TLS register" },
+    { "idiva",	"SDIV and UDIV hardware division in ARM mode" },
+    { "idivt",	"SDIV and UDIV hardware division in Thumb mode" },
+    { "lpae",	"40-bit Large Physical Address Extension" },
+    /* arm/hw_cap2 */
+    { "pmull",	"64x64->128-bit F2m multiplication (arch>8)" },
+    { "aes",	"Crypto:AES (arch>8)" },
+    { "sha1",	"Crypto:SHA1 (arch>8)" },
+    { "sha2",	"Crypto:SHA2 (arch>8)" },
+    { "crc32",	"CRC32 checksum instructions (arch>8)" },
+    /* arm64/hw_cap */
+    { "fp",	"" },
+    { "asimd",	"Advanced SIMD/NEON on AArch64 (arch>8)" },
+    { "atomics",	"" },
+    { "fphp",	"" },
+    { "asimdhp",	"" },
+    { "cpuid",	"" },
+    { "asimdrdm",	"" },
+    { "jscvt",	"" },
+    { "fcma",	"" },
+    { "lrcpc",	"" },
+
+    { NULL, NULL},
+};
+
+static struct {
+    int code; char *name;
+} tab_arm_implementer[] = {
+    { 0x41,	"ARM" },
+    { 0x44,	"Intel (formerly DEC) StrongARM" },
+    { 0x4e,	"nVidia" },
+    { 0x54,	"Texas Instruments" },
+    { 0x56,	"Marvell" },
+    { 0x69,	"Intel XScale" },
+    { 0, NULL},
+};
+
+static struct {
+    /* source: t = tested, d = official docs, f = web */
+    int code; char *part_desc;
+} tab_arm_arm_part[] = { /* only valid for implementer 0x41 ARM */
+    /*d */ { 0x920,	"ARM920" },
+    /*d */ { 0x926,	"ARM926" },
+    /*d */ { 0x946,	"ARM946" },
+    /*d */ { 0x966,	"ARM966" },
+    /*d */ { 0xb02,	"ARM11 MPCore" },
+    /*d */ { 0xb36,	"ARM1136" },
+    /*d */ { 0xb56,	"ARM1156" },
+    /*dt*/ { 0xb76,	"ARM1176" },
+    /*dt*/ { 0xc05,	"Cortex-A5" },
+    /*d */ { 0xc07,	"Cortex-A7 MPCore" },
+    /*dt*/ { 0xc08,	"Cortex-A8" },
+    /*dt*/ { 0xc09,	"Cortex-A9" },
+    /*d */ { 0xc0e,	"Cortex-A17 MPCore" },
+    /*d */ { 0xc0f,	"Cortex-A15" },
+    /*d */ { 0xd01,	"Cortex-A32" },
+    /*dt*/ { 0xd03,	"Cortex-A53" },
+    /*d */ { 0xd04,	"Cortex-A35" },
+    /*d */ { 0xd07,	"Cortex-A57 MPCore" },
+    /*d */ { 0xd08,	"Cortex-A72" },
+    /*d */ { 0xd09,	"Cortex-A73" },
+           { 0, NULL},
+};
+
+static char all_flags[1024] = "";
+
+#define APPEND_FLAG(f) strcat(all_flags, f); strcat(all_flags, " ");
+const char *arm_flag_list() {
+    int i = 0, built = 0;
+    built = strlen(all_flags);
+    if (!built) {
+        while(tab_flag_meaning[i].name != NULL) {
+            APPEND_FLAG(tab_flag_meaning[i].name);
+            i++;
+        }
+    }
+    return all_flags;
+}
+
+const char *arm_flag_meaning(const char *flag) {
+    int i = 0;
+    if (flag)
+    while(tab_flag_meaning[i].name != NULL) {
+        if (strcmp(tab_flag_meaning[i].name, flag) == 0)
+            return tab_flag_meaning[i].meaning;
+        i++;
+    }
+    return NULL;
+}
+
+static int code_match(int c0, const char* code1) {
+    int c1;
+    if (code1 == NULL) return 0;
+    c1 = strtol(code1, NULL, 0);
+    return (c0 == c1) ? 1 : 0;
+}
+
+const char *arm_implementer(const char *code) {
+    int i = 0;
+    if (code)
+    while(tab_arm_implementer[i].code) {
+        if (code_match(tab_arm_implementer[i].code, code))
+            return tab_arm_implementer[i].name;
+        i++;
+    }
+    return NULL;
+}
+
+const char *arm_part(const char *imp_code, const char *part_code) {
+    int i = 0;
+    if (imp_code && part_code) {
+        if (code_match(0x41, imp_code)) {
+            /* 0x41=ARM parts */
+            while(tab_arm_arm_part[i].code) {
+                if (code_match(tab_arm_arm_part[i].code, part_code))
+                    return tab_arm_arm_part[i].part_desc;
+                i++;
+            }
+        }
+    }
+    return NULL;
+}
+
+char *arm_decoded_name(const char *imp, const char *part, const char *var, const char *rev, const char *arch, const char *model_name) {
+    char *dnbuff;
+    char *imp_name = NULL, *part_desc = NULL;
+    int r = 0, p = 0;
+    dnbuff = malloc(256);
+    if (dnbuff) {
+        memset(dnbuff, 0, 256);
+
+        if (imp && arch && part && rev) {
+            /* http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.dui0395b/CIHCAGHH.html
+             * variant and revision can be rendered r{variant}p{revision} */
+            r = strtol(var, NULL, 0);
+            p = strtol(rev, NULL, 0);
+            imp_name = (char*) arm_implementer(imp);
+            part_desc = (char*) arm_part(imp, part);
+            if (imp_name || part_desc) {
+                sprintf(dnbuff, "%s %s r%dp%d (arch:%s)",
+                        (imp_name) ? imp_name : imp,
+                        (part_desc) ? part_desc : part,
+                        r, p, arch);
+            } else {
+                /* fallback for now */
+                sprintf(dnbuff, "%s [imp:%s part:%s r%dp%d arch:%s]",
+                        model_name,
+                        (imp_name) ? imp_name : imp,
+                        (part_desc) ? part_desc : part,
+                        r, p, arch);
+            }
+        } else {
+            /* prolly not ARM arch at all */
+            if (model_name)
+                sprintf(dnbuff, "%s", model_name);
+            else {
+                free(dnbuff);
+                return NULL;
+            }
+        }
+    }
+    return dnbuff;
+}

--- a/modules/devices/arm/arm_data.h
+++ b/modules/devices/arm/arm_data.h
@@ -1,0 +1,38 @@
+/*
+ * rpiz - https://github.com/bp0/rpiz
+ * Copyright (C) 2017  Burt P. <pburt0@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ */
+
+#ifndef _ARMDATA_H_
+#define _ARMDATA_H_
+
+/* table lookups */
+const char *arm_implementer(const char *code);
+const char *arm_part(const char *imp_code, const char *part_code);
+
+/* cpu_implementer, cpu_part, cpu_variant, cpu_revision, cpu_architecture from /proc/cpuinfo
+ * model_name is returned as a fallback if not enough data is known */
+char *arm_decoded_name(
+    const char *imp, const char *part, const char *var, const char *rev,
+    const char *arch, const char *model_name);
+
+/* cpu flags from /proc/cpuinfo */
+const char *arm_flag_list(void);                  /* list of all known flags */
+const char *arm_flag_meaning(const char *flag);  /* lookup flag meaning */
+
+#endif

--- a/modules/devices/arm/processor.c
+++ b/modules/devices/arm/processor.c
@@ -22,11 +22,12 @@
 /* sources:
  *   https://unix.stackexchange.com/a/43563
  *   git:linux/arch/arm/kernel/setup.c
+ *   git:linux/arch/arm64/kernel/cpuinfo.c
  */
 static struct {
     char *name, *meaning;
 } flag_meaning[] = {
-    /* hw_cap */
+    /* arm/hw_cap */
     { "swp",	"SWP instruction (atomic read-modify-write)" },
     { "half",	"Half-word loads and stores" },
     { "thumb",	"Thumb (16-bit instruction set)" },
@@ -49,14 +50,24 @@ static struct {
     { "idiva",	"SDIV and UDIV hardware division in ARM mode" },
     { "idivt",	"SDIV and UDIV hardware division in Thumb mode" },
     { "lpae",	"40-bit Large Physical Address Extension" },
-    /* hw_cap2 */
+    /* arm/hw_cap2 */
     { "pmull",	"64x64->128-bit F2m multiplication (arch>8)" },
     { "aes",	"Crypto:AES (arch>8)" },
     { "sha1",	"Crypto:SHA1 (arch>8)" },
     { "sha2",	"Crypto:SHA2 (arch>8)" },
     { "crc32",	"CRC32 checksum instructions (arch>8)" },
-    /* ?? */
+    /* arm64/hw_cap */
+    { "fp",	"" },
     { "asimd",	"Advanced SIMD/NEON on AArch64 (arch>8)" },
+    { "atomics",	"" },
+    { "fphp",	"" },
+    { "asimdhp",	"" },
+    { "cpuid",	"" },
+    { "asimdrdm",	"" },
+    { "jscvt",	"" },
+    { "fcma",	"" },
+    { "lrcpc",	"" },
+
     { NULL, NULL},
 };
 

--- a/modules/devices/arm/processor.c
+++ b/modules/devices/arm/processor.c
@@ -19,22 +19,101 @@
 #include "hardinfo.h"
 #include "devices.h"
 
+/* source: https://unix.stackexchange.com/a/43563 */
+static struct {
+    char *name, *meaning;
+} flag_meaning[] = {
+    { "swp",	"SWP instruction (atomic read-modify-write)" },
+    { "half",	"Half-word loads and stores" },
+    { "thumb",	"Thumb (16-bit instruction set)" },
+    { "26bit",	"26-Bit Model (Processor status register folded into program counter)" },
+    { "fastmult",	"32x32->64-bit multiplication" },
+    { "fpa",	"Floating point accelerator" },
+    { "vfp",	"VFP (early SIMD vector floating point instructions)" },
+    { "edsp",	"DSP extensions (the 'e' variant of the ARM9 CPUs, and all others above)" },
+    { "java",	"Jazelle (Java bytecode accelerator)" },
+    { "iwmmxt",	"SIMD instructions similar to Intel MMX" },
+    { "crunch",	"MaverickCrunch coprocessor (if kernel support enabled)" },
+    { "thumbee",	"ThumbEE" },
+    { "neon",	"Advanced SIMD/NEON on AArch32" },
+    { "asimd",	"Advanced SIMD/NEON on AArch64" },
+    { "evtstrm",	"kernel event stream using generic architected timer" },
+    { "vfpv3",	"VFP version 3" },
+    { "vfpv3d16",	"VFP version 3 with 16 D-registers" },
+    { "vfpv4",	"VFP version 4 with fast context switching" },
+    { "vfpd32",	"VFP with 32 D-registers" },
+    { "tls",	"TLS register" },
+    { "idiva",	"SDIV and UDIV hardware division in ARM mode" },
+    { "idivt",	"SDIV and UDIV hardware division in Thumb mode" },
+    { "pmull{2}",	"64x64->128-bit F2m multiplication" },
+    { NULL, NULL},
+};
+
+GHashTable *cpu_flags = NULL; /* FIXME: when is it freed? */
+
+static void
+populate_cpu_flags_list_internal()
+{
+    int i;
+    cpu_flags = g_hash_table_new(g_str_hash, g_str_equal);
+    for (i = 0; flag_meaning[i].name != NULL; i++) {
+        g_hash_table_insert(cpu_flags, flag_meaning[i].name,
+                            flag_meaning[i].meaning);
+    }
+}
+
+static gint get_cpu_int(const gchar* file, gint cpuid) {
+    gchar *tmp0 = NULL;
+    gchar *tmp1 = NULL;
+    gint ret = 0;
+
+    tmp0 = g_strdup_printf("/sys/devices/system/cpu/cpu%d/%s", cpuid, file);
+    g_file_get_contents(tmp0, &tmp1, NULL, NULL);
+    ret = atol(tmp1);
+
+    g_free(tmp0);
+    g_free(tmp1);
+    return ret;
+}
+
 GSList *
 processor_scan(void)
 {
+    GSList *procs = NULL;
     Processor *processor;
+    gint processor_number = 0;
     FILE *cpuinfo;
     gchar buffer[128];
+    gchar *tmpfreq_str = NULL;
 
     cpuinfo = fopen("/proc/cpuinfo", "r");
     if (!cpuinfo)
     return NULL;
 
-    processor = g_new0(Processor, 1);
     while (fgets(buffer, 128, cpuinfo)) {
         gchar **tmp = g_strsplit(buffer, ":", 2);
 
-        if (tmp[0] && tmp[1]) {
+        if (g_str_has_prefix(tmp[0], "processor")) {
+            if (processor) {
+                procs = g_slist_append(procs, processor);
+            }
+
+            processor = g_new0(Processor, 1);
+            //get_int("processor", processor->id);
+            processor->id = processor_number;
+            processor_number++;
+
+            /* freq */
+            processor->cpukhz_cur = get_cpu_int("cpufreq/scaling_cur_freq", processor->id);
+            processor->cpukhz_min = get_cpu_int("cpufreq/scaling_min_freq", processor->id);
+            processor->cpukhz_max = get_cpu_int("cpufreq/scaling_max_freq", processor->id);
+            if (processor->cpukhz_max)
+                processor->cpu_mhz = processor->cpukhz_max / 1000;
+            else
+                processor->cpu_mhz = 0.0f;
+        }
+
+        if (processor && tmp[0] && tmp[1]) {
             tmp[0] = g_strstrip(tmp[0]);
             tmp[1] = g_strstrip(tmp[1]);
 
@@ -43,27 +122,55 @@ processor_scan(void)
                 get_str("model name", processor->model_name);
             get_str("Features", processor->flags);
             get_float("BogoMIPS", processor->bogomips);
-
-            get_str("Hardware", processor->has_fpu);
         }
         g_strfreev(tmp);
     }
 
-    processor->cpu_mhz = 0.0f;
+    if (processor)
+        procs = g_slist_append(procs, processor);
 
     fclose(cpuinfo);
 
-    return g_slist_append(NULL, processor);
+    return procs;
+}
+
+gchar *processor_get_capabilities_from_flags(gchar * strflags)
+{
+    gchar **flags, **old;
+    gchar *tmp = NULL;
+    gint j = 0;
+
+    if (!cpu_flags)
+        populate_cpu_flags_list_internal();
+
+    flags = g_strsplit(strflags, " ", 0);
+    old = flags;
+
+    while (flags[j]) {
+        gchar *meaning = g_hash_table_lookup(cpu_flags, flags[j]);
+
+        if (meaning) {
+            tmp = h_strdup_cprintf("%s=%s\n", tmp, flags[j], meaning);
+        } else {
+            tmp = h_strdup_cprintf("%s=\n", tmp, flags[j]);
+        }
+        j++;
+    }
+    if (tmp == NULL || g_strcmp0(tmp, "") == 0)
+        tmp = g_strdup_printf("%s=%s\n", "empty", _("Empty List"));
+
+    g_strfreev(old);
+    return tmp;
 }
 
 gchar *
-processor_get_info(GSList *processors)
+processor_get_detailed_info(Processor *processor)
 {
-        Processor *processor = (Processor *)processors->data;
-        
-    return g_strdup_printf("[Processor]\n"
+    gchar *tmp_flags, *ret;
+    tmp_flags = processor_get_capabilities_from_flags(processor->flags);
+
+    ret = g_strdup_printf("[Processor]\n"
                            "Name=%s\n"
-                           "Features=%s\n"
                    "BogoMips=%.2f\n"
                    "Endianesss="
 #if G_BYTE_ORDER == G_LITTLE_ENDIAN
@@ -72,9 +179,57 @@ processor_get_info(GSList *processors)
                        "Big Endian"
 #endif
                        "\n"
-                   "Hardware=%s\n",
+                       "[Freq]\n"
+                       "Min=%d kHz\n"
+                       "Max=%d kHz\n"
+                       "Cur=%d kHz\n"
+                       "[Capabilities]\n"
+                       "%s"
+                       "%s",
                    processor->model_name,
-                   processor->flags,
                    processor->bogomips,
-                   processor->has_fpu);
+                   processor->cpukhz_min,
+                   processor->cpukhz_max,
+                   processor->cpukhz_cur,
+                   tmp_flags,
+                    "");
+    g_free(tmp_flags);
+    return ret;
+}
+
+gchar *processor_get_info(GSList * processors)
+{
+    Processor *processor;
+
+    if (g_slist_length(processors) > 1) {
+    gchar *ret, *tmp, *hashkey;
+    GSList *l;
+
+    tmp = g_strdup("");
+
+    for (l = processors; l; l = l->next) {
+        processor = (Processor *) l->data;
+
+        tmp = g_strdup_printf(_("%s$CPU%d$%s=%.2fMHz\n"),
+                  tmp, processor->id,
+                  processor->model_name,
+                  processor->cpu_mhz);
+
+        hashkey = g_strdup_printf("CPU%d", processor->id);
+        moreinfo_add_with_prefix("DEV", hashkey,
+                processor_get_detailed_info(processor));
+           g_free(hashkey);
+    }
+
+    ret = g_strdup_printf("[$ShellParam$]\n"
+                  "ViewType=1\n"
+                  "[Processors]\n"
+                  "%s", tmp);
+    g_free(tmp);
+
+    return ret;
+    }
+
+    processor = (Processor *) processors->data;
+    return processor_get_detailed_info(processor);
 }

--- a/modules/devices/arm/processor.c
+++ b/modules/devices/arm/processor.c
@@ -28,25 +28,25 @@ processor_scan(void)
 
     cpuinfo = fopen("/proc/cpuinfo", "r");
     if (!cpuinfo)
-	return NULL;
+    return NULL;
 
     processor = g_new0(Processor, 1);
     while (fgets(buffer, 128, cpuinfo)) {
-	gchar **tmp = g_strsplit(buffer, ":", 2);
+        gchar **tmp = g_strsplit(buffer, ":", 2);
 
-	if (tmp[0] && tmp[1]) {
-	    tmp[0] = g_strstrip(tmp[0]);
-	    tmp[1] = g_strstrip(tmp[1]);
+        if (tmp[0] && tmp[1]) {
+            tmp[0] = g_strstrip(tmp[0]);
+            tmp[1] = g_strstrip(tmp[1]);
 
-		get_str("Processor", processor->model_name);
-		if (!processor->model_name)
-			get_str("model name", processor->model_name);
-	    get_str("Features", processor->flags);
-	    get_float("BogoMIPS", processor->bogomips);
+            get_str("Processor", processor->model_name);
+            if (!processor->model_name)
+                get_str("model name", processor->model_name);
+            get_str("Features", processor->flags);
+            get_float("BogoMIPS", processor->bogomips);
 
-	    get_str("Hardware", processor->has_fpu);
-	}
-	g_strfreev(tmp);
+            get_str("Hardware", processor->has_fpu);
+        }
+        g_strfreev(tmp);
     }
 
     processor->cpu_mhz = 0.0f;
@@ -61,20 +61,20 @@ processor_get_info(GSList *processors)
 {
         Processor *processor = (Processor *)processors->data;
         
-	return g_strdup_printf("[Processor]\n"
-	                       "Name=%s\n"
-	                       "Features=%s\n"
-			       "BogoMips=%.2f\n"
-			       "Endianesss="
+    return g_strdup_printf("[Processor]\n"
+                           "Name=%s\n"
+                           "Features=%s\n"
+                   "BogoMips=%.2f\n"
+                   "Endianesss="
 #if G_BYTE_ORDER == G_LITTLE_ENDIAN
-                               "Little Endian"
+                       "Little Endian"
 #else
-                               "Big Endian"
+                       "Big Endian"
 #endif
-                               "\n"
-			       "Hardware=%s\n",
-			       processor->model_name,
-			       processor->flags,
-			       processor->bogomips,
-			       processor->has_fpu);
+                       "\n"
+                   "Hardware=%s\n",
+                   processor->model_name,
+                   processor->flags,
+                   processor->bogomips,
+                   processor->has_fpu);
 }

--- a/modules/devices/arm/processor.c
+++ b/modules/devices/arm/processor.c
@@ -19,10 +19,14 @@
 #include "hardinfo.h"
 #include "devices.h"
 
-/* source: https://unix.stackexchange.com/a/43563 */
+/* sources:
+ *   https://unix.stackexchange.com/a/43563
+ *   git:linux/arch/arm/kernel/setup.c
+ */
 static struct {
     char *name, *meaning;
 } flag_meaning[] = {
+    /* hw_cap */
     { "swp",	"SWP instruction (atomic read-modify-write)" },
     { "half",	"Half-word loads and stores" },
     { "thumb",	"Thumb (16-bit instruction set)" },
@@ -36,7 +40,6 @@ static struct {
     { "crunch",	"MaverickCrunch coprocessor (if kernel support enabled)" },
     { "thumbee",	"ThumbEE" },
     { "neon",	"Advanced SIMD/NEON on AArch32" },
-    { "asimd",	"Advanced SIMD/NEON on AArch64" },
     { "evtstrm",	"kernel event stream using generic architected timer" },
     { "vfpv3",	"VFP version 3" },
     { "vfpv3d16",	"VFP version 3 with 16 D-registers" },
@@ -45,7 +48,15 @@ static struct {
     { "tls",	"TLS register" },
     { "idiva",	"SDIV and UDIV hardware division in ARM mode" },
     { "idivt",	"SDIV and UDIV hardware division in Thumb mode" },
-    { "pmull{2}",	"64x64->128-bit F2m multiplication" },
+    { "lpae",	"40-bit Large Physical Address Extension" },
+    /* hw_cap2 */
+    { "pmull",	"64x64->128-bit F2m multiplication (arch>8)" },
+    { "aes",	"Crypto:AES (arch>8)" },
+    { "sha1",	"Crypto:SHA1 (arch>8)" },
+    { "sha2",	"Crypto:SHA2 (arch>8)" },
+    { "crc32",	"CRC32 checksum instructions (arch>8)" },
+    /* ?? */
+    { "asimd",	"Advanced SIMD/NEON on AArch64 (arch>8)" },
     { NULL, NULL},
 };
 


### PR DESCRIPTION
get_motherboard() will now return something for Raspberry Pi boards.
example:
"Raspberry Pi 3 (Q1 2016) pcb-rev:1.2 soc:BCM2835 mem:1GB mfg-by:Sony"

It can be seen in the GUI by selecting "Computer".