### PR TITLE
device tree: fix crash when device tree is not found

### DIFF
--- a/includes/cpu_util.h
+++ b/includes/cpu_util.h
@@ -7,8 +7,7 @@
 #define PROC_CPUINFO "/proc/cpuinfo"
 #endif
 
-/* needs a local Processor *processor */
-#define STRIFNULL(f,cs) if (processor->f == NULL) processor->f = g_strdup(cs);
+#define STRIFNULL(f,cs) if (f == NULL) f = g_strdup(cs);
 #define UNKIFNULL(f) STRIFNULL(f, _("(Unknown)") )
 #define EMPIFNULL(f) STRIFNULL(f, "")
 

--- a/includes/dt_util.h
+++ b/includes/dt_util.h
@@ -40,7 +40,7 @@ typedef uint32_t dt_uint; /* big-endian */
 typedef struct _dtr dtr;
 typedef struct _dtr_obj dtr_obj;
 
-dtr *dtr_new(char *base_path); /* NULL for DTR_ROOT */
+dtr *dtr_new(const char *base_path); /* NULL for DTR_ROOT */
 void dtr_free(dtr *);
 int dtr_was_found(dtr *);
 const char *dtr_base_path(dtr *);
@@ -76,6 +76,9 @@ int dtr_cellv_find(dtr_obj *obj, char *qprop, int limit);
 char *dtr_maps_info(dtr *); /* returns hardinfo shell section */
 
 const char *dtr_find_device_tree_root(void);
+
+/* write to the message log */
+void dtr_msg(dtr *s, char *fmt, ...);
 
 #define sp_sep(STR) (strlen(STR) ? " " : "")
 /* appends an element to a string, adding a space if

--- a/includes/dt_util.h
+++ b/includes/dt_util.h
@@ -42,6 +42,7 @@ typedef struct _dtr_obj dtr_obj;
 
 dtr *dtr_new(char *base_path); /* NULL for DTR_ROOT */
 void dtr_free(dtr *);
+int dtr_was_found(dtr *);
 const char *dtr_base_path(dtr *);
 char *dtr_messages(dtr *); /* returns a message log */
 

--- a/modules/devices/arm/processor.c
+++ b/modules/devices/arm/processor.c
@@ -138,19 +138,19 @@ processor_scan(void)
         processor = (Processor *) pi->data;
 
         /* strings can't be null or segfault later */
-        STRIFNULL(model_name, _("ARM Processor") );
-        EMPIFNULL(flags);
-        UNKIFNULL(cpu_implementer);
-        UNKIFNULL(cpu_architecture);
-        UNKIFNULL(cpu_variant);
-        UNKIFNULL(cpu_part);
-        UNKIFNULL(cpu_revision);
+        STRIFNULL(processor->model_name, _("ARM Processor") );
+        EMPIFNULL(processor->flags);
+        UNKIFNULL(processor->cpu_implementer);
+        UNKIFNULL(processor->cpu_architecture);
+        UNKIFNULL(processor->cpu_variant);
+        UNKIFNULL(processor->cpu_part);
+        UNKIFNULL(processor->cpu_revision);
 
         processor->decoded_name = arm_decoded_name(
             processor->cpu_implementer, processor->cpu_part,
             processor->cpu_variant, processor->cpu_revision,
             processor->cpu_architecture, processor->model_name);
-        UNKIFNULL(decoded_name);
+        UNKIFNULL(processor->decoded_name);
 
         /* topo & freq */
         processor->cpufreq = cpufreq_new(processor->id);

--- a/modules/devices/devicetree.c
+++ b/modules/devices/devicetree.c
@@ -25,6 +25,7 @@
 #include <sys/types.h>
 #include <stdint.h>
 #include "devices.h"
+#include "cpu_util.h"
 #include "dt_util.h"
 
 /* Hardinfo labels that have # are truncated and/or hidden.
@@ -166,6 +167,8 @@ gchar *get_summary() {
 
     model = get_dt_string("/model", 0);
     compat = get_dt_string("/compatible", 1);
+    UNKIFNULL(model);
+    EMPIFNULL(compat);
 
     /* Expand on the DT information from known machines, like RPi.
      * RPi stores a revision value in /proc/cpuinfo that can be used
@@ -217,6 +220,7 @@ gchar *get_summary() {
     /* fallback */
     if (ret == NULL) {
         tmp[0] = get_dt_string("/serial-number", 1);
+        EMPIFNULL(tmp[0]);
         ret = g_strdup_printf(
                 "[%s]\n"
                 "%s=%s\n"
@@ -308,7 +312,8 @@ void __scan_dtree()
     mi_add("Summary", summary);
     mi_add("Maps", maps);
 
-    add_keys("/");
+    if(dtr_was_found(dt))
+        add_keys("/");
     messages = msg_section(0);
     mi_add("Messages", messages);
 

--- a/modules/devices/devicetree/dt_util.c
+++ b/modules/devices/devicetree/dt_util.c
@@ -221,19 +221,24 @@ const char *dtr_find_device_tree_root() {
             return candidates[i];
         i++;
     }
-    return "/did/not/find/device-tree";
+    return NULL;
 }
 
 dtr *dtr_new_x(char *base_path, int fast) {
     dtr *dt = malloc(sizeof(dtr));
     if (dt != NULL) {
         memset(dt, 0, sizeof(dtr));
+        dt->log = strdup("");
+
+        if (base_path == NULL)
+            base_path = DTR_ROOT;
+
         if (base_path != NULL)
             dt->base_path = strdup(base_path);
-        else
-            dt->base_path = strdup(DTR_ROOT);
-
-        dt->log = strdup("");
+        else {
+            dtr_msg(dt, "%s", "Device Tree not found.");
+            return dt;
+        }
 
         /* build alias and phandle lists */
         dt->aliases = NULL;
@@ -261,6 +266,14 @@ void dtr_free(dtr *s) {
         free(s->log);
         free(s);
     }
+}
+
+int dtr_was_found(dtr *s) {
+    if (s != NULL) {
+        if (s->base_path != NULL)
+            return 1;
+    }
+    return 0;
 }
 
 void dtr_msg(dtr *s, char *fmt, ...) {

--- a/modules/devices/devicetree/dt_util.c
+++ b/modules/devices/devicetree/dt_util.c
@@ -224,7 +224,7 @@ const char *dtr_find_device_tree_root() {
     return NULL;
 }
 
-dtr *dtr_new_x(char *base_path, int fast) {
+dtr *dtr_new_x(const char *base_path, int fast) {
     dtr *dt = malloc(sizeof(dtr));
     if (dt != NULL) {
         memset(dt, 0, sizeof(dtr));
@@ -253,7 +253,7 @@ dtr *dtr_new_x(char *base_path, int fast) {
     return dt;
 }
 
-dtr *dtr_new(char *base_path) {
+dtr *dtr_new(const char *base_path) {
     return dtr_new_x(base_path, 0);
 }
 

--- a/modules/devices/devicetree/pmac_data.c
+++ b/modules/devices/devicetree/pmac_data.c
@@ -58,14 +58,13 @@ static gchar *ppc_mac_details(void) {
     if (machine == NULL)
         goto pmd_exit;
 
-#define _UNKIFNULL(STR) if (STR == NULL) { STR = strdup(_("(Unknown)")); }
-    _UNKIFNULL(platform);
-    _UNKIFNULL(model);
-    _UNKIFNULL(motherboard);
-    _UNKIFNULL(detected_as);
-    _UNKIFNULL(pmac_flags);
-    _UNKIFNULL(l2_cache);
-    _UNKIFNULL(pmac_gen);
+    UNKIFNULL(platform);
+    UNKIFNULL(model);
+    UNKIFNULL(motherboard);
+    UNKIFNULL(detected_as);
+    UNKIFNULL(pmac_flags);
+    UNKIFNULL(l2_cache);
+    UNKIFNULL(pmac_gen);
 
     ret = g_strdup_printf("[%s]\n"
                 "%s=%s\n"

--- a/modules/devices/ia64/processor.c
+++ b/modules/devices/ia64/processor.c
@@ -105,12 +105,12 @@ processor_scan(void)
         processor = (Processor *) pi->data;
 
         /* strings can't be null or segfault later */
-        STRIFNULL(model_name, _("IA64 Processor") );
-        UNKIFNULL(vendor_id);
-        STRIFNULL(arch, "IA-64");
-        STRIFNULL(archrev, "0");
-        UNKIFNULL(family);
-        UNKIFNULL(features);
+        STRIFNULL(processor->model_name, _("IA64 Processor") );
+        UNKIFNULL(processor->vendor_id);
+        STRIFNULL(processor->arch, "IA-64");
+        STRIFNULL(processor->archrev, "0");
+        UNKIFNULL(processor->family);
+        UNKIFNULL(processor->features);
 
         /* topo & freq */
         processor->cpufreq = cpufreq_new(processor->id);

--- a/modules/devices/parisc/processor.c
+++ b/modules/devices/parisc/processor.c
@@ -104,9 +104,9 @@ processor_scan(void)
         processor = (Processor *) pi->data;
 
         /* strings can't be null or segfault later */
-        STRIFNULL(model_name, _("PA-RISC Processor") );
-        STRIFNULL(cpu_family, "PA-RISC");
-        UNKIFNULL(strmodel);
+        STRIFNULL(processor->model_name, _("PA-RISC Processor") );
+        STRIFNULL(processor->cpu_family, "PA-RISC");
+        UNKIFNULL(processor->strmodel);
 
         /* topo & freq */
         processor->cpufreq = cpufreq_new(processor->id);

--- a/modules/devices/ppc/processor.c
+++ b/modules/devices/ppc/processor.c
@@ -114,8 +114,8 @@ processor_scan(void)
         processor = (Processor *) pi->data;
 
         /* strings can't be null or segfault later */
-        STRIFNULL(model_name, _("POWER Processor") );
-        UNKIFNULL(revision);
+        STRIFNULL(processor->model_name, _("POWER Processor") );
+        UNKIFNULL(processor->revision);
 
         /* topo & freq */
         processor->cpufreq = cpufreq_new(processor->id);

--- a/modules/devices/riscv/processor.c
+++ b/modules/devices/riscv/processor.c
@@ -104,10 +104,10 @@ processor_scan(void)
         processor = (Processor *) pi->data;
 
         /* strings can't be null or segfault later */
-        STRIFNULL(model_name, _("RISC-V Processor") );
-        UNKIFNULL(mmu);
-        UNKIFNULL(isa);
-        UNKIFNULL(uarch);
+        STRIFNULL(processor->model_name, _("RISC-V Processor") );
+        UNKIFNULL(processor->mmu);
+        UNKIFNULL(processor->isa);
+        UNKIFNULL(processor->uarch);
 
         processor->flags = riscv_isa_to_flags(processor->isa);
 

--- a/modules/devices/s390/processor.c
+++ b/modules/devices/s390/processor.c
@@ -89,8 +89,8 @@ processor_scan(void)
         processor = (Processor *) pi->data;
 
         /* strings can't be null or segfault later */
-        STRIFNULL(model_name, _("S390 Processor") );
-        UNKIFNULL(proc_str);
+        STRIFNULL(processor->model_name, _("S390 Processor") );
+        UNKIFNULL(processor->proc_str);
 
         /* topo & freq */
         processor->cpufreq = cpufreq_new(processor->id);

--- a/modules/devices/sh/processor.c
+++ b/modules/devices/sh/processor.c
@@ -52,8 +52,8 @@ processor_scan(void)
 
     fclose(cpuinfo);
 
-    STRIFNULL(model_name, _("SuperH Processor"));
-    UNKIFNULL(vendor_id);
+    STRIFNULL(processor->model_name, _("SuperH Processor"));
+    UNKIFNULL(processor->vendor_id);
 
     return g_slist_append(NULL, processor);
 }


### PR DESCRIPTION
* check if device tree was found before add_keys()
* UNKIFNULL(model) before strcmp
* make UNKIFNULL() STRIFNULL() EMPIFNULL() macros more generic
