### PR TITLE
Various recent stuff

### DIFF
--- a/includes/callbacks.h
+++ b/includes/callbacks.h
@@ -24,7 +24,6 @@
 void cb_about();
 void cb_about_module(GtkAction *action);
 void cb_generate_report();
-void cb_save_graphic();
 void cb_quit();
 void cb_refresh();
 void cb_copy_to_clipboard();

--- a/includes/hardinfo.h
+++ b/includes/hardinfo.h
@@ -89,7 +89,6 @@ gchar       *strreplace(gchar *string, gchar *replace, gchar *replacement);
 /* Widget utility functions */
 void widget_set_cursor(GtkWidget *widget, GdkCursorType cursor_type);
 gint tree_view_get_visible_height(GtkTreeView *tv);
-void tree_view_save_image(gchar *filename);
 
 /* File Chooser utility functions */
 void      file_chooser_open_expander(GtkWidget *chooser);

--- a/includes/uidefs.h
+++ b/includes/uidefs.h
@@ -1,5 +1,5 @@
 #ifndef __UIDEFS_H__
-#define __UIDEFS_H__ 
+#define __UIDEFS_H__
 
 #include "config.h"
 
@@ -12,7 +12,7 @@
 
 #ifdef HAS_LIBSOUP
 #define SYNC_MANAGER_ITEMS "		<separator/>" \
-"		<menuitem name=\"SyncManager\" action=\"SyncManagerAction\" />" 
+"		<menuitem name=\"SyncManager\" action=\"SyncManagerAction\" />"
 
 #else		/* !HAS_LIBSOUP */
 #define SYNC_MANAGER_ITEMS
@@ -24,10 +24,6 @@ char *uidefs_str = "<ui>" \
 "		<menuitem name=\"Report\" action=\"ReportAction\" />" \
 "		<menuitem name=\"Copy\" action=\"CopyAction\" />" \
 SYNC_MANAGER_ITEMS
-/*
- * Save Image is not ready for prime time. Yet.
- * "<menuitem name=\"SaveGraph\" action=\"SaveGraphAction\" />" \
- */
 "		<separator/>" \
 "		<menuitem name=\"Quit\" action=\"QuitAction\" />" \
 "	</menu>" \

--- a/modules/benchmark.c
+++ b/modules/benchmark.c
@@ -56,7 +56,9 @@ static ModuleEntry entries[] = {
     {N_("CPU Zlib"), "file-roller.png", callback_zlib, scan_zlib, MODULE_FLAG_NONE},
     {N_("FPU FFT"), "fft.png", callback_fft, scan_fft, MODULE_FLAG_NONE},
     {N_("FPU Raytracing"), "raytrace.png", callback_raytr, scan_raytr, MODULE_FLAG_NONE},
+#if !GTK_CHECK_VERSION(3,0,0)
     {N_("GPU Drawing"), "module.png", callback_gui, scan_gui, MODULE_FLAG_NO_REMOTE},
+#endif
     {NULL}
 };
 

--- a/modules/computer/os.c
+++ b/modules/computer/os.c
@@ -165,7 +165,7 @@ desktop_with_session_type(const gchar *desktop_env)
     tmp = g_getenv("XDG_SESSION_TYPE");
     if (tmp) {
         if (!g_str_equal(tmp, "unspecified"))
-            return g_strdup_printf(_("%s on %s"), desktop_env, tmp);
+            return g_strdup_printf(_(/*/{desktop environment} on {session type}*/ "%s on %s"), desktop_env, tmp);
     }
 
     return g_strdup(desktop_env);
@@ -352,11 +352,11 @@ detect_distro(void)
             /* HACK: Some Debian systems doesn't include the distribuition
              * name in /etc/debian_release, so add them here. */
             if (isdigit(contents[0]) || contents[0] != 'D')
-                return g_strdup_printf("Debian GNU/Linux %s", idle_free(contents));
+                return g_strdup_printf("Debian GNU/Linux %s", (char*)idle_free(contents));
         }
 
         if (g_str_equal(distro_db[i].codename, "fatdog"))
-            return g_strdup_printf("Fatdog64 [%.10s]", idle_free(contents));
+            return g_strdup_printf("Fatdog64 [%.10s]", (char*)idle_free(contents));
 
         return contents;
     }

--- a/modules/network.c
+++ b/modules/network.c
@@ -80,6 +80,7 @@ void scan_statistics(gboolean reload)
     FILE *netstat;
     gchar buffer[256];
     gchar *netstat_path;
+    int line = 0;
 
     SCAN_START();
 
@@ -99,22 +100,16 @@ void scan_statistics(gboolean reload)
             __statistics = h_strdup_cprintf("[%s]\n",
                                             __statistics,
                                             tmp);
-
             g_free(tmp);
-          } else if (isdigit(buffer[4])) {
-            gchar *tmp1 = buffer + 4,
-                  *tmp2 = tmp1;
 
-            while (*tmp2 && !isspace(*tmp2)) tmp2++;
-            *tmp2 = 0;
-            tmp2++;
+          } else {
+            gchar *tmp = buffer;
 
-            *tmp2 = toupper(*tmp2);
+            while (*tmp && isspace(*tmp)) tmp++;
 
-            __statistics = h_strdup_cprintf("%s=%s\n",
+            __statistics = h_strdup_cprintf("<b> </b>#%d=%s\n",
                                             __statistics,
-                                            g_strstrip(tmp1),
-                                            g_strstrip(tmp2));
+                                            line++, tmp);
           }
         }
 

--- a/shell/callbacks.c
+++ b/shell/callbacks.c
@@ -210,9 +210,7 @@ void cb_about()
 				 "You should have received a copy of the GNU General Public License "
 				 "along with this program; if not, write to the Free Software "
 				 "Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA"));
-#if GTK_CHECK_VERSION(2,8,0)
     gtk_about_dialog_set_wrap_license(GTK_ABOUT_DIALOG(about), TRUE);
-#endif
 
     gtk_about_dialog_set_authors(GTK_ABOUT_DIALOG(about), authors);
     gtk_about_dialog_set_artists(GTK_ABOUT_DIALOG(about), artists);

--- a/shell/callbacks.c
+++ b/shell/callbacks.c
@@ -37,52 +37,6 @@ void cb_sync_manager()
     sync_manager_show(shell->window);
 }
 
-void cb_save_graphic()
-{
-    Shell *shell = shell_get_main_shell();
-    GtkWidget *dialog;
-    gchar *filename;
-
-    /* save the pixbuf to a png file */
-#if GTK_CHECK_VERSION(3, 0, 0)
-    dialog = gtk_file_chooser_dialog_new(_("Save Image"),
-					 NULL,
-					 GTK_FILE_CHOOSER_ACTION_SAVE,
-					 "_Cancel",
-					 GTK_RESPONSE_CANCEL,
-					 "_Save",
-					 GTK_RESPONSE_ACCEPT, NULL);
-#else
-    dialog = gtk_file_chooser_dialog_new(_("Save Image"),
-					 NULL,
-					 GTK_FILE_CHOOSER_ACTION_SAVE,
-					 GTK_STOCK_CANCEL,
-					 GTK_RESPONSE_CANCEL,
-					 GTK_STOCK_SAVE,
-					 GTK_RESPONSE_ACCEPT, NULL);
-#endif
-
-    filename = g_strconcat(shell->selected->name, ".png", NULL);
-    gtk_file_chooser_set_current_name(GTK_FILE_CHOOSER(dialog), filename);
-    g_free(filename);
-
-    if (gtk_dialog_run(GTK_DIALOG(dialog)) == GTK_RESPONSE_ACCEPT) {
-	filename = gtk_file_chooser_get_filename(GTK_FILE_CHOOSER(dialog));
-	gtk_widget_destroy(dialog);
-
-	shell_status_update(_("Saving image..."));
-
-	tree_view_save_image(filename);
-
-	shell_status_update(_("Done."));
-	g_free(filename);
-
-	return;
-    }
-
-    gtk_widget_destroy(dialog);
-}
-
 void cb_open_web_page()
 {
     open_url("http://www.hardinfo.org");

--- a/shell/loadgraph.c
+++ b/shell/loadgraph.c
@@ -26,17 +26,10 @@
 #include "loadgraph.h"
 
 struct _LoadGraph {
-#if GTK_CHECK_VERSION(3, 0, 0)
-    cairo_surface_t *buf;
-    cairo_t       *grid;
-    cairo_t       *trace;
-    cairo_t       *fill;
-#else
     GdkPixmap     *buf;
     GdkGC         *grid;
     GdkGC         *trace;
     GdkGC         *fill;
-#endif
     GtkWidget     *area;
 
     gint          *data;
@@ -128,45 +121,32 @@ void load_graph_clear(LoadGraph * lg)
 void load_graph_set_color(LoadGraph * lg, LoadGraphColor color)
 {
     lg->color = color;
-#if GTK_CHECK_VERSION(3, 0, 0)
-#define UNPACK_COLOR(C) (((C)>>16) & 0xff), (((C)>>8) & 0xff), ((C) & 0xff)
-    cairo_set_source_rgb(lg->trace, UNPACK_COLOR(lg->color) );
-    cairo_set_source_rgb(lg->fill, UNPACK_COLOR(lg->color - 0x303030) );
-    cairo_set_source_rgb(lg->grid, UNPACK_COLOR(lg->color - 0xcdcdcd) );
-#else
     gdk_rgb_gc_set_foreground(lg->trace, lg->color);
     gdk_rgb_gc_set_foreground(lg->fill, lg->color - 0x303030);
     gdk_rgb_gc_set_foreground(lg->grid, lg->color - 0xcdcdcd);
-#endif
 }
 
 void load_graph_destroy(LoadGraph * lg)
 {
-#if GTK_CHECK_VERSION(3, 0, 0)
-    g_object_unref(lg->buf);
-#else
+    g_free(lg->data);
+    gtk_widget_destroy(lg->area);
     gdk_pixmap_unref(lg->buf);
-#endif
     g_object_unref(lg->trace);
     g_object_unref(lg->grid);
     g_object_unref(lg->fill);
     g_object_unref(lg->layout);
-    gtk_widget_destroy(lg->area);
-    g_free(lg->data);
     g_free(lg);
 }
 
-static gboolean _expose(GtkWidget * widget, GdkEventExpose * event, gpointer user_data)
+static gboolean _expose(GtkWidget * widget, GdkEventExpose * event,
+            gpointer user_data)
 {
     LoadGraph *lg = (LoadGraph *) user_data;
-#if GTK_CHECK_VERSION(3, 0, 0)
-    /* TODO:GTK3 copy from lg->buf or lg->area? to widget? */
-#else
     GdkDrawable *draw = GDK_DRAWABLE(lg->buf);
+
     gdk_draw_drawable(lg->area->window,
-            lg->area->style->black_gc,
-            draw, 0, 0, 0, 0, lg->width, lg->height);
-#endif
+              lg->area->style->black_gc,
+              draw, 0, 0, 0, 0, lg->width, lg->height);
     return FALSE;
 }
 
@@ -174,124 +154,64 @@ void load_graph_configure_expose(LoadGraph * lg)
 {
     /* creates the backing store pixmap */
     gtk_widget_realize(lg->area);
-#if GTK_CHECK_VERSION(3, 0, 0)
-    cairo_content_t content;
-    GdkWindow *gdk_window = gtk_widget_get_window(lg->area);
-    lg->buf = gdk_window_create_similar_surface(gdk_window, CAIRO_CONTENT_COLOR, lg->width, lg->height);
-    lg->grid = cairo_create(lg->buf);
-    lg->trace = cairo_create(lg->buf);
-    lg->fill = cairo_create(lg->buf);
-#else
     lg->buf = gdk_pixmap_new(lg->area->window, lg->width, lg->height, -1);
+
     /* create the graphic contexts */
     lg->grid = gdk_gc_new(GDK_DRAWABLE(lg->buf));
     lg->trace = gdk_gc_new(GDK_DRAWABLE(lg->buf));
     lg->fill = gdk_gc_new(GDK_DRAWABLE(lg->buf));
-#endif
 
     /* the default color is green */
     load_graph_set_color(lg, LG_COLOR_GREEN);
 
     /* init graphic contexts */
-#if GTK_CHECK_VERSION(3, 0, 0)
-    cairo_set_line_width(lg->grid, 1);
-    cairo_set_line_cap(lg->grid, CAIRO_LINE_CAP_BUTT);
-    cairo_set_line_join(lg->grid, CAIRO_LINE_JOIN_MITER);
-    cairo_set_dash(lg->grid, 0, (gint8*)"\2\2", 2);
-#else
     gdk_gc_set_line_attributes(lg->grid,
-               1, GDK_LINE_ON_OFF_DASH,
-               GDK_CAP_NOT_LAST, GDK_JOIN_ROUND);
+                   1, GDK_LINE_ON_OFF_DASH,
+                   GDK_CAP_NOT_LAST, GDK_JOIN_ROUND);
     gdk_gc_set_dashes(lg->grid, 0, (gint8*)"\2\2", 2);
-#endif
 
-#if 0    /* old-style grid */
-    gdk_rgb_gc_set_foreground(lg->grid, 0x707070);
-#endif
-
-#if GTK_CHECK_VERSION(3, 0, 0)
-    cairo_set_line_width(lg->trace, 1);
-    cairo_set_line_cap(lg->trace, CAIRO_LINE_CAP_BUTT);
-    cairo_set_line_join(lg->trace, CAIRO_LINE_JOIN_MITER);
-#else
     gdk_gc_set_line_attributes(lg->trace,
                    1, GDK_LINE_SOLID,
                    GDK_CAP_PROJECTING, GDK_JOIN_ROUND);
-#endif
 
-#if 0 /* old-style fill */
-    gdk_gc_set_line_attributes(lg->fill,
-                   1, GDK_LINE_SOLID,
-                   GDK_CAP_BUTT, GDK_JOIN_BEVEL);
-#endif
-
-#if GTK_CHECK_VERSION(3, 0, 0)
-    /* configures the draw event */
-    g_signal_connect(G_OBJECT(lg->area), "draw",
-        (GCallback) _expose, lg);
-#else
     /* configures the expose event */
     g_signal_connect(G_OBJECT(lg->area), "expose-event",
-        (GCallback) _expose, lg);
-#endif
+             (GCallback) _expose, lg);
 }
-
-#if GTK_CHECK_VERSION(3, 0, 0)
-#define _draw_line(D, CR, X1, Y1, X2, Y2) \
-    cairo_move_to(CR, X1, Y1); \
-    cairo_line_to(CR, X2, Y2);
-#else
-#define _draw_line(D, GC, X1, Y1, X2, Y2) gdk_draw_line(D, GC, X1, Y1, X2, Y2)
-#endif
 
 static void _draw_label_and_line(LoadGraph * lg, gint position, gint value)
 {
     gchar *tmp;
 
     /* draw lines */
-    if (position > 0) {
-        _draw_line(GDK_DRAWABLE(lg->buf), lg->grid, 0, position,
-            lg->width, position);
-    } else
+    if (position > 0)
+        gdk_draw_line(GDK_DRAWABLE(lg->buf), lg->grid, 0, position,
+                  lg->width, position);
+    else
         position = -1 * position;
 
     /* draw label */
     tmp =
-        g_strdup_printf("<span size=\"x-small\">%d%s</span>", value,
+    g_strdup_printf("<span size=\"x-small\">%d%s</span>", value,
             lg->suffix);
 
     pango_layout_set_markup(lg->layout, tmp, -1);
-#if GTK_CHECK_VERSION(3, 0, 0)
     pango_layout_set_width(lg->layout,
-                lg->width * PANGO_SCALE);
-    gtk_widget_create_pango_layout(lg->area, NULL);
-#else
-    pango_layout_set_width(lg->layout,
-                lg->area->allocation.width * PANGO_SCALE);
+               lg->area->allocation.width * PANGO_SCALE);
     gdk_draw_layout(GDK_DRAWABLE(lg->buf), lg->trace, 2, position,
-                lg->layout);
-#endif
+            lg->layout);
 
     g_free(tmp);
 }
 
 static void _draw(LoadGraph * lg)
 {
-#if GTK_CHECK_VERSION(3, 0, 0)
-    void *draw = NULL; /* not used by cairo */
-#else
     GdkDrawable *draw = GDK_DRAWABLE(lg->buf);
-#endif
     gint i, d;
 
     /* clears the drawing area */
-#if GTK_CHECK_VERSION(3, 0, 0)
-    cairo_rectangle(lg->fill, 0, 0, lg->width, lg->height);
-    cairo_fill (lg->fill);
-#else
     gdk_draw_rectangle(draw, lg->area->style->black_gc,
-                TRUE, 0, 0, lg->width, lg->height);
-#endif
+               TRUE, 0, 0, lg->width, lg->height);
 
 
     /* the graph */
@@ -306,48 +226,21 @@ static void _draw(LoadGraph * lg)
     points[0].y = points[i].y = lg->height;
     points[i].x = points[i - 1].x = lg->width;
 
-#if GTK_CHECK_VERSION(3, 0, 0)
-    /* TODO:GTK3 draw using loop and _draw_line() */
-#else
     gdk_draw_polygon(draw, lg->fill, TRUE, points, lg->size + 1);
     gdk_draw_polygon(draw, lg->trace, FALSE, points, lg->size + 1);
-#endif
 
     g_free(points);
 
     /* vertical bars */
     for (i = lg->width, d = 0; i > 1; i--, d++)
-        if ((d % 45) == 0 && d) {
-            _draw_line(draw, lg->grid, i, 0, i, lg->height);
-        }
+        if ((d % 45) == 0 && d)
+            gdk_draw_line(draw, lg->grid, i, 0, i, lg->height);
 
     /* horizontal bars and labels; 25%, 50% and 75% */
     _draw_label_and_line(lg, -1, lg->max_value);
     _draw_label_and_line(lg, lg->height / 4, 3 * (lg->max_value / 4));
     _draw_label_and_line(lg, lg->height / 2, lg->max_value / 2);
     _draw_label_and_line(lg, 3 * (lg->height / 4), lg->max_value / 4);
-
-#if 0  /* old-style drawing */
-    for (i = 0; i < lg->size; i++) {
-        gint this = lg->height - lg->data[i] * lg->scale;
-        gint next = lg->height - lg->data[i + 1] * lg->scale;
-        gint i4 = i * 4;
-
-        _draw_line(draw, lg->fill, i4, this, i4, lg->height);
-        _draw_line(draw, lg->fill, i4 + 2, this, i4 + 2, lg->height);
-    }
-
-    for (i = 0; i < lg->size; i++) {
-        gint this = lg->height - lg->data[i] * lg->scale;
-        gint next = lg->height - lg->data[i + 1] * lg->scale;
-        gint i4 = i * 4;
-
-        _draw_line(draw, lg->trace, i4, this, i4 + 2,
-                  (this + next) / 2);
-        _draw_line(draw, lg->trace, i4 + 2, (this + next) / 2,
-                  i4 + 4, next);
-    }
-#endif
 
     gtk_widget_queue_draw(lg->area);
 }
@@ -359,7 +252,7 @@ void load_graph_update_ex(LoadGraph *lg, guint line, gdouble value)
         load_graph_update(lg, value);
 }
 
-void load_graph_update(LoadGraph *lg, gdouble v)
+void load_graph_update(LoadGraph * lg, gdouble v)
 {
     gint i;
     gint value = (gint)v;
@@ -377,14 +270,14 @@ void load_graph_update(LoadGraph *lg, gdouble v)
 
     /* calculates the maximum value */
     if (lg->remax_count++ > 20) {
-    /* only finds the maximum amongst the data every 20 times */
-    lg->remax_count = 0;
+        /* only finds the maximum amongst the data every 20 times */
+        lg->remax_count = 0;
 
-    gint max = lg->data[0];
-    for (i = 1; i < lg->size; i++) {
-        if (lg->data[i] > max)
-        max = lg->data[i];
-    }
+        gint max = lg->data[0];
+        for (i = 1; i < lg->size; i++) {
+            if (lg->data[i] > max)
+            max = lg->data[i];
+        }
 
         lg->max_value = max;
     } else {
@@ -405,53 +298,3 @@ gint load_graph_get_height(LoadGraph *lg) {
         return lg->height;
     return 0;
 }
-
-
-#ifdef LOADGRAPH_UNIT_TEST
-gboolean lg_update(gpointer d)
-{
-    LoadGraph *lg = (LoadGraph *) d;
-
-    static int i = 0;
-    static int j = 1;
-
-    if (i > 150) {
-        j = -1;
-    } else if (i < 0) {
-        j = 1;
-    }
-
-    i += j;
-    if (rand() % 10 > 8)
-        i *= 2;
-    if (rand() % 10 < 2)
-        i /= 2;
-    load_graph_update(lg, i + rand() % 50);
-
-    return TRUE;
-}
-
-int main(int argc, char **argv)
-{
-    LoadGraph *lg;
-    GtkWidget *window;
-
-    gtk_init(&argc, &argv);
-
-    window = gtk_window_new(GTK_WINDOW_TOPLEVEL);
-    gtk_widget_show(window);
-
-    lg = load_graph_new(50);
-    gtk_container_add(GTK_CONTAINER(window), load_graph_get_framed(lg));
-    gtk_container_set_border_width(GTK_CONTAINER(window), 20);
-    load_graph_configure_expose(lg);
-
-    lg_update(lg);
-
-    g_timeout_add(100, lg_update, lg);
-
-    gtk_main();
-
-    return 0;
-}
-#endif

--- a/shell/menu.c
+++ b/shell/menu.c
@@ -53,16 +53,11 @@ static GtkActionEntry entries[] = {
      N_("_Open..."), NULL,
      NULL,
      G_CALLBACK(cb_sync_manager)},
-     
+
     {"CopyAction", GTK_STOCK_COPY,
      N_("_Copy to Clipboard"), "<control>C",
      N_("Copy to clipboard"),
      G_CALLBACK(cb_copy_to_clipboard)},
-
-    {"SaveGraphAction", GTK_STOCK_SAVE_AS,
-     N_("_Save image as..."), "<control>S",
-     NULL,
-     G_CALLBACK(cb_save_graphic)},
 
     {"RefreshAction", GTK_STOCK_REFRESH,
      N_("_Refresh"), "F5",
@@ -130,15 +125,15 @@ void menu_init(Shell * shell)
     /* Pack up our objects:
      * menu_box -> window
      * actions -> action_group
-     * action_group -> menu_manager */  
-    gtk_action_group_set_translation_domain( action_group, "hardinfo" );//gettext 
+     * action_group -> menu_manager */
+    gtk_action_group_set_translation_domain( action_group, "hardinfo" );//gettext
     gtk_action_group_add_actions(action_group, entries,
 				 G_N_ELEMENTS(entries), NULL);
     gtk_action_group_add_toggle_actions(action_group, toggle_entries,
 					G_N_ELEMENTS(toggle_entries),
 					NULL);
     gtk_ui_manager_insert_action_group(menu_manager, action_group, 0);
-    
+
 
     /* Read in the UI from our XML file */
     error = NULL;

--- a/shell/shell.c
+++ b/shell/shell.c
@@ -33,10 +33,6 @@
 
 #include "callbacks.h"
 
-#ifndef gtk_notebook_set_page
-#define gtk_notebook_set_page(P, N) gtk_notebook_set_current_page(P, N)
-#endif
-
 /*
  * Internal Prototypes ********************************************************
  */
@@ -1007,7 +1003,7 @@ static void set_view_type(ShellViewType viewtype, gboolean reload)
     case SHELL_VIEW_DUAL:
         gtk_widget_show(shell->info->scroll);
         gtk_widget_show(shell->moreinfo->scroll);
-        gtk_notebook_set_page(GTK_NOTEBOOK(shell->notebook), 0);
+        gtk_notebook_set_current_page(GTK_NOTEBOOK(shell->notebook), 0);
         gtk_widget_show(shell->notebook);
 
 #if GTK_CHECK_VERSION(3, 0, 0)
@@ -1022,7 +1018,7 @@ static void set_view_type(ShellViewType viewtype, gboolean reload)
         break;
     case SHELL_VIEW_LOAD_GRAPH:
         gtk_widget_show(shell->info->scroll);
-        gtk_notebook_set_page(GTK_NOTEBOOK(shell->notebook), 1);
+        gtk_notebook_set_current_page(GTK_NOTEBOOK(shell->notebook), 1);
         gtk_widget_show(shell->notebook);
         load_graph_clear(shell->loadgraph);
 
@@ -1043,7 +1039,7 @@ static void set_view_type(ShellViewType viewtype, gboolean reload)
 	gtk_widget_show(shell->notebook);
         gtk_widget_show(shell->moreinfo->scroll);
 
-	gtk_notebook_set_page(GTK_NOTEBOOK(shell->notebook), 0);
+	gtk_notebook_set_current_page(GTK_NOTEBOOK(shell->notebook), 0);
 	/* fallthrough */
     case SHELL_VIEW_PROGRESS:
         gtk_widget_show(shell->info->scroll);
@@ -1058,7 +1054,7 @@ static void set_view_type(ShellViewType viewtype, gboolean reload)
 		gtk_widget_hide(shell->notebook);
 	break;
     case SHELL_VIEW_SUMMARY:
-        gtk_notebook_set_page(GTK_NOTEBOOK(shell->notebook), 2);
+        gtk_notebook_set_current_page(GTK_NOTEBOOK(shell->notebook), 2);
 
         gtk_widget_show(shell->notebook);
         gtk_widget_hide(shell->info->scroll);

--- a/shell/shell.c
+++ b/shell/shell.c
@@ -284,9 +284,7 @@ void shell_view_set_enabled(gboolean setting)
     shell_action_set_enabled("CopyAction", setting);
     shell_action_set_enabled("ReportAction", setting);
     shell_action_set_enabled("SyncManagerAction", setting && sync_manager_count_entries() > 0);
-    shell_action_set_enabled("SaveGraphAction",
-			     setting ? shell->view_type ==
-			     SHELL_VIEW_PROGRESS : FALSE);
+
 }
 
 void shell_status_set_enabled(gboolean setting)
@@ -764,7 +762,6 @@ void shell_init(GSList * modules)
 
     shell_action_set_enabled("RefreshAction", FALSE);
     shell_action_set_enabled("CopyAction", FALSE);
-    shell_action_set_enabled("SaveGraphAction", FALSE);
     shell_action_set_active("SidePaneAction", TRUE);
     shell_action_set_active("ToolbarAction", TRUE);
 
@@ -985,9 +982,6 @@ static void set_view_type(ShellViewType viewtype, gboolean reload)
     /* turn off the rules hint */
     gtk_tree_view_set_rules_hint(GTK_TREE_VIEW(shell->info->view), FALSE);
 
-    /* turn off the save graphic action */
-    shell_action_set_enabled("SaveGraphAction", FALSE);
-
     close_note(NULL, NULL);
 
     switch (viewtype) {
@@ -1043,7 +1037,6 @@ static void set_view_type(ShellViewType viewtype, gboolean reload)
 	/* fallthrough */
     case SHELL_VIEW_PROGRESS:
         gtk_widget_show(shell->info->scroll);
-	shell_action_set_enabled("SaveGraphAction", TRUE);
 
 	if (!reload) {
   	  gtk_tree_view_column_set_visible(shell->info->col_progress, TRUE);

--- a/shell/shell.c
+++ b/shell/shell.c
@@ -843,7 +843,7 @@ static gboolean update_field(gpointer data)
 static gboolean reload_section(gpointer data)
 {
     ShellModuleEntry *entry = (ShellModuleEntry *) data;
-#if GTK_CHECK_VERSION(3, 0, 0)
+#if GTK_CHECK_VERSION(2, 14, 0)
     GdkWindow *gdk_window = gtk_widget_get_window(GTK_WIDGET(shell->window));
 #endif
 
@@ -864,7 +864,7 @@ static gboolean reload_section(gpointer data)
 #endif
 
 	/* avoid drawing the window while we reload */
-#if GTK_CHECK_VERSION(3, 0, 0)
+#if GTK_CHECK_VERSION(2, 14, 0)
     gdk_window_freeze_updates(gdk_window);
 #else
 	gdk_window_freeze_updates(shell->window->window);
@@ -898,7 +898,7 @@ static gboolean reload_section(gpointer data)
         }
 
 	/* make the window drawable again */
-#if GTK_CHECK_VERSION(3, 0, 0)
+#if GTK_CHECK_VERSION(2, 14, 0)
     gdk_window_thaw_updates(gdk_window);
 #else
 	gdk_window_thaw_updates(shell->window->window);
@@ -954,7 +954,7 @@ info_tree_compare_val_func(GtkTreeModel * model,
 
 static void set_view_type(ShellViewType viewtype, gboolean reload)
 {
-#if GTK_CHECK_VERSION(3, 0, 0)
+#if GTK_CHECK_VERSION(2, 18, 0)
     GtkAllocation* alloc;
 #endif
 
@@ -1006,7 +1006,7 @@ static void set_view_type(ShellViewType viewtype, gboolean reload)
         gtk_notebook_set_current_page(GTK_NOTEBOOK(shell->notebook), 0);
         gtk_widget_show(shell->notebook);
 
-#if GTK_CHECK_VERSION(3, 0, 0)
+#if GTK_CHECK_VERSION(2, 18, 0)
         alloc = g_new(GtkAllocation, 1);
         gtk_widget_get_allocation(shell->hpaned, alloc);
         gtk_paned_set_position(GTK_PANED(shell->vpaned), alloc->height / 2);
@@ -1022,7 +1022,7 @@ static void set_view_type(ShellViewType viewtype, gboolean reload)
         gtk_widget_show(shell->notebook);
         load_graph_clear(shell->loadgraph);
 
-#if GTK_CHECK_VERSION(3, 0, 0)
+#if GTK_CHECK_VERSION(2, 18, 0)
         alloc = g_new(GtkAllocation, 1);
         gtk_widget_get_allocation(shell->hpaned, alloc);
         gtk_paned_set_position(GTK_PANED(shell->vpaned),
@@ -1407,7 +1407,7 @@ module_selected_show_info(ShellModuleEntry * entry, gboolean reload)
     gboolean has_shell_param = FALSE;
     gint i;
     gsize ngroups;
-#if GTK_CHECK_VERSION(3, 0, 0)
+#if GTK_CHECK_VERSION(2, 14, 0)
     GdkWindow *gdk_window = gtk_widget_get_window(GTK_WIDGET(shell->info->view));
 #endif
 
@@ -1415,7 +1415,7 @@ module_selected_show_info(ShellModuleEntry * entry, gboolean reload)
     key_data = module_entry_function(entry);
 
     /* */
-#if GTK_CHECK_VERSION(3, 0, 0)
+#if GTK_CHECK_VERSION(2, 14, 0)
 	gdk_window_freeze_updates(gdk_window);
 #else
     gdk_window_freeze_updates(shell->info->view->window);
@@ -1470,7 +1470,7 @@ module_selected_show_info(ShellModuleEntry * entry, gboolean reload)
     gtk_tree_view_set_model(GTK_TREE_VIEW(shell->info->view), shell->info->model);
     gtk_tree_view_expand_all(GTK_TREE_VIEW(shell->info->view));
 
-#if GTK_CHECK_VERSION(3, 0, 0)
+#if GTK_CHECK_VERSION(2, 14, 0)
 	gdk_window_thaw_updates(gdk_window);
 #else
     gdk_window_thaw_updates(shell->info->view->window);

--- a/shell/shell.c
+++ b/shell/shell.c
@@ -854,10 +854,8 @@ static gboolean reload_section(gpointer data)
 #if GTK_CHECK_VERSION(3, 0, 0)
     /* TODO:GTK3 */
 #else
-#if GTK_CHECK_VERSION(2, 0, 0)
 	pos_info_scroll = RANGE_GET_VALUE(info, vscrollbar);
 	pos_more_scroll = RANGE_GET_VALUE(moreinfo, vscrollbar);
-#endif
 #endif
 
 	/* avoid drawing the window while we reload */

--- a/test/ws_scan.sh
+++ b/test/ws_scan.sh
@@ -6,6 +6,6 @@
 cd ..
 grep -lHIrP --include=*.{h,c} -- '^((\t+ +)|( +\t+)|\s+$)' | sed 's/^/- [ ] /' > test/hardinfo-bad.txt
 grep -LHIrP --include=*.{h,c} -- '^((\t+ +)|( +\t+)|\s+$)' | sed 's/^/- [x] /' > test/hardinfo-good.txt
-cat test/hardinfo-bad.txt test/hardinfo-good.txt | LC_ALL=C sort -k 1.5 | grep -vP " (test|build)"
+cat test/hardinfo-bad.txt test/hardinfo-good.txt | LC_ALL=C sort -k 1.5 | grep -vP " (test|build|deps)"
 rm test/hardinfo-bad.txt test/hardinfo-good.txt
 cd test


### PR DESCRIPTION
Changes based on recent merges and discussions.

* GTK_CHECK_VERSION()-related: shows some code that doesn't need gtk3. If moving up to 2.18 as a requirement (#118), these and all existing conditional code segments for 2.x could be removed. 
* loadgraph gtk2 only, doesn't need conditionals for gtk3.
* Some recent changes to comptuer/os.c caused some compiler warnings.
* Removing tree_view_save_image(), a feature that was "never finished" (https://github.com/lpereira/hardinfo/pull/114#discussion_r129861059)
* The fix to network statistics is just something that was waiting to be in a PR somewhere.