### PR TITLE
Call setlocale() to clear the default "C" locale for CLI

### DIFF
--- a/hardinfo/hardinfo.c
+++ b/hardinfo/hardinfo.c
@@ -33,6 +33,7 @@ int main(int argc, char **argv)
 {
     GSList *modules;
 
+    setlocale(LC_ALL, "");
     bindtextdomain("hardinfo", LOCALEDIR);
     textdomain("hardinfo");
 


### PR DESCRIPTION
Fixes strings not being translated in the CLI.
See: https://github.com/lpereira/hardinfo/issues/105#issuecomment-319002090