### PR TITLE
Device Tree related changes

### DIFF
--- a/includes/dt_util.h
+++ b/includes/dt_util.h
@@ -22,6 +22,7 @@ enum {
     DTP_HEX,     /* list of 32-bit values displayed in hex */
     DTP_UINT,
  /* DTP_INT, */
+    DTP_OVR,     /* all in /__overrides__ */
     DTP_PH,      /* phandle */
     DTP_PH_REF,  /* reference to phandle */
     DTP_REG,     /* <#address-cells, #size-cells> */

--- a/includes/dt_util.h
+++ b/includes/dt_util.h
@@ -72,4 +72,10 @@ char *dtr_maps_info(dtr *); /* returns hardinfo shell section */
 
 const char *dtr_find_device_tree_root(void);
 
+#define sp_sep(STR) (strlen(STR) ? " " : "")
+/* appends an element to a string, adding a space if
+ * the string is not empty.
+ * ex: ret = appf(ret, "%s=%s\n", name, value); */
+char *appf(char *src, char *fmt, ...);
+
 #endif

--- a/includes/dt_util.h
+++ b/includes/dt_util.h
@@ -9,7 +9,7 @@
 #define DTEX_MTUP 0
 
 #ifndef DTR_ROOT
-#define DTR_ROOT "/proc/device-tree"
+#define DTR_ROOT dtr_find_device_tree_root()
 #endif
 
 enum {
@@ -69,5 +69,7 @@ char *dtr_list_byte(uint8_t *bytes, unsigned long count);
 char *dtr_list_hex(dt_uint *list, unsigned long count);
 
 char *dtr_maps_info(dtr *); /* returns hardinfo shell section */
+
+const char *dtr_find_device_tree_root(void);
 
 #endif

--- a/includes/dt_util.h
+++ b/includes/dt_util.h
@@ -6,6 +6,7 @@
 
 /* some not-quite-complete stuff that can be disabled */
 #define DTEX_PHREFS 1
+#define DTEX_MTUP 0
 
 #ifndef DTR_ROOT
 #define DTR_ROOT "/proc/device-tree"

--- a/includes/dt_util.h
+++ b/includes/dt_util.h
@@ -68,6 +68,8 @@ char *dtr_elem_uint(dt_uint e);
 char *dtr_list_byte(uint8_t *bytes, unsigned long count);
 char *dtr_list_hex(dt_uint *list, unsigned long count);
 
+int dtr_cellv_find(dtr_obj *obj, char *qprop, int limit);
+
 char *dtr_maps_info(dtr *); /* returns hardinfo shell section */
 
 const char *dtr_find_device_tree_root(void);

--- a/modules/devices/devicetree/dt_util.c
+++ b/modules/devices/devicetree/dt_util.c
@@ -192,6 +192,22 @@ void _dtr_read_aliases(dtr *);
 void _dtr_read_symbols(dtr *);
 void _dtr_map_phandles(dtr *, char *np);
 
+const char *dtr_find_device_tree_root() {
+    char *candidates[] = {
+        "/proc/device-tree",
+        "/sys/firmware/devicetree/base",
+        /* others? */
+        NULL
+    };
+    int i = 0;
+    while (candidates[i] != NULL) {
+        if(access(candidates[i], F_OK) != -1)
+            return candidates[i];
+        i++;
+    }
+    return "/did/not/find/device-tree";
+}
+
 dtr *dtr_new_x(char *base_path, int fast) {
     dtr *dt = malloc(sizeof(dtr));
     if (dt != NULL) {

--- a/test/data/rpi1_raspbian.dts
+++ b/test/data/rpi1_raspbian.dts
@@ -1,0 +1,758 @@
+/dts-v1/;
+
+/ {
+	compatible = "brcm,bcm2835";
+	serial-number = "00000000925ea123";
+	model = "Raspberry Pi Model B Rev 1";
+	memreserve = <0xf000000 0x1000000>;
+	interrupt-parent = <0x1>;
+	#address-cells = <0x1>;
+	#size-cells = <0x1>;
+
+	clocks {
+		compatible = "simple-bus";
+		#address-cells = <0x1>;
+		#size-cells = <0x0>;
+
+		clock@3 {
+			compatible = "fixed-clock";
+			#clock-cells = <0x0>;
+			phandle = <0x2>;
+			reg = <0x3>;
+			clock-output-names = "osc";
+			clock-frequency = <0x124f800>;
+		};
+
+		clock@4 {
+			compatible = "fixed-clock";
+			#clock-cells = <0x0>;
+			phandle = <0x11>;
+			reg = <0x4>;
+			clock-output-names = "otg";
+			clock-frequency = <0x1c9c3800>;
+		};
+	};
+
+	__overrides__ {
+		i2c1 = [00 00 00 1b 73 74 61 74 75 73 00];
+		i2c_vc = [00 00 00 1b 73 74 61 74 75 73 00];
+		sd_overclock = "", "", "", " brcm,overclock-50:0";
+		i2c0_baudrate = [00 00 00 1a 63 6c 6f 63 6b 2d 66 72 65 71 75 65 6e 63 79 3a 30 00];
+		sd_pio_limit = "", "", "", " brcm,pio-limit:0";
+		act_led_trigger = [00 00 00 1c 6c 69 6e 75 78 2c 64 65 66 61 75 6c 74 2d 74 72 69 67 67 65 72 00];
+		audio = [00 00 00 1d 73 74 61 74 75 73 00];
+		sd_debug = "", "", "", " brcm,debug";
+		cache_line_size = [00 00 00 15 63 61 63 68 65 2d 6c 69 6e 65 2d 73 69 7a 65 3a 30 00];
+		i2c1_baudrate = [00 00 00 1b 63 6c 6f 63 6b 2d 66 72 65 71 75 65 6e 63 79 3a 30 00];
+		spi = [00 00 00 19 73 74 61 74 75 73 00];
+		i2c_arm = [00 00 00 1a 73 74 61 74 75 73 00];
+		uart0 = [00 00 00 16 73 74 61 74 75 73 00];
+		i2c2_iknowwhatimdoing = [00 00 00 10 73 74 61 74 75 73 00];
+		i2s = [00 00 00 18 73 74 61 74 75 73 00];
+		i2c0 = [00 00 00 1a 73 74 61 74 75 73 00];
+		watchdog = [00 00 00 1e 73 74 61 74 75 73 00];
+		i2c_baudrate = [00 00 00 1a 63 6c 6f 63 6b 2d 66 72 65 71 75 65 6e 63 79 3a 30 00];
+		i2c_vc_baudrate = [00 00 00 1b 63 6c 6f 63 6b 2d 66 72 65 71 75 65 6e 63 79 3a 30 00];
+		act_led_activelow = <0x1c 0x6770696f 0x733a3800>;
+		i2c2_baudrate = [00 00 00 10 63 6c 6f 63 6b 2d 66 72 65 71 75 65 6e 63 79 3a 30 00];
+		sd_force_pio = "", "", "", " brcm,force-pio?";
+		uart1 = [00 00 00 17 73 74 61 74 75 73 00];
+		i2c_arm_baudrate = [00 00 00 1a 63 6c 6f 63 6b 2d 66 72 65 71 75 65 6e 63 79 3a 30 00];
+		random = [00 00 00 1f 73 74 61 74 75 73 00];
+		act_led_gpio = <0x1c 0x6770696f 0x733a3400>;
+		i2c = [00 00 00 1a 73 74 61 74 75 73 00];
+	};
+
+	system {
+		linux,serial = <0x0 0x925b29dd>;
+		linux,revision = <0x2>;
+	};
+
+	__symbols__ {
+		pwm = "/soc/pwm@7e20c000";
+		clk_usb = "/clocks/clock@4";
+		pixelvalve0 = "/soc/pixelvalve@7e206000";
+		intc = "/soc/interrupt-controller@7e00b200";
+		spi2 = "/soc/spi@7e2150c0";
+		dsi1 = "/soc/dsi@7e700000";
+		clocks = "/soc/cprman@7e101000";
+		i2c1 = "/soc/i2c@7e804000";
+		i2c_vc = "/soc/i2c@7e804000";
+		firmwarekms = "/soc/firmwarekms@7e600000";
+		smi = "/soc/smi@7e600000";
+		gpu = "/soc/gpu";
+		spi0 = "/soc/spi@7e204000";
+		thermal = "/soc/thermal";
+		vdd_5v0_reg = "/fixedregulator_5v0";
+		vchiq = "/soc/vchiq";
+		sdhost = "/soc/sdhost@7e202000";
+		aux = "/soc/aux@0x7e215000";
+		gpio = "/soc/gpio@7e200000";
+		dpi = "/soc/dpi@7e208000";
+		v3d = "/soc/v3d@7ec00000";
+		audio = "/soc/audio";
+		vdd_3v3_reg = "/fixedregulator_3v3";
+		dma = "/soc/dma@7e007000";
+		spidev1 = "/soc/spi@7e204000/spidev@1";
+		vc4 = "/soc/gpu";
+		power = "/soc/power";
+		soc = "/soc";
+		leds = "/leds";
+		i2s_pins = "/soc/gpio@7e200000/i2s";
+		firmware = "/soc/firmware";
+		cprman = "/soc/cprman@7e101000";
+		mmc = "/soc/mmc@7e300000";
+		pixelvalve1 = "/soc/pixelvalve@7e207000";
+		spi = "/soc/spi@7e204000";
+		spi0_pins = "/soc/gpio@7e200000/spi0_pins";
+		pitouchscreen_touch = "/soc/i2cdsi/bridge@38";
+		i2c_arm = "/soc/i2c@7e205000";
+		clk_osc = "/clocks/clock@3";
+		ethernet = "/soc/usb@7e980000/usb1@1/usbether@1";
+		uart0 = "/soc/serial@7e201000";
+		i2c1_pins = "/soc/gpio@7e200000/i2c1";
+		fb = "/soc/fb";
+		sdhost_pins = "/soc/gpio@7e200000/sdhost_pins";
+		i2c2 = "/soc/i2c@7e805000";
+		i2s = "/soc/i2s@7e203000";
+		spi1 = "/soc/spi@7e215080";
+		usb = "/soc/usb@7e980000";
+		dsi0 = "/soc/dsi@7e209000";
+		audio_pins = "/soc/gpio@7e200000/audio_pins";
+		i2c0 = "/soc/i2c@7e205000";
+		i2c0_pins = "/soc/gpio@7e200000/i2c0";
+		watchdog = "/soc/watchdog@7e100000";
+		vec = "/soc/vec@7e806000";
+		i2c_dsi = "/soc/i2cdsi";
+		pitouchscreen_bridge = "/soc/i2cdsi/bridge@45";
+		spi0_cs_pins = "/soc/gpio@7e200000/spi0_cs_pins";
+		sound = "/soc/sound";
+		hvs = "/soc/hvs@7e400000";
+		act_led = "/leds/act";
+		spidev0 = "/soc/spi@7e204000/spidev@0";
+		hdmi = "/soc/hdmi@7e902000";
+		pixelvalve2 = "/soc/pixelvalve@7e807000";
+		mailbox = "/soc/mailbox@7e00b880";
+		uart1 = "/soc/serial@7e215040";
+		random = "/soc/rng@7e104000";
+		i2c = "/soc/i2c@7e205000";
+	};
+
+	soc {
+		compatible = "simple-bus";
+		ranges = <0x7e000000 0x20000000 0x2000000>;
+		#address-cells = <0x1>;
+		#size-cells = <0x1>;
+		phandle = <0x21>;
+		dma-ranges = <0x40000000 0x0 0x20000000>;
+
+		serial@7e201000 {
+			compatible = "brcm,bcm2835-pl011", "arm,pl011", "arm,primecell";
+			clocks = <0x6 0x13 0x6 0x14>;
+			clock-names = "uartclk", "apb_pclk";
+			status = "okay";
+			interrupts = <0x2 0x19>;
+			phandle = <0x16>;
+			arm,primecell-periphid = <0x241011>;
+			reg = <0x7e201000 0x1000>;
+		};
+
+		pixelvalve@7e207000 {
+			compatible = "brcm,bcm2835-pixelvalve1";
+			status = "disabled";
+			interrupts = <0x2 0xe>;
+			phandle = <0x25>;
+			reg = <0x7e207000 0x100>;
+		};
+
+		cprman@7e101000 {
+			compatible = "brcm,bcm2835-cprman";
+			clocks = <0x2 0x3 0x0 0x3 0x1 0x3 0x2 0x4 0x0 0x4 0x1 0x4 0x2>;
+			firmware = <0x5>;
+			#clock-cells = <0x1>;
+			phandle = <0x6>;
+			reg = <0x7e101000 0x2000>;
+		};
+
+		hvs@7e400000 {
+			compatible = "brcm,bcm2835-hvs";
+			status = "disabled";
+			interrupts = <0x2 0x1>;
+			phandle = <0x29>;
+			reg = <0x7e400000 0x6000>;
+		};
+
+		gpio@7e200000 {
+			compatible = "brcm,bcm2835-gpio";
+			gpio-controller;
+			#interrupt-cells = <0x2>;
+			interrupts = <0x2 0x11 0x2 0x12>;
+			phandle = <0x9>;
+			reg = <0x7e200000 0xb4>;
+			#gpio-cells = <0x2>;
+			interrupt-controller;
+
+			i2c1 {
+				brcm,pins = <0x2 0x3>;
+				phandle = <0xf>;
+				brcm,function = <0x4>;
+			};
+
+			spi0_pins {
+				brcm,pins = <0x9 0xa 0xb>;
+				phandle = <0xa>;
+				brcm,function = <0x4>;
+			};
+
+			sdhost_pins {
+				brcm,pins = <0x30 0x31 0x32 0x33 0x34 0x35>;
+				phandle = <0x12>;
+				brcm,function = <0x4>;
+			};
+
+			i2s {
+				brcm,pins = <0x1c 0x1d 0x1e 0x1f>;
+				phandle = <0x8>;
+				brcm,function = <0x6>;
+			};
+
+			audio_pins {
+				brcm,pins = <0x28 0x2d>;
+				phandle = <0x14>;
+				brcm,function = <0x4>;
+			};
+
+			i2c0 {
+				brcm,pins = <0x0 0x1>;
+				phandle = <0xc>;
+				brcm,function = <0x4>;
+			};
+
+			spi0_cs_pins {
+				brcm,pins = <0x8 0x7>;
+				phandle = <0xb>;
+				brcm,function = <0x1>;
+			};
+		};
+
+		pixelvalve@7e807000 {
+			compatible = "brcm,bcm2835-pixelvalve2";
+			status = "disabled";
+			interrupts = <0x2 0xa>;
+			phandle = <0x2b>;
+			reg = <0x7e807000 0x100>;
+		};
+
+		v3d@7ec00000 {
+			power-domains = <0xe 0xa>;
+			compatible = "brcm,vc4-v3d";
+			status = "disabled";
+			interrupts = <0x1 0xa>;
+			phandle = <0x2f>;
+			reg = <0x7ec00000 0x1000>;
+		};
+
+		gpu {
+			compatible = "brcm,bcm2835-vc4";
+			status = "disabled";
+			phandle = <0x30>;
+		};
+
+		mmc@7e300000 {
+			compatible = "brcm,bcm2835-mmc";
+			clocks = <0x6 0x1c>;
+			status = "disabled";
+			interrupts = <0x2 0x1e>;
+			brcm,overclock-50 = <0x0>;
+			dma-names = "rx-tx";
+			phandle = <0x32>;
+			reg = <0x7e300000 0x100>;
+			dmas = <0x7 0xb>;
+		};
+
+		arm-pmu {
+			compatible = "arm,arm1176-pmu";
+		};
+
+		thermal {
+			compatible = "brcm,bcm2835-thermal";
+			firmware = <0x5>;
+			phandle = <0x39>;
+		};
+
+		spi@7e204000 {
+			compatible = "brcm,bcm2835-spi";
+			clocks = <0x6 0x14>;
+			status = "disabled";
+			#address-cells = <0x1>;
+			interrupts = <0x2 0x16>;
+			cs-gpios = <0x9 0x8 0x1 0x9 0x7 0x1>;
+			#size-cells = <0x0>;
+			dma-names = "tx", "rx";
+			phandle = <0x19>;
+			reg = <0x7e204000 0x1000>;
+			pinctrl-0 = <0xa 0xb>;
+			dmas = <0x7 0x6 0x7 0x7>;
+			pinctrl-names = "default";
+
+			spidev@1 {
+				compatible = "spidev";
+				#address-cells = <0x1>;
+				#size-cells = <0x0>;
+				phandle = <0x23>;
+				reg = <0x1>;
+				spi-max-frequency = <0x7a120>;
+			};
+
+			spidev@0 {
+				compatible = "spidev";
+				#address-cells = <0x1>;
+				#size-cells = <0x0>;
+				phandle = <0x22>;
+				reg = <0x0>;
+				spi-max-frequency = <0x7a120>;
+			};
+		};
+
+		i2cdsi {
+			gpios = <0x9 0x2 0x0 0x9 0x3 0x0>;
+			compatible = "i2c-gpio";
+			status = "disabled";
+			#address-cells = <0x1>;
+			#size-cells = <0x0>;
+			phandle = <0x35>;
+
+			bridge@45 {
+				compatible = "raspberrypi,touchscreen-bridge-i2c";
+				phandle = <0x36>;
+				reg = <0x45>;
+			};
+
+			bridge@38 {
+				compatible = "raspberrypi,touchscreen-ts-i2c";
+				phandle = <0x37>;
+				reg = <0x38>;
+			};
+		};
+
+		vchiq {
+			compatible = "brcm,bcm2835-vchiq";
+			cache-line-size = <0x20>;
+			firmware = <0x5>;
+			interrupts = <0x0 0x2>;
+			phandle = <0x15>;
+			reg = <0x7e00b840 0xf>;
+		};
+
+		i2c@7e804000 {
+			compatible = "brcm,bcm2835-i2c";
+			clocks = <0x6 0x14>;
+			status = "disabled";
+			#address-cells = <0x1>;
+			interrupts = <0x2 0x15>;
+			#size-cells = <0x0>;
+			phandle = <0x1b>;
+			reg = <0x7e804000 0x1000>;
+			clock-frequency = <0x186a0>;
+			pinctrl-0 = <0xf>;
+			pinctrl-names = "default";
+		};
+
+		audio {
+			brcm,pwm-channels = <0x8>;
+			compatible = "brcm,bcm2835-audio";
+			status = "okay";
+			phandle = <0x1d>;
+			pinctrl-0 = <0x14>;
+			pinctrl-names = "default";
+		};
+
+		timer@7e003000 {
+			compatible = "brcm,bcm2835-system-timer";
+			interrupts = <0x1 0x0 0x1 0x1 0x1 0x2 0x1 0x3>;
+			reg = <0x7e003000 0x1000>;
+			clock-frequency = <0xf4240>;
+		};
+
+		i2s@7e203000 {
+			compatible = "brcm,bcm2835-i2s";
+			clocks = <0x6 0x1f>;
+			#sound-dai-cells = <0x0>;
+			status = "disabled";
+			dma-names = "tx", "rx";
+			phandle = <0x18>;
+			reg = <0x7e203000 0x24>;
+			pinctrl-0 = <0x8>;
+			dmas = <0x7 0x2 0x7 0x3>;
+			pinctrl-names = "default";
+		};
+
+		mailbox@7e00b880 {
+			compatible = "brcm,bcm2835-mbox";
+			#mbox-cells = <0x0>;
+			interrupts = <0x0 0x1>;
+			phandle = <0x13>;
+			reg = <0x7e00b880 0x40>;
+		};
+
+		gpiomem {
+			compatible = "brcm,bcm2835-gpiomem";
+			reg = <0x7e200000 0x1000>;
+		};
+
+		vec@7e806000 {
+			compatible = "brcm,bcm2835-vec";
+			clocks = <0x6 0x18>;
+			status = "disabled";
+			interrupts = <0x2 0x1b>;
+			phandle = <0x2a>;
+			reg = <0x7e806000 0x1000>;
+		};
+
+		power {
+			compatible = "raspberrypi,bcm2835-power";
+			firmware = <0x5>;
+			phandle = <0xe>;
+			#power-domain-cells = <0x1>;
+		};
+
+		pixelvalve@7e206000 {
+			compatible = "brcm,bcm2835-pixelvalve0";
+			status = "disabled";
+			interrupts = <0x2 0xd>;
+			phandle = <0x24>;
+			reg = <0x7e206000 0x100>;
+		};
+
+		firmware {
+			compatible = "raspberrypi,bcm2835-firmware";
+			mboxes = <0x13>;
+			phandle = <0x5>;
+		};
+
+		dsi@7e209000 {
+			compatible = "brcm,bcm2835-dsi0";
+			clocks = <0x6 0x20 0x6 0x2f 0x6 0x31>;
+			clock-names = "phy", "escape", "pixel";
+			status = "disabled";
+			#address-cells = <0x1>;
+			interrupts = <0x2 0x4>;
+			#size-cells = <0x0>;
+			#clock-cells = <0x1>;
+			phandle = <0x3>;
+			reg = <0x7e209000 0x78>;
+			clock-output-names = "dsi0_byte", "dsi0_ddr2", "dsi0_ddr";
+		};
+
+		fb {
+			compatible = "brcm,bcm2708-fb";
+			firmware = <0x5>;
+			status = "okay";
+			phandle = <0x38>;
+		};
+
+		sdhost@7e202000 {
+			compatible = "brcm,bcm2835-sdhost";
+			clocks = <0x6 0x14>;
+			brcm,pio-limit = <0x1>;
+			status = "okay";
+			interrupts = <0x2 0x18>;
+			brcm,overclock-50 = <0x0>;
+			bus-width = <0x4>;
+			dma-names = "rx-tx";
+			phandle = <0x20>;
+			reg = <0x7e202000 0x100>;
+			pinctrl-0 = <0x12>;
+			dmas = <0x7 0xd>;
+			pinctrl-names = "default";
+		};
+
+		dpi@7e208000 {
+			compatible = "brcm,bcm2835-dpi";
+			clocks = <0x6 0x14 0x6 0x2c>;
+			clock-names = "core", "pixel";
+			status = "disabled";
+			#address-cells = <0x1>;
+			#size-cells = <0x0>;
+			phandle = <0x31>;
+			reg = <0x7e208000 0x8c>;
+		};
+
+		hdmi@7e902000 {
+			power-domains = <0xe 0x5>;
+			compatible = "brcm,bcm2835-hdmi";
+			clocks = <0x6 0x10 0x6 0x19>;
+			clock-names = "pixel", "hdmi";
+			ddc = <0x10>;
+			status = "disabled";
+			interrupts = <0x2 0x8 0x2 0x9>;
+			dma-names = "audio-rx";
+			phandle = <0x2c>;
+			hpd-gpios = <0x9 0x2e 0x0>;
+			reg = <0x7e902000 0x600 0x7e808000 0x100>;
+			dmas = <0x7 0x11>;
+		};
+
+		pwm@7e20c000 {
+			compatible = "brcm,bcm2835-pwm";
+			clocks = <0x6 0x1e>;
+			status = "disabled";
+			assigned-clock-rates = <0x989680>;
+			assigned-clocks = <0x6 0x1e>;
+			phandle = <0x28>;
+			reg = <0x7e20c000 0x28>;
+			#pwm-cells = <0x2>;
+		};
+
+		watchdog@7e100000 {
+			compatible = "brcm,bcm2835-pm-wdt";
+			phandle = <0x1e>;
+			reg = <0x7e100000 0x28>;
+		};
+
+		interrupt-controller@7e00b200 {
+			compatible = "brcm,bcm2835-armctrl-ic";
+			#interrupt-cells = <0x2>;
+			phandle = <0x1>;
+			reg = <0x7e00b200 0x200>;
+			interrupt-controller;
+		};
+
+		dsi@7e700000 {
+			power-domains = <0xe 0x12>;
+			compatible = "brcm,bcm2835-dsi1";
+			clocks = <0x6 0x23 0x6 0x30 0x6 0x32>;
+			clock-names = "phy", "escape", "pixel";
+			status = "disabled";
+			#address-cells = <0x1>;
+			interrupts = <0x2 0xc>;
+			#size-cells = <0x0>;
+			#clock-cells = <0x1>;
+			phandle = <0x4>;
+			reg = <0x7e700000 0x8c>;
+			clock-output-names = "dsi1_byte", "dsi1_ddr2", "dsi1_ddr";
+		};
+
+		sound {
+			status = "disabled";
+			phandle = <0x3a>;
+		};
+
+		i2c@7e205000 {
+			compatible = "brcm,bcm2835-i2c";
+			clocks = <0x6 0x14>;
+			status = "disabled";
+			#address-cells = <0x1>;
+			interrupts = <0x2 0x15>;
+			#size-cells = <0x0>;
+			phandle = <0x1a>;
+			reg = <0x7e205000 0x1000>;
+			clock-frequency = <0x186a0>;
+			pinctrl-0 = <0xc>;
+			pinctrl-names = "default";
+		};
+
+		serial@7e215040 {
+			compatible = "brcm,bcm2835-aux-uart";
+			clocks = <0xd 0x0>;
+			status = "disabled";
+			interrupt-parent = <0xd>;
+			interrupts = <0x0>;
+			phandle = <0x17>;
+			reg = <0x7e215040 0x40>;
+		};
+
+		dma@7e007000 {
+			#dma-cells = <0x1>;
+			compatible = "brcm,bcm2835-dma";
+			brcm,dma-channel-mask = <0x7f34>;
+			interrupts = <0x1 0x10 0x1 0x11 0x1 0x12 0x1 0x13 0x1 0x14 0x1 0x15 0x1 0x16 0x1 0x17 0x1 0x18 0x1 0x19 0x1 0x1a 0x1 0x1b 0x1 0x1b 0x1 0x1b 0x1 0x1b 0x1 0x1c>;
+			phandle = <0x7>;
+			reg = <0x7e007000 0xf00>;
+			interrupt-names = "dma0", "dma1", "dma2", "dma3", "dma4", "dma5", "dma6", "dma7", "dma8", "dma9", "dma10", "dma11", "dma12", "dma13", "dma14", "dma-shared-all";
+		};
+
+		i2c@7e805000 {
+			compatible = "brcm,bcm2835-i2c";
+			clocks = <0x6 0x14>;
+			status = "disabled";
+			#address-cells = <0x1>;
+			interrupts = <0x2 0x15>;
+			#size-cells = <0x0>;
+			phandle = <0x10>;
+			reg = <0x7e805000 0x1000>;
+			clock-frequency = <0x186a0>;
+		};
+
+		spi@7e215080 {
+			compatible = "brcm,bcm2835-aux-spi";
+			clocks = <0xd 0x1>;
+			status = "disabled";
+			interrupt-parent = <0xd>;
+			#address-cells = <0x1>;
+			interrupts = <0x1>;
+			#size-cells = <0x0>;
+			phandle = <0x26>;
+			reg = <0x7e215080 0x40>;
+		};
+
+		aux@0x7e215000 {
+			compatible = "brcm,bcm2835-aux";
+			clocks = <0x6 0x14>;
+			#interrupt-cells = <0x1>;
+			interrupts = <0x1 0x1d>;
+			#clock-cells = <0x1>;
+			phandle = <0xd>;
+			reg = <0x7e215000 0x8>;
+			interrupt-controller;
+		};
+
+		firmwarekms@7e600000 {
+			compatible = "raspberrypi,rpi-firmware-kms";
+			status = "disabled";
+			interrupts = <0x2 0x10>;
+			brcm,firmware = <0x5>;
+			phandle = <0x33>;
+			reg = <0x7e600000 0x100>;
+		};
+
+		rng@7e104000 {
+			compatible = "brcm,bcm2835-rng";
+			phandle = <0x1f>;
+			reg = <0x7e104000 0x10>;
+		};
+
+		usb@7e980000 {
+			power-domains = <0xe 0x6>;
+			compatible = "brcm,bcm2708-usb";
+			clocks = <0x11>;
+			clock-names = "otg";
+			#address-cells = <0x1>;
+			interrupts = <0x2 0x0 0x1 0x9>;
+			#size-cells = <0x0>;
+			phandle = <0x2d>;
+			reg = <0x7e980000 0x10000 0x7e006000 0x1000>;
+
+			usb1@1 {
+				compatible = "usb424,9512";
+				#address-cells = <0x1>;
+				#size-cells = <0x0>;
+				reg = <0x1>;
+
+				usbether@1 {
+					compatible = "usb424,ec00";
+					local-mac-address = [04 05 07 01 02 03];
+					phandle = <0x2e>;
+					reg = <0x1>;
+				};
+			};
+		};
+
+		smi@7e600000 {
+			compatible = "brcm,bcm2835-smi";
+			clocks = <0x6 0x2a>;
+			status = "disabled";
+			interrupts = <0x2 0x10>;
+			assigned-clock-rates = <0x7735940>;
+			dma-names = "rx-tx";
+			assigned-clocks = <0x6 0x2a>;
+			phandle = <0x34>;
+			reg = <0x7e600000 0x100>;
+			dmas = <0x7 0x4>;
+		};
+
+		spi@7e2150c0 {
+			compatible = "brcm,bcm2835-aux-spi";
+			clocks = <0xd 0x2>;
+			status = "disabled";
+			interrupt-parent = <0xd>;
+			#address-cells = <0x1>;
+			interrupts = <0x2>;
+			#size-cells = <0x0>;
+			phandle = <0x27>;
+			reg = <0x7e2150c0 0x40>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+		phandle = <0x3d>;
+
+		act {
+			gpios = <0x9 0x10 0x1>;
+			label = "led0";
+			phandle = <0x1c>;
+			linux,default-trigger = "mmc0";
+		};
+	};
+
+	aliases {
+		intc = "/soc/interrupt-controller@7e00b200";
+		spi2 = "/soc/spi@7e2150c0";
+		i2c1 = "/soc/i2c@7e804000";
+		i2c_vc = "/soc/i2c@7e804000";
+		spi0 = "/soc/spi@7e204000";
+		thermal = "/soc/thermal";
+		vchiq = "/soc/vchiq";
+		sdhost = "/soc/sdhost@7e202000";
+		aux = "/soc/aux@0x7e215000";
+		gpio = "/soc/gpio@7e200000";
+		audio = "/soc/audio";
+		dma = "/soc/dma@7e007000";
+		soc = "/soc";
+		leds = "/leds";
+		mmc = "/soc/mmc@7e300000";
+		serial1 = "/soc/serial@7e215040";
+		i2c_arm = "/soc/i2c@7e205000";
+		ethernet = "/soc/usb@7e980000/usb1@1/usbether@1";
+		uart0 = "/soc/serial@7e201000";
+		fb = "/soc/fb";
+		i2c2 = "/soc/i2c@7e805000";
+		i2s = "/soc/i2s@7e203000";
+		spi1 = "/soc/spi@7e215080";
+		usb = "/soc/usb@7e980000";
+		i2c0 = "/soc/i2c@7e205000";
+		watchdog = "/soc/watchdog@7e100000";
+		sound = "/soc/sound";
+		mailbox = "/soc/mailbox@7e00b880";
+		uart1 = "/soc/serial@7e215040";
+		random = "/soc/rng@7e104000";
+		i2c = "/soc/i2c@7e205000";
+		serial0 = "/soc/serial@7e201000";
+	};
+
+	chosen {
+		bootargs = "bcm2708_fb.fbwidth=1680 bcm2708_fb.fbheight=1050 bcm2708_fb.fbdepth=16 bcm2708_fb.fbswap=1 vc_mem.mem_base=0xfa00000 vc_mem.mem_size=0x10000000  dwc_otg.lpm_enable=0 console=ttyAMA0,115200 console=tty1 root=/dev/mmcblk0p6 rootfstype=ext4 elevator=deadline fsck.repair=yes rootwait";
+		kaslr-seed = <0xb1f76783 0x32e6766e>;
+	};
+
+	memory {
+		device_type = "memory";
+		reg = <0x0 0xf000000>;
+	};
+
+	fixedregulator_3v3 {
+		compatible = "regulator-fixed";
+		phandle = <0x3c>;
+		regulator-min-microvolt = <0x325aa0>;
+		regulator-max-microvolt = <0x325aa0>;
+		regulator-always-on;
+		regulator-name = "3v3";
+	};
+
+	fixedregulator_5v0 {
+		compatible = "regulator-fixed";
+		phandle = <0x3b>;
+		regulator-min-microvolt = <0x4c4b40>;
+		regulator-max-microvolt = <0x4c4b40>;
+		regulator-always-on;
+		regulator-name = "5v0";
+	};
+
+	axi {
+
+		vc_mem {
+			reg = <0xfa00000 0x10000000 0x40000000>;
+		};
+	};
+};

--- a/test/data/rpi3_arch_arm64.dts
+++ b/test/data/rpi3_arch_arm64.dts
@@ -1,0 +1,666 @@
+/dts-v1/;
+
+/ {
+	compatible = "raspberrypi,3-model-b", "brcm,bcm2837";
+	serial-number = "00000000d544ea12";
+	model = "Raspberry Pi 3 Model B";
+	interrupt-parent = <0x1>;
+	#address-cells = <0x1>;
+	#size-cells = <0x1>;
+
+	clocks {
+		compatible = "simple-bus";
+		#address-cells = <0x1>;
+		#size-cells = <0x0>;
+
+		clock@3 {
+			compatible = "fixed-clock";
+			#clock-cells = <0x0>;
+			phandle = <0x3>;
+			reg = <0x3>;
+			clock-output-names = "osc";
+			clock-frequency = <0x124f800>;
+			linux,phandle = <0x3>;
+		};
+
+		clock@4 {
+			compatible = "fixed-clock";
+			#clock-cells = <0x0>;
+			phandle = <0xe>;
+			reg = <0x4>;
+			clock-output-names = "otg";
+			clock-frequency = <0x1c9c3800>;
+			linux,phandle = <0xe>;
+		};
+	};
+
+	soc {
+		compatible = "simple-bus";
+		ranges = <0x7e000000 0x3f000000 0x1000000 0x40000000 0x40000000 0x1000>;
+		#address-cells = <0x1>;
+		#size-cells = <0x1>;
+		dma-ranges = <0xc0000000 0x0 0x3f000000>;
+
+		serial@7e201000 {
+			compatible = "brcm,bcm2835-pl011", "arm,pl011", "arm,primecell";
+			clocks = <0x4 0x13 0x4 0x14>;
+			clock-names = "uartclk", "apb_pclk";
+			interrupts = <0x2 0x19>;
+			arm,primecell-periphid = <0x241011>;
+			reg = <0x7e201000 0x1000>;
+		};
+
+		pixelvalve@7e207000 {
+			compatible = "brcm,bcm2835-pixelvalve1";
+			interrupts = <0x2 0xe>;
+			reg = <0x7e207000 0x100>;
+		};
+
+		cprman@7e101000 {
+			compatible = "brcm,bcm2835-cprman";
+			clocks = <0x3>;
+			#clock-cells = <0x1>;
+			phandle = <0x4>;
+			reg = <0x7e101000 0x2000>;
+			linux,phandle = <0x4>;
+		};
+
+		thermal@7e212000 {
+			compatible = "brcm,bcm2837-thermal";
+			clocks = <0x4 0x1b>;
+			status = "okay";
+			reg = <0x7e212000 0x8>;
+		};
+
+		hvs@7e400000 {
+			compatible = "brcm,bcm2835-hvs";
+			interrupts = <0x2 0x1>;
+			reg = <0x7e400000 0x6000>;
+		};
+
+		gpio@7e200000 {
+			compatible = "brcm,bcm2835-gpio";
+			gpio-controller;
+			#interrupt-cells = <0x2>;
+			interrupts = <0x2 0x11 0x2 0x12 0x2 0x13 0x2 0x14>;
+			phandle = <0x11>;
+			reg = <0x7e200000 0xb4>;
+			#gpio-cells = <0x2>;
+			linux,phandle = <0x11>;
+			pinctrl-names = "default";
+			interrupt-controller;
+
+			uart0_gpio14 {
+				brcm,pins = <0xe 0xf>;
+				brcm,function = <0x4>;
+			};
+
+			gpclk1_gpio5 {
+				brcm,pins = <0x5>;
+				brcm,function = <0x4>;
+			};
+
+			uart1_ctsrts_gpio16 {
+				brcm,pins = <0x10 0x11>;
+				brcm,function = <0x2>;
+			};
+
+			jtag_gpio4 {
+				brcm,pins = <0x4 0x5 0x6 0xc 0xd>;
+				brcm,function = <0x3>;
+			};
+
+			alt0 {
+				brcm,pins = <0x4 0x5 0x7 0x8 0x9 0xa 0xb 0xe 0xf>;
+				brcm,function = <0x4>;
+			};
+
+			uart0_gpio30 {
+				brcm,pins = <0x1e 0x1f>;
+				brcm,function = <0x7>;
+			};
+
+			uart1_ctsrts_gpio42 {
+				brcm,pins = <0x2a 0x2b>;
+				brcm,function = <0x2>;
+			};
+
+			gpclk0_gpio4 {
+				brcm,pins = <0x4>;
+				brcm,function = <0x4>;
+			};
+
+			pwm0_gpio12 {
+				brcm,pins = <0xc>;
+				brcm,function = <0x4>;
+			};
+
+			pwm1_gpio19 {
+				brcm,pins = <0x13>;
+				brcm,function = <0x2>;
+			};
+
+			pwm0_gpio40 {
+				brcm,pins = <0x28>;
+				phandle = <0x8>;
+				brcm,function = <0x4>;
+				linux,phandle = <0x8>;
+			};
+
+			gpclk2_gpio43 {
+				brcm,pins = <0x2b>;
+				brcm,function = <0x4>;
+			};
+
+			uart1_ctsrts_gpio30 {
+				brcm,pins = <0x1e 0x1f>;
+				brcm,function = <0x2>;
+			};
+
+			gpioout {
+				brcm,pins = <0x6>;
+				brcm,function = <0x1>;
+			};
+
+			spi0_gpio35 {
+				brcm,pins = <0x23 0x24 0x25 0x26 0x27>;
+				brcm,function = <0x4>;
+			};
+
+			pwm1_gpio45 {
+				brcm,pins = <0x2d>;
+				phandle = <0x9>;
+				brcm,function = <0x4>;
+				linux,phandle = <0x9>;
+			};
+
+			pcm_gpio28 {
+				brcm,pins = <0x1c 0x1d 0x1e 0x1f>;
+				brcm,function = <0x6>;
+			};
+
+			dpi_gpio0 {
+				brcm,pins = <0x0 0x1 0x2 0x3 0x4 0x5 0x6 0x7 0x8 0x9 0xa 0xb 0xc 0xd 0xe 0xf 0x10 0x11 0x12 0x13 0x14 0x15 0x16 0x17 0x18 0x19 0x1a 0x1b>;
+				brcm,function = <0x6>;
+			};
+
+			i2c0_gpio0 {
+				brcm,pins = <0x0 0x1>;
+				phandle = <0x6>;
+				brcm,function = <0x4>;
+				linux,phandle = <0x6>;
+			};
+
+			pcm_gpio18 {
+				brcm,pins = <0x12 0x13 0x14 0x15>;
+				brcm,function = <0x4>;
+			};
+
+			pwm1_gpio13 {
+				brcm,pins = <0xd>;
+				brcm,function = <0x4>;
+			};
+
+			pwm1_gpio41 {
+				brcm,pins = <0x29>;
+				brcm,function = <0x4>;
+			};
+
+			spi0_gpio7 {
+				brcm,pins = <0x7 0x8 0x9 0xa 0xb>;
+				brcm,function = <0x4>;
+			};
+
+			i2c1_gpio44 {
+				brcm,pins = <0x2c 0x2d>;
+				brcm,function = <0x6>;
+			};
+
+			i2c_slave_gpio18 {
+				brcm,pins = <0x12 0x13 0x14 0x15>;
+				brcm,function = <0x7>;
+			};
+
+			emmc_gpio48 {
+				brcm,pins = <0x30 0x31 0x32 0x33 0x34 0x35>;
+				phandle = <0xa>;
+				brcm,function = <0x7>;
+				linux,phandle = <0xa>;
+			};
+
+			i2c1_gpio2 {
+				brcm,pins = <0x2 0x3>;
+				phandle = <0xb>;
+				brcm,function = <0x4>;
+				linux,phandle = <0xb>;
+			};
+
+			spi1_gpio16 {
+				brcm,pins = <0x10 0x11 0x12 0x13 0x14 0x15>;
+				brcm,function = <0x3>;
+			};
+
+			jtag_gpio22 {
+				brcm,pins = <0x16 0x17 0x18 0x19 0x1a 0x1b>;
+				brcm,function = <0x3>;
+			};
+
+			uart1_gpio36 {
+				brcm,pins = <0x24 0x25 0x26 0x27>;
+				brcm,function = <0x6>;
+			};
+
+			spi2_gpio40 {
+				brcm,pins = <0x28 0x29 0x2a 0x2b 0x2c 0x2d>;
+				brcm,function = <0x3>;
+			};
+
+			i2c0_gpio44 {
+				brcm,pins = <0x2c 0x2d>;
+				brcm,function = <0x5>;
+			};
+
+			uart0_ctsrts_gpio16 {
+				brcm,pins = <0x10 0x11>;
+				brcm,function = <0x7>;
+			};
+
+			gpclk2_gpio6 {
+				brcm,pins = <0x6>;
+				brcm,function = <0x4>;
+			};
+
+			sdhost_gpio48 {
+				brcm,pins = <0x30 0x31 0x32 0x33 0x34 0x35>;
+				brcm,function = <0x4>;
+			};
+
+			emmc_gpio34 {
+				brcm,pins = <0x22 0x23 0x24 0x25 0x26 0x27>;
+				brcm,pull = <0x0 0x2 0x2 0x2 0x2 0x2>;
+				brcm,function = <0x7>;
+			};
+
+			gpclk1_gpio44 {
+				brcm,pins = <0x2c>;
+				brcm,function = <0x4>;
+			};
+
+			uart1_gpio14 {
+				brcm,pins = <0xe 0xf>;
+				brcm,function = <0x2>;
+			};
+
+			i2c0_gpio32 {
+				brcm,pins = <0x20 0x22>;
+				brcm,function = <0x4>;
+			};
+
+			uart1_gpio32 {
+				brcm,pins = <0x20 0x21>;
+				brcm,function = <0x2>;
+			};
+
+			pwm0_gpio18 {
+				brcm,pins = <0x12>;
+				brcm,function = <0x2>;
+			};
+
+			gpclk1_gpio42 {
+				brcm,pins = <0x2a>;
+				brcm,function = <0x4>;
+			};
+
+			uart0_ctsrts_gpio32 {
+				brcm,pins = <0x20 0x21>;
+				brcm,function = <0x7>;
+			};
+
+			uart1_gpio40 {
+				brcm,pins = <0x28 0x29>;
+				brcm,function = <0x2>;
+			};
+
+			emmc_gpio22 {
+				brcm,pins = <0x16 0x17 0x18 0x19 0x1a 0x1b>;
+				brcm,function = <0x7>;
+			};
+		};
+
+		pixelvalve@7e807000 {
+			compatible = "brcm,bcm2835-pixelvalve2";
+			interrupts = <0x2 0xa>;
+			reg = <0x7e807000 0x100>;
+		};
+
+		v3d@7ec00000 {
+			power-domains = <0xc 0xa>;
+			compatible = "brcm,bcm2835-v3d";
+			interrupts = <0x1 0xa>;
+			reg = <0x7ec00000 0x1000>;
+		};
+
+		gpu {
+			compatible = "brcm,bcm2835-vc4";
+		};
+
+		spi@7e204000 {
+			compatible = "brcm,bcm2835-spi";
+			clocks = <0x4 0x14>;
+			status = "disabled";
+			#address-cells = <0x1>;
+			interrupts = <0x2 0x16>;
+			#size-cells = <0x0>;
+			reg = <0x7e204000 0x1000>;
+		};
+
+		sdhci@7e300000 {
+			compatible = "brcm,bcm2835-sdhci";
+			clocks = <0x4 0x1c>;
+			status = "okay";
+			interrupts = <0x2 0x1e>;
+			bus-width = <0x4>;
+			reg = <0x7e300000 0x100>;
+			pinctrl-0 = <0xa>;
+			pinctrl-names = "default";
+		};
+
+		i2c@7e804000 {
+			compatible = "brcm,bcm2835-i2c";
+			clocks = <0x4 0x14>;
+			status = "okay";
+			#address-cells = <0x1>;
+			interrupts = <0x2 0x15>;
+			#size-cells = <0x0>;
+			reg = <0x7e804000 0x1000>;
+			clock-frequency = <0x186a0>;
+			pinctrl-0 = <0xb>;
+			pinctrl-names = "default";
+		};
+
+		timer@7e003000 {
+			compatible = "brcm,bcm2835-system-timer";
+			interrupts = <0x1 0x0 0x1 0x1 0x1 0x2 0x1 0x3>;
+			reg = <0x7e003000 0x1000>;
+			clock-frequency = <0xf4240>;
+		};
+
+		i2s@7e203000 {
+			compatible = "brcm,bcm2835-i2s";
+			status = "disabled";
+			dma-names = "tx", "rx";
+			reg = <0x7e203000 0x20 0x7e101098 0x2>;
+			dmas = <0x5 0x2 0x5 0x3>;
+		};
+
+		mailbox@7e00b880 {
+			compatible = "brcm,bcm2835-mbox";
+			#mbox-cells = <0x0>;
+			interrupts = <0x0 0x1>;
+			phandle = <0xf>;
+			reg = <0x7e00b880 0x40>;
+			linux,phandle = <0xf>;
+		};
+
+		vec@7e806000 {
+			power-domains = <0xc 0x7>;
+			compatible = "brcm,bcm2835-vec";
+			clocks = <0x4 0x18>;
+			status = "okay";
+			interrupts = <0x2 0x1b>;
+			reg = <0x7e806000 0x1000>;
+		};
+
+		power {
+			compatible = "raspberrypi,bcm2835-power";
+			firmware = <0x10>;
+			phandle = <0xc>;
+			linux,phandle = <0xc>;
+			#power-domain-cells = <0x1>;
+		};
+
+		pixelvalve@7e206000 {
+			compatible = "brcm,bcm2835-pixelvalve0";
+			interrupts = <0x2 0xd>;
+			reg = <0x7e206000 0x100>;
+		};
+
+		firmware {
+			compatible = "raspberrypi,bcm2835-firmware";
+			mboxes = <0xf>;
+			phandle = <0x10>;
+			linux,phandle = <0x10>;
+		};
+
+		hdmi@7e902000 {
+			power-domains = <0xc 0x5>;
+			compatible = "brcm,bcm2835-hdmi";
+			clocks = <0x4 0x10 0x4 0x19>;
+			clock-names = "pixel", "hdmi";
+			ddc = <0xd>;
+			status = "okay";
+			interrupts = <0x2 0x8 0x2 0x9>;
+			reg = <0x7e902000 0x600 0x7e808000 0x100>;
+		};
+
+		pwm@7e20c000 {
+			compatible = "brcm,bcm2835-pwm";
+			clocks = <0x4 0x1e>;
+			status = "okay";
+			assigned-clock-rates = <0x989680>;
+			assigned-clocks = <0x4 0x1e>;
+			reg = <0x7e20c000 0x28>;
+			pinctrl-0 = <0x8 0x9>;
+			#pwm-cells = <0x2>;
+			pinctrl-names = "default";
+		};
+
+		watchdog@7e100000 {
+			compatible = "brcm,bcm2835-pm-wdt";
+			reg = <0x7e100000 0x28>;
+		};
+
+		interrupt-controller@7e00b200 {
+			compatible = "brcm,bcm2836-armctrl-ic";
+			#interrupt-cells = <0x2>;
+			interrupt-parent = <0x2>;
+			interrupts = <0x8>;
+			phandle = <0x1>;
+			reg = <0x7e00b200 0x200>;
+			linux,phandle = <0x1>;
+			interrupt-controller;
+		};
+
+		local_intc {
+			compatible = "brcm,bcm2836-l1-intc";
+			#interrupt-cells = <0x1>;
+			interrupt-parent = <0x2>;
+			phandle = <0x2>;
+			reg = <0x40000000 0x100>;
+			linux,phandle = <0x2>;
+			interrupt-controller;
+		};
+
+		i2c@7e205000 {
+			compatible = "brcm,bcm2835-i2c";
+			clocks = <0x4 0x14>;
+			status = "okay";
+			#address-cells = <0x1>;
+			interrupts = <0x2 0x15>;
+			#size-cells = <0x0>;
+			reg = <0x7e205000 0x1000>;
+			clock-frequency = <0x186a0>;
+			pinctrl-0 = <0x6>;
+			pinctrl-names = "default";
+		};
+
+		serial@7e215040 {
+			compatible = "brcm,bcm2835-aux-uart";
+			clocks = <0x7 0x0>;
+			status = "okay";
+			interrupts = <0x1 0x1d>;
+			reg = <0x7e215040 0x40>;
+		};
+
+		dma@7e007000 {
+			#dma-cells = <0x1>;
+			compatible = "brcm,bcm2835-dma";
+			brcm,dma-channel-mask = <0x7f35>;
+			interrupts = <0x1 0x10 0x1 0x11 0x1 0x12 0x1 0x13 0x1 0x14 0x1 0x15 0x1 0x16 0x1 0x17 0x1 0x18 0x1 0x19 0x1 0x1a 0x1 0x1b 0x1 0x1b 0x1 0x1b 0x1 0x1b 0x1 0x1c>;
+			phandle = <0x5>;
+			reg = <0x7e007000 0xf00>;
+			linux,phandle = <0x5>;
+			interrupt-names = "dma0", "dma1", "dma2", "dma3", "dma4", "dma5", "dma6", "dma7", "dma8", "dma9", "dma10", "dma11", "dma12", "dma13", "dma14", "dma-shared-all";
+		};
+
+		i2c@7e805000 {
+			compatible = "brcm,bcm2835-i2c";
+			clocks = <0x4 0x14>;
+			status = "okay";
+			#address-cells = <0x1>;
+			interrupts = <0x2 0x15>;
+			#size-cells = <0x0>;
+			phandle = <0xd>;
+			reg = <0x7e805000 0x1000>;
+			linux,phandle = <0xd>;
+		};
+
+		spi@7e215080 {
+			compatible = "brcm,bcm2835-aux-spi";
+			clocks = <0x7 0x1>;
+			status = "disabled";
+			#address-cells = <0x1>;
+			interrupts = <0x1 0x1d>;
+			#size-cells = <0x0>;
+			reg = <0x7e215080 0x40>;
+		};
+
+		aux@0x7e215000 {
+			compatible = "brcm,bcm2835-aux";
+			clocks = <0x4 0x14>;
+			#clock-cells = <0x1>;
+			phandle = <0x7>;
+			reg = <0x7e215000 0x8>;
+			linux,phandle = <0x7>;
+		};
+
+		rng@7e104000 {
+			compatible = "brcm,bcm2835-rng";
+			reg = <0x7e104000 0x10>;
+		};
+
+		usb@7e980000 {
+			power-domains = <0xc 0x6>;
+			compatible = "brcm,bcm2835-usb";
+			clocks = <0xe>;
+			clock-names = "otg";
+			#address-cells = <0x1>;
+			interrupts = <0x1 0x9>;
+			#size-cells = <0x0>;
+			reg = <0x7e980000 0x10000>;
+			dr_mode = "host";
+
+			usb1@1 {
+				compatible = "usb424,9514";
+				#address-cells = <0x1>;
+				#size-cells = <0x0>;
+				reg = <0x1>;
+
+				usbether@1 {
+					compatible = "usb424,ec00";
+					reg = <0x1>;
+				};
+			};
+		};
+
+		spi@7e2150c0 {
+			compatible = "brcm,bcm2835-aux-spi";
+			clocks = <0x7 0x2>;
+			status = "disabled";
+			#address-cells = <0x1>;
+			interrupts = <0x1 0x1d>;
+			#size-cells = <0x0>;
+			reg = <0x7e2150c0 0x40>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		act {
+			gpios = <0x11 0x2f 0x0>;
+			label = "ACT";
+			default-state = "keep";
+			linux,default-trigger = "heartbeat";
+		};
+	};
+
+	aliases {
+		ethernet = "/soc/usb@7e980000/usb1@1/usbether@1";
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200 console=tty0 root=PARTUUID=08d5518c-02 rw rootwait smsc95xx.macaddr=01:02:03:04:05:06";
+		linux,initrd-start = ":wP";
+		linux,initrd-end = <0x3ab2d71e>;
+	};
+
+	framebuffer@3daf0000 {
+		compatible = "simple-framebuffer";
+		width = <0x290>;
+		stride = <0xa40>;
+		status = "okay";
+		reg = <0x3daf0000 0x10a800>;
+		format = "a8r8g8b8";
+		height = <0x1a0>;
+	};
+
+	timer {
+		compatible = "arm,armv7-timer";
+		always-on;
+		interrupt-parent = <0x2>;
+		interrupts = <0x0 0x1 0x3 0x2>;
+	};
+
+	memory {
+		device_type = "memory";
+		reg = <0x0 0x3b000000>;
+	};
+
+	cpus {
+		#address-cells = <0x1>;
+		#size-cells = <0x0>;
+
+		cpu@3 {
+			compatible = "arm,cortex-a53";
+			cpu-release-addr = <0x0 0xf0>;
+			device_type = "cpu";
+			enable-method = "spin-table";
+			reg = <0x3>;
+		};
+
+		cpu@1 {
+			compatible = "arm,cortex-a53";
+			cpu-release-addr = <0x0 0xe0>;
+			device_type = "cpu";
+			enable-method = "spin-table";
+			reg = <0x1>;
+		};
+
+		cpu@2 {
+			compatible = "arm,cortex-a53";
+			cpu-release-addr = <0x0 0xe8>;
+			device_type = "cpu";
+			enable-method = "spin-table";
+			reg = <0x2>;
+		};
+
+		cpu@0 {
+			compatible = "arm,cortex-a53";
+			cpu-release-addr = <0x0 0xd8>;
+			device_type = "cpu";
+			enable-method = "spin-table";
+			reg = <0x0>;
+		};
+	};
+};

--- a/test/data/rpi3_raspbian.dts
+++ b/test/data/rpi3_raspbian.dts
@@ -1,0 +1,892 @@
+/dts-v1/;
+
+/ {
+	compatible = "brcm,bcm2837", "brcm,bcm2836";
+	serial-number = "00000000d544ea12";
+	model = "Raspberry Pi 3 Model B Rev 1.2";
+	memreserve = <0x3b000000 0x4000000>;
+	interrupt-parent = <0x1>;
+	#address-cells = <0x1>;
+	#size-cells = <0x1>;
+
+	clocks {
+		compatible = "simple-bus";
+		#address-cells = <0x1>;
+		#size-cells = <0x0>;
+
+		clock@3 {
+			compatible = "fixed-clock";
+			#clock-cells = <0x0>;
+			phandle = <0x3>;
+			reg = <0x3>;
+			clock-output-names = "osc";
+			clock-frequency = <0x124f800>;
+		};
+
+		clock@4 {
+			compatible = "fixed-clock";
+			#clock-cells = <0x0>;
+			phandle = <0x16>;
+			reg = <0x4>;
+			clock-output-names = "otg";
+			clock-frequency = <0x1c9c3800>;
+		};
+	};
+
+	__overrides__ {
+		pwr_led_gpio = "", "", "", "(gpios:4";
+		i2c1 = "", "", "", "&status";
+		i2c_vc = "", "", "", "%status";
+		sd_overclock = "", "", "", ",brcm,overclock-50:0";
+		i2c0_baudrate = "", "", "", "%clock-frequency:0";
+		sd_pio_limit = "", "", "", ",brcm,pio-limit:0";
+		act_led_trigger = "", "", "", "'linux,default-trigger";
+		audio = "", "", "", ")status";
+		sd_debug = "", "", "", ",brcm,debug";
+		cache_line_size = [00 00 00 1c 63 61 63 68 65 2d 6c 69 6e 65 2d 73 69 7a 65 3a 30 00];
+		i2c1_baudrate = "", "", "", "&clock-frequency:0";
+		spi = "", "", "", "$status";
+		i2c_arm = "", "", "", "&status";
+		pwr_led_activelow = "", "", "", "(gpios:8";
+		uart0 = "", "", "", "!status";
+		i2c2_iknowwhatimdoing = [00 00 00 14 73 74 61 74 75 73 00];
+		i2s = "", "", "", "#status";
+		i2c0 = "", "", "", "%status";
+		arm_freq = <0x1d 0x636c6f63 0x6b2d6672 0x65717565 0x6e63793a 0x30000000 0x1e636c 0x6f636b2d 0x66726571 0x75656e63 0x793a3000 0x1f 0x636c6f63 0x6b2d6672 0x65717565 0x6e63793a 0x30000000 0x20636c 0x6f636b2d 0x66726571 0x75656e63 0x793a3000>;
+		watchdog = "", "", "", "*status";
+		i2c_baudrate = "", "", "", "&clock-frequency:0";
+		i2c_vc_baudrate = "", "", "", "%clock-frequency:0";
+		act_led_activelow = "", "", "", "'gpios:8";
+		i2c2_baudrate = [00 00 00 14 63 6c 6f 63 6b 2d 66 72 65 71 75 65 6e 63 79 3a 30 00];
+		sd_force_pio = "", "", "", ",brcm,force-pio?";
+		pwr_led_trigger = "", "", "", "(linux,default-trigger";
+		uart1 = "", "", "", "\"status";
+		i2c_arm_baudrate = "", "", "", "&clock-frequency:0";
+		random = "", "", "", "+status";
+		act_led_gpio = "", "", "", "'gpios:4";
+		i2c = "", "", "", "&status";
+	};
+
+	system {
+		linux,serial = <0x0 0xd5442118>;
+		linux,revision = <0xa02082>;
+	};
+
+	__symbols__ {
+		pwm = "/soc/pwm@7e20c000";
+		clk_usb = "/clocks/clock@4";
+		pixelvalve0 = "/soc/pixelvalve@7e206000";
+		intc = "/soc/interrupt-controller@7e00b200";
+		spi2 = "/soc/spi@7e2150c0";
+		dsi1 = "/soc/dsi@7e700000";
+		clocks = "/soc/cprman@7e101000";
+		i2c1 = "/soc/i2c@7e804000";
+		i2c_vc = "/soc/i2c@7e205000";
+		firmwarekms = "/soc/firmwarekms@7e600000";
+		smi = "/soc/smi@7e600000";
+		gpu = "/soc/gpu";
+		spi0 = "/soc/spi@7e204000";
+		thermal = "/soc/thermal";
+		vdd_5v0_reg = "/fixedregulator_5v0";
+		vchiq = "/soc/vchiq";
+		sdhost = "/soc/sdhost@7e202000";
+		aux = "/soc/aux@0x7e215000";
+		gpio = "/soc/gpio@7e200000";
+		dpi = "/soc/dpi@7e208000";
+		v3d = "/soc/v3d@7ec00000";
+		audio = "/soc/audio";
+		vdd_3v3_reg = "/fixedregulator_3v3";
+		dma = "/soc/dma@7e007000";
+		spidev1 = "/soc/spi@7e204000/spidev@1";
+		v7_cpu3 = "/cpus/cpu@3";
+		vc4 = "/soc/gpu";
+		power = "/soc/power";
+		soc = "/soc";
+		v7_cpu1 = "/cpus/cpu@1";
+		leds = "/leds";
+		i2s_pins = "/soc/gpio@7e200000/i2s";
+		firmware = "/soc/firmware";
+		cprman = "/soc/cprman@7e101000";
+		mmc = "/soc/mmc@7e300000";
+		pixelvalve1 = "/soc/pixelvalve@7e207000";
+		spi = "/soc/spi@7e204000";
+		spi0_pins = "/soc/gpio@7e200000/spi0_pins";
+		pitouchscreen_touch = "/soc/i2cdsi/bridge@38";
+		i2c_arm = "/soc/i2c@7e804000";
+		clk_osc = "/clocks/clock@3";
+		ethernet = "/soc/usb@7e980000/usb1@1/usbether@1";
+		uart0 = "/soc/serial@7e201000";
+		i2c1_pins = "/soc/gpio@7e200000/i2c1";
+		fb = "/soc/fb";
+		sdhost_pins = "/soc/gpio@7e200000/sdhost_pins";
+		i2c2 = "/soc/i2c@7e805000";
+		uart1_pins = "/soc/gpio@7e200000/uart1_pins";
+		i2s = "/soc/i2s@7e203000";
+		spi1 = "/soc/spi@7e215080";
+		virtgpio = "/soc/virtgpio";
+		usb = "/soc/usb@7e980000";
+		dsi0 = "/soc/dsi@7e209000";
+		expgpio = "/soc/expgpio";
+		audio_pins = "/soc/gpio@7e200000/audio_pins";
+		i2c0 = "/soc/i2c@7e205000";
+		i2c0_pins = "/soc/gpio@7e200000/i2c0";
+		pwr_led = "/leds/pwr";
+		watchdog = "/soc/watchdog@7e100000";
+		uart0_pins = "/soc/gpio@7e200000/uart0_pins";
+		vec = "/soc/vec@7e806000";
+		local_intc = "/soc/local_intc";
+		i2c_dsi = "/soc/i2cdsi";
+		pitouchscreen_bridge = "/soc/i2cdsi/bridge@45";
+		spi0_cs_pins = "/soc/gpio@7e200000/spi0_cs_pins";
+		sound = "/soc/sound";
+		hvs = "/soc/hvs@7e400000";
+		act_led = "/leds/act";
+		spidev0 = "/soc/spi@7e204000/spidev@0";
+		v7_cpu2 = "/cpus/cpu@2";
+		bt_pins = "/soc/gpio@7e200000/bt_pins";
+		sdio_pins = "/soc/gpio@7e200000/sdio_pins";
+		cpus = "/cpus";
+		hdmi = "/soc/hdmi@7e902000";
+		pixelvalve2 = "/soc/pixelvalve@7e807000";
+		v7_cpu0 = "/cpus/cpu@0";
+		mailbox = "/soc/mailbox@7e00b880";
+		uart1 = "/soc/serial@7e215040";
+		random = "/soc/rng@7e104000";
+		i2c = "/soc/i2c@7e804000";
+	};
+
+	soc {
+		compatible = "simple-bus";
+		ranges = <0x7e000000 0x3f000000 0x1000000 0x40000000 0x40000000 0x40000>;
+		#address-cells = <0x1>;
+		#size-cells = <0x1>;
+		phandle = <0x2d>;
+		dma-ranges = <0xc0000000 0x0 0x3f000000>;
+
+		serial@7e201000 {
+			compatible = "brcm,bcm2835-pl011", "arm,pl011", "arm,primecell";
+			clocks = <0x7 0x13 0x7 0x14>;
+			clock-names = "uartclk", "apb_pclk";
+			status = "okay";
+			interrupts = <0x2 0x19>;
+			phandle = <0x21>;
+			arm,primecell-periphid = <0x241011>;
+			reg = <0x7e201000 0x1000>;
+			pinctrl-0 = <0x8 0x9>;
+			pinctrl-names = "default";
+		};
+
+		pixelvalve@7e207000 {
+			compatible = "brcm,bcm2835-pixelvalve1";
+			status = "disabled";
+			interrupts = <0x2 0xe>;
+			phandle = <0x31>;
+			reg = <0x7e207000 0x100>;
+		};
+
+		cprman@7e101000 {
+			compatible = "brcm,bcm2835-cprman";
+			clocks = <0x3 0x4 0x0 0x4 0x1 0x4 0x2 0x5 0x0 0x5 0x1 0x5 0x2>;
+			firmware = <0x6>;
+			#clock-cells = <0x1>;
+			phandle = <0x7>;
+			reg = <0x7e101000 0x2000>;
+		};
+
+		hvs@7e400000 {
+			compatible = "brcm,bcm2835-hvs";
+			status = "disabled";
+			interrupts = <0x2 0x1>;
+			phandle = <0x35>;
+			reg = <0x7e400000 0x6000>;
+		};
+
+		gpio@7e200000 {
+			compatible = "brcm,bcm2835-gpio";
+			gpio-controller;
+			#interrupt-cells = <0x2>;
+			interrupts = <0x2 0x11 0x2 0x12>;
+			phandle = <0xc>;
+			reg = <0x7e200000 0xb4>;
+			#gpio-cells = <0x2>;
+			interrupt-controller;
+
+			i2c1 {
+				brcm,pins = <0x2 0x3>;
+				phandle = <0x13>;
+				brcm,function = <0x4>;
+			};
+
+			spi0_pins {
+				brcm,pins = <0x9 0xa 0xb>;
+				phandle = <0xd>;
+				brcm,function = <0x4>;
+			};
+
+			sdhost_pins {
+				brcm,pins = <0x30 0x31 0x32 0x33 0x34 0x35>;
+				phandle = <0x17>;
+				brcm,function = <0x4>;
+			};
+
+			uart1_pins {
+				brcm,pins;
+				phandle = <0x11>;
+				brcm,pull;
+				brcm,function;
+			};
+
+			i2s {
+				brcm,pins = <0x12 0x13 0x14 0x15>;
+				phandle = <0xb>;
+				brcm,function = <0x4>;
+			};
+
+			audio_pins {
+				brcm,pins = <0x28 0x29>;
+				phandle = <0x1a>;
+				brcm,function = <0x4>;
+			};
+
+			i2c0 {
+				brcm,pins = <0x0 0x1>;
+				phandle = <0xf>;
+				brcm,function = <0x4>;
+			};
+
+			uart0_pins {
+				brcm,pins = <0x20 0x21>;
+				phandle = <0x8>;
+				brcm,pull = <0x0 0x2>;
+				brcm,function = <0x7>;
+			};
+
+			spi0_cs_pins {
+				brcm,pins = <0x8 0x7>;
+				phandle = <0xe>;
+				brcm,function = <0x1>;
+			};
+
+			bt_pins {
+				brcm,pins = <0x2b>;
+				phandle = <0x9>;
+				brcm,pull = <0x0>;
+				brcm,function = <0x4>;
+			};
+
+			sdio_pins {
+				brcm,pins = <0x22 0x23 0x24 0x25 0x26 0x27>;
+				phandle = <0x18>;
+				brcm,pull = <0x0 0x2 0x2 0x2 0x2 0x2>;
+				brcm,function = <0x7>;
+			};
+		};
+
+		pixelvalve@7e807000 {
+			compatible = "brcm,bcm2835-pixelvalve2";
+			status = "disabled";
+			interrupts = <0x2 0xa>;
+			phandle = <0x37>;
+			reg = <0x7e807000 0x100>;
+		};
+
+		v3d@7ec00000 {
+			power-domains = <0x12 0xa>;
+			compatible = "brcm,vc4-v3d";
+			status = "disabled";
+			interrupts = <0x1 0xa>;
+			phandle = <0x3b>;
+			reg = <0x7ec00000 0x1000>;
+		};
+
+		gpu {
+			compatible = "brcm,bcm2835-vc4";
+			status = "disabled";
+			phandle = <0x3c>;
+		};
+
+		mmc@7e300000 {
+			compatible = "brcm,bcm2835-mmc";
+			clocks = <0x7 0x1c>;
+			status = "okay";
+			interrupts = <0x2 0x1e>;
+			brcm,overclock-50 = <0x0>;
+			bus-width = <0x4>;
+			dma-names = "rx-tx";
+			phandle = <0x3e>;
+			reg = <0x7e300000 0x100>;
+			pinctrl-0 = <0x18>;
+			dmas = <0xa 0xb>;
+			non-removable;
+			pinctrl-names = "default";
+		};
+
+		arm-pmu {
+			compatible = "arm,cortex-a7-pmu";
+			interrupt-parent = <0x2>;
+			interrupts = <0x9>;
+		};
+
+		thermal {
+			compatible = "brcm,bcm2835-thermal";
+			firmware = <0x6>;
+			phandle = <0x45>;
+		};
+
+		spi@7e204000 {
+			compatible = "brcm,bcm2835-spi";
+			clocks = <0x7 0x14>;
+			status = "disabled";
+			#address-cells = <0x1>;
+			interrupts = <0x2 0x16>;
+			cs-gpios = <0xc 0x8 0x1 0xc 0x7 0x1>;
+			#size-cells = <0x0>;
+			dma-names = "tx", "rx";
+			phandle = <0x24>;
+			reg = <0x7e204000 0x1000>;
+			pinctrl-0 = <0xd 0xe>;
+			dmas = <0xa 0x6 0xa 0x7>;
+			pinctrl-names = "default";
+
+			spidev@1 {
+				compatible = "spidev";
+				#address-cells = <0x1>;
+				#size-cells = <0x0>;
+				phandle = <0x2f>;
+				reg = <0x1>;
+				spi-max-frequency = <0x7a120>;
+			};
+
+			spidev@0 {
+				compatible = "spidev";
+				#address-cells = <0x1>;
+				#size-cells = <0x0>;
+				phandle = <0x2e>;
+				reg = <0x0>;
+				spi-max-frequency = <0x7a120>;
+			};
+		};
+
+		i2cdsi {
+			gpios = <0xc 0x2c 0x0 0xc 0x2d 0x0>;
+			compatible = "i2c-gpio";
+			status = "disabled";
+			#address-cells = <0x1>;
+			#size-cells = <0x0>;
+			phandle = <0x41>;
+
+			bridge@45 {
+				compatible = "raspberrypi,touchscreen-bridge-i2c";
+				phandle = <0x42>;
+				reg = <0x45>;
+			};
+
+			bridge@38 {
+				compatible = "raspberrypi,touchscreen-ts-i2c";
+				phandle = <0x43>;
+				reg = <0x38>;
+			};
+		};
+
+		vchiq {
+			compatible = "brcm,bcm2835-vchiq";
+			cache-line-size = <0x40>;
+			firmware = <0x6>;
+			interrupts = <0x0 0x2>;
+			phandle = <0x1c>;
+			reg = <0x7e00b840 0xf>;
+		};
+
+		i2c@7e804000 {
+			compatible = "brcm,bcm2835-i2c";
+			clocks = <0x7 0x14>;
+			status = "disabled";
+			#address-cells = <0x1>;
+			interrupts = <0x2 0x15>;
+			#size-cells = <0x0>;
+			phandle = <0x26>;
+			reg = <0x7e804000 0x1000>;
+			clock-frequency = <0x186a0>;
+			pinctrl-0 = <0x13>;
+			pinctrl-names = "default";
+		};
+
+		audio {
+			brcm,pwm-channels = <0x8>;
+			compatible = "brcm,bcm2835-audio";
+			status = "okay";
+			phandle = <0x29>;
+			pinctrl-0 = <0x1a>;
+			pinctrl-names = "default";
+		};
+
+		i2s@7e203000 {
+			compatible = "brcm,bcm2835-i2s";
+			clocks = <0x7 0x1f>;
+			#sound-dai-cells = <0x0>;
+			status = "disabled";
+			dma-names = "tx", "rx";
+			phandle = <0x23>;
+			reg = <0x7e203000 0x24>;
+			pinctrl-0 = <0xb>;
+			dmas = <0xa 0x2 0xa 0x3>;
+			pinctrl-names = "default";
+		};
+
+		mailbox@7e00b880 {
+			compatible = "brcm,bcm2835-mbox";
+			#mbox-cells = <0x0>;
+			interrupts = <0x0 0x1>;
+			phandle = <0x19>;
+			reg = <0x7e00b880 0x40>;
+		};
+
+		gpiomem {
+			compatible = "brcm,bcm2835-gpiomem";
+			reg = <0x7e200000 0x1000>;
+		};
+
+		vec@7e806000 {
+			compatible = "brcm,bcm2835-vec";
+			clocks = <0x7 0x18>;
+			status = "disabled";
+			interrupts = <0x2 0x1b>;
+			phandle = <0x36>;
+			reg = <0x7e806000 0x1000>;
+		};
+
+		power {
+			compatible = "raspberrypi,bcm2835-power";
+			firmware = <0x6>;
+			phandle = <0x12>;
+			#power-domain-cells = <0x1>;
+		};
+
+		pixelvalve@7e206000 {
+			compatible = "brcm,bcm2835-pixelvalve0";
+			status = "disabled";
+			interrupts = <0x2 0xd>;
+			phandle = <0x30>;
+			reg = <0x7e206000 0x100>;
+		};
+
+		firmware {
+			compatible = "raspberrypi,bcm2835-firmware";
+			mboxes = <0x19>;
+			phandle = <0x6>;
+		};
+
+		dsi@7e209000 {
+			compatible = "brcm,bcm2835-dsi0";
+			clocks = <0x7 0x20 0x7 0x2f 0x7 0x31>;
+			clock-names = "phy", "escape", "pixel";
+			status = "disabled";
+			#address-cells = <0x1>;
+			interrupts = <0x2 0x4>;
+			#size-cells = <0x0>;
+			#clock-cells = <0x1>;
+			phandle = <0x4>;
+			reg = <0x7e209000 0x78>;
+			clock-output-names = "dsi0_byte", "dsi0_ddr2", "dsi0_ddr";
+		};
+
+		fb {
+			compatible = "brcm,bcm2708-fb";
+			firmware = <0x6>;
+			status = "okay";
+			phandle = <0x44>;
+		};
+
+		sdhost@7e202000 {
+			compatible = "brcm,bcm2835-sdhost";
+			clocks = <0x7 0x14>;
+			brcm,pio-limit = <0x1>;
+			status = "okay";
+			interrupts = <0x2 0x18>;
+			brcm,overclock-50 = <0x0>;
+			bus-width = <0x4>;
+			dma-names = "rx-tx";
+			phandle = <0x2c>;
+			reg = <0x7e202000 0x100>;
+			pinctrl-0 = <0x17>;
+			dmas = <0xa 0xd>;
+			pinctrl-names = "default";
+		};
+
+		virtgpio {
+			compatible = "brcm,bcm2835-virtgpio";
+			gpio-controller;
+			firmware = <0x6>;
+			status = "okay";
+			phandle = <0x1b>;
+			#gpio-cells = <0x2>;
+		};
+
+		dpi@7e208000 {
+			compatible = "brcm,bcm2835-dpi";
+			clocks = <0x7 0x14 0x7 0x2c>;
+			clock-names = "core", "pixel";
+			status = "disabled";
+			#address-cells = <0x1>;
+			#size-cells = <0x0>;
+			phandle = <0x3d>;
+			reg = <0x7e208000 0x8c>;
+		};
+
+		expgpio {
+			compatible = "brcm,bcm2835-expgpio";
+			gpio-controller;
+			firmware = <0x6>;
+			status = "okay";
+			phandle = <0x15>;
+			#gpio-cells = <0x2>;
+		};
+
+		hdmi@7e902000 {
+			power-domains = <0x12 0x5>;
+			compatible = "brcm,bcm2835-hdmi";
+			clocks = <0x7 0x10 0x7 0x19>;
+			clock-names = "pixel", "hdmi";
+			ddc = <0x14>;
+			status = "disabled";
+			interrupts = <0x2 0x8 0x2 0x9>;
+			dma-names = "audio-rx";
+			phandle = <0x38>;
+			hpd-gpios = <0x15 0x4 0x1>;
+			reg = <0x7e902000 0x600 0x7e808000 0x100>;
+			dmas = <0xa 0x11>;
+		};
+
+		timer {
+			compatible = "arm,armv7-timer";
+			always-on;
+			interrupt-parent = <0x2>;
+			interrupts = <0x0 0x1 0x3 0x2>;
+		};
+
+		pwm@7e20c000 {
+			compatible = "brcm,bcm2835-pwm";
+			clocks = <0x7 0x1e>;
+			status = "disabled";
+			assigned-clock-rates = <0x989680>;
+			assigned-clocks = <0x7 0x1e>;
+			phandle = <0x34>;
+			reg = <0x7e20c000 0x28>;
+			#pwm-cells = <0x2>;
+		};
+
+		watchdog@7e100000 {
+			compatible = "brcm,bcm2835-pm-wdt";
+			phandle = <0x2a>;
+			reg = <0x7e100000 0x28>;
+		};
+
+		interrupt-controller@7e00b200 {
+			compatible = "brcm,bcm2836-armctrl-ic";
+			#interrupt-cells = <0x2>;
+			interrupt-parent = <0x2>;
+			interrupts = <0x8>;
+			phandle = <0x1>;
+			reg = <0x7e00b200 0x200>;
+			interrupt-controller;
+		};
+
+		local_intc {
+			compatible = "brcm,bcm2836-l1-intc";
+			#interrupt-cells = <0x1>;
+			interrupt-parent = <0x2>;
+			phandle = <0x2>;
+			reg = <0x40000000 0x100>;
+			interrupt-controller;
+		};
+
+		dsi@7e700000 {
+			power-domains = <0x12 0x12>;
+			compatible = "brcm,bcm2835-dsi1";
+			clocks = <0x7 0x23 0x7 0x30 0x7 0x32>;
+			clock-names = "phy", "escape", "pixel";
+			status = "disabled";
+			#address-cells = <0x1>;
+			interrupts = <0x2 0xc>;
+			#size-cells = <0x0>;
+			#clock-cells = <0x1>;
+			phandle = <0x5>;
+			reg = <0x7e700000 0x8c>;
+			clock-output-names = "dsi1_byte", "dsi1_ddr2", "dsi1_ddr";
+		};
+
+		sound {
+			status = "disabled";
+			phandle = <0x46>;
+		};
+
+		i2c@7e205000 {
+			compatible = "brcm,bcm2835-i2c";
+			clocks = <0x7 0x14>;
+			status = "disabled";
+			#address-cells = <0x1>;
+			interrupts = <0x2 0x15>;
+			#size-cells = <0x0>;
+			phandle = <0x25>;
+			reg = <0x7e205000 0x1000>;
+			clock-frequency = <0x186a0>;
+			pinctrl-0 = <0xf>;
+			pinctrl-names = "default";
+		};
+
+		serial@7e215040 {
+			compatible = "brcm,bcm2835-aux-uart";
+			clocks = <0x10 0x0>;
+			status = "disabled";
+			interrupt-parent = <0x10>;
+			interrupts = <0x0>;
+			phandle = <0x22>;
+			reg = <0x7e215040 0x40>;
+			pinctrl-0 = <0x11>;
+			pinctrl-names = "default";
+		};
+
+		dma@7e007000 {
+			#dma-cells = <0x1>;
+			compatible = "brcm,bcm2835-dma";
+			brcm,dma-channel-mask = <0x7f34>;
+			interrupts = <0x1 0x10 0x1 0x11 0x1 0x12 0x1 0x13 0x1 0x14 0x1 0x15 0x1 0x16 0x1 0x17 0x1 0x18 0x1 0x19 0x1 0x1a 0x1 0x1b 0x1 0x1b 0x1 0x1b 0x1 0x1b 0x1 0x1c>;
+			phandle = <0xa>;
+			reg = <0x7e007000 0xf00>;
+			interrupt-names = "dma0", "dma1", "dma2", "dma3", "dma4", "dma5", "dma6", "dma7", "dma8", "dma9", "dma10", "dma11", "dma12", "dma13", "dma14", "dma-shared-all";
+		};
+
+		i2c@7e805000 {
+			compatible = "brcm,bcm2835-i2c";
+			clocks = <0x7 0x14>;
+			status = "disabled";
+			#address-cells = <0x1>;
+			interrupts = <0x2 0x15>;
+			#size-cells = <0x0>;
+			phandle = <0x14>;
+			reg = <0x7e805000 0x1000>;
+			clock-frequency = <0x186a0>;
+		};
+
+		spi@7e215080 {
+			compatible = "brcm,bcm2835-aux-spi";
+			clocks = <0x10 0x1>;
+			status = "disabled";
+			interrupt-parent = <0x10>;
+			#address-cells = <0x1>;
+			interrupts = <0x1>;
+			#size-cells = <0x0>;
+			phandle = <0x32>;
+			reg = <0x7e215080 0x40>;
+		};
+
+		aux@0x7e215000 {
+			compatible = "brcm,bcm2835-aux";
+			clocks = <0x7 0x14>;
+			#interrupt-cells = <0x1>;
+			interrupts = <0x1 0x1d>;
+			#clock-cells = <0x1>;
+			phandle = <0x10>;
+			reg = <0x7e215000 0x8>;
+			interrupt-controller;
+		};
+
+		firmwarekms@7e600000 {
+			compatible = "raspberrypi,rpi-firmware-kms";
+			status = "disabled";
+			interrupts = <0x2 0x10>;
+			brcm,firmware = <0x6>;
+			phandle = <0x3f>;
+			reg = <0x7e600000 0x100>;
+		};
+
+		rng@7e104000 {
+			compatible = "brcm,bcm2835-rng";
+			phandle = <0x2b>;
+			reg = <0x7e104000 0x10>;
+		};
+
+		syscon@40000000 {
+			compatible = "brcm,bcm2836-arm-local", "syscon";
+			reg = <0x40000000 0x100>;
+		};
+
+		usb@7e980000 {
+			power-domains = <0x12 0x6>;
+			compatible = "brcm,bcm2708-usb";
+			clocks = <0x16>;
+			clock-names = "otg";
+			#address-cells = <0x1>;
+			interrupts = <0x2 0x0 0x1 0x9>;
+			#size-cells = <0x0>;
+			phandle = <0x39>;
+			reg = <0x7e980000 0x10000 0x7e006000 0x1000>;
+
+			usb1@1 {
+				compatible = "usb424,9514";
+				#address-cells = <0x1>;
+				#size-cells = <0x0>;
+				reg = <0x1>;
+
+				usbether@1 {
+					compatible = "usb424,ec00";
+					local-mac-address = [04 05 06 01 02 03];
+					phandle = <0x3a>;
+					reg = <0x1>;
+				};
+			};
+		};
+
+		smi@7e600000 {
+			compatible = "brcm,bcm2835-smi";
+			clocks = <0x7 0x2a>;
+			status = "disabled";
+			interrupts = <0x2 0x10>;
+			assigned-clock-rates = <0x7735940>;
+			dma-names = "rx-tx";
+			assigned-clocks = <0x7 0x2a>;
+			phandle = <0x40>;
+			reg = <0x7e600000 0x100>;
+			dmas = <0xa 0x4>;
+		};
+
+		spi@7e2150c0 {
+			compatible = "brcm,bcm2835-aux-spi";
+			clocks = <0x10 0x2>;
+			status = "disabled";
+			interrupt-parent = <0x10>;
+			#address-cells = <0x1>;
+			interrupts = <0x2>;
+			#size-cells = <0x0>;
+			phandle = <0x33>;
+			reg = <0x7e2150c0 0x40>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+		phandle = <0x49>;
+
+		act {
+			gpios = <0x1b 0x0 0x0>;
+			label = "led0";
+			phandle = <0x27>;
+			linux,default-trigger = "mmc0";
+		};
+
+		pwr {
+			gpios = <0x15 0x7 0x0>;
+			label = "led1";
+			phandle = <0x28>;
+			linux,default-trigger = "input";
+		};
+	};
+
+	aliases {
+		intc = "/soc/interrupt-controller@7e00b200";
+		spi2 = "/soc/spi@7e2150c0";
+		i2c1 = "/soc/i2c@7e804000";
+		i2c_vc = "/soc/i2c@7e205000";
+		spi0 = "/soc/spi@7e204000";
+		thermal = "/soc/thermal";
+		vchiq = "/soc/vchiq";
+		sdhost = "/soc/sdhost@7e202000";
+		aux = "/soc/aux@0x7e215000";
+		gpio = "/soc/gpio@7e200000";
+		audio = "/soc/audio";
+		dma = "/soc/dma@7e007000";
+		soc = "/soc";
+		leds = "/leds";
+		mmc = "/soc/mmc@7e300000";
+		serial1 = "/soc/serial@7e201000";
+		i2c_arm = "/soc/i2c@7e804000";
+		ethernet = "/soc/usb@7e980000/usb1@1/usbether@1";
+		uart0 = "/soc/serial@7e201000";
+		fb = "/soc/fb";
+		i2c2 = "/soc/i2c@7e805000";
+		i2s = "/soc/i2s@7e203000";
+		spi1 = "/soc/spi@7e215080";
+		usb = "/soc/usb@7e980000";
+		i2c0 = "/soc/i2c@7e205000";
+		watchdog = "/soc/watchdog@7e100000";
+		sound = "/soc/sound";
+		mailbox = "/soc/mailbox@7e00b880";
+		uart1 = "/soc/serial@7e215040";
+		random = "/soc/rng@7e104000";
+		i2c = "/soc/i2c@7e804000";
+		serial0 = "/soc/serial@7e215040";
+	};
+
+	chosen {
+		bootargs = "8250.nr_uarts=0 bcm2708_fb.fbwidth=640 bcm2708_fb.fbheight=480 bcm2708_fb.fbswap=1 vc_mem.mem_base=0x3dc00000 vc_mem.mem_size=0x3f000000  dwc_otg.lpm_enable=0 console=ttyS0,115200 console=tty1 root=/dev/mmcblk0p7 rootfstype=ext4 elevator=deadline fsck.repair=yes rootwait";
+		kaslr-seed = <0xef42e779 0x662d8187>;
+	};
+
+	memory {
+		device_type = "memory";
+		reg = <0x0 0x3b000000>;
+	};
+
+	fixedregulator_3v3 {
+		compatible = "regulator-fixed";
+		phandle = <0x48>;
+		regulator-min-microvolt = <0x325aa0>;
+		regulator-max-microvolt = <0x325aa0>;
+		regulator-always-on;
+		regulator-name = "3v3";
+	};
+
+	cpus {
+		#address-cells = <0x1>;
+		#size-cells = <0x0>;
+		phandle = <0x4a>;
+
+		cpu@3 {
+			compatible = "arm,cortex-a7";
+			device_type = "cpu";
+			phandle = <0x20>;
+			reg = <0x3>;
+			clock-frequency = <0x47868c00>;
+		};
+
+		cpu@1 {
+			compatible = "arm,cortex-a7";
+			device_type = "cpu";
+			phandle = <0x1e>;
+			reg = <0x1>;
+			clock-frequency = <0x47868c00>;
+		};
+
+		cpu@2 {
+			compatible = "arm,cortex-a7";
+			device_type = "cpu";
+			phandle = <0x1f>;
+			reg = <0x2>;
+			clock-frequency = <0x47868c00>;
+		};
+
+		cpu@0 {
+			compatible = "arm,cortex-a7";
+			device_type = "cpu";
+			phandle = <0x1d>;
+			reg = <0x0>;
+			clock-frequency = <0x47868c00>;
+		};
+	};
+
+	fixedregulator_5v0 {
+		compatible = "regulator-fixed";
+		phandle = <0x47>;
+		regulator-min-microvolt = <0x4c4b40>;
+		regulator-max-microvolt = <0x4c4b40>;
+		regulator-always-on;
+		regulator-name = "5v0";
+	};
+
+	axi {
+
+		vc_mem {
+			reg = <0x3dc00000 0x3f000000 0xc0000000>;
+		};
+	};
+};


### PR DESCRIPTION
* Added some Device Tree .dts to test/data. Please add more. Use `dtc -I fs /proc/device-tree` or perhaps `dtc -I fs /sys/firmware/devicetree/base` to create.
* Fix bug where every property appeared as byte sequence sometimes.
* Look for Device Tree root in two known locations. Please add more if you find it elsewhere.
* Decode /_ _ overrides _ _ fields
* Started some work decoding clocks and gpios, currently turned off because it is incomplete.
* reg grouping using inherited #address-cells and #size-cells.


