### PR TITLE
Make the strend function accessible

### DIFF
--- a/hardinfo/util.c
+++ b/hardinfo/util.c
@@ -113,7 +113,7 @@ gchar *seconds_to_string(unsigned int seconds)
     return g_strdup_printf(wdays, whours, wminutes);
 }
 
-inline gchar *size_human_readable(gfloat size)
+gchar *size_human_readable(gfloat size)
 {
     if (size < KiB)
 	return g_strdup_printf(_("%.1f B"), size);
@@ -129,7 +129,7 @@ inline gchar *size_human_readable(gfloat size)
     return g_strdup_printf(_("%.1f PiB"), size / PiB);
 }
 
-inline char *strend(gchar * str, gchar chr)
+char *strend(gchar * str, gchar chr)
 {
     if (!str)
 	return NULL;
@@ -141,7 +141,7 @@ inline char *strend(gchar * str, gchar chr)
     return str;
 }
 
-inline void remove_quotes(gchar * str)
+void remove_quotes(gchar * str)
 {
     if (!str)
 	return;
@@ -152,7 +152,7 @@ inline void remove_quotes(gchar * str)
     strend(str, '"');
 }
 
-inline void remove_linefeed(gchar * str)
+void remove_linefeed(gchar * str)
 {
     strend(str, '\n');
 }


### PR DESCRIPTION
In Ubuntu, we had a problem building HardInfo on the s390x architecture because the way our build system is set up, it does not allow HardInfo to use the `strend` function if it was inlined. [Here](https://launchpadlibrarian.net/282109653/buildlog_ubuntu-yakkety-s390x.hardinfo_0.5.1-1.4ubuntu1_BUILDING.txt.gz) is the build log from that failure.

Making the changes in this pull request in Ubuntu's packaging made HardInfo buildable on s390x and caused no additional problems.