### PR TITLE
hardinfo CLI translation fixes

### DIFF
--- a/hardinfo/hardinfo.c
+++ b/hardinfo/hardinfo.c
@@ -44,9 +44,9 @@ int main(int argc, char **argv)
 
     /* show version information and quit */
     if (params.show_version) {
-	g_print("HardInfo version " VERSION "\n");
-	g_print
-	    (_("Copyright (C) 2003-2009 Leandro A. F. Pereira. See COPYING for details.\n\n"));
+        g_print("HardInfo version " VERSION "\n");
+        g_print
+            (_(/*/ %d will be latest year of copyright*/ "Copyright (C) 2003-%d Leandro A. F. Pereira. See COPYING for details.\n\n"), 2017);
 
 	g_print(_("Compile-time options:\n"
 		"  Release version:   %s (%s)\n"
@@ -74,7 +74,7 @@ int main(int argc, char **argv)
     /* list all module names */
     if (params.list_modules) {
 	g_print(_("Modules:\n"
-		"%-20s%-15s%-12s\n"), _("File Name"), _("Name"), _("Version"));
+		"%-20s %-15s %-12s\n"), _("File Name"), _("Name"), _("Version"));
 
 	for (modules = modules_load_all(); modules;
 	     modules = modules->next) {
@@ -82,7 +82,7 @@ int main(int argc, char **argv)
 	    ModuleAbout *ma = module_get_about(module);
 	    gchar *name = g_path_get_basename(g_module_name(module->dll));
 
-	    g_print("%-20s%-15s%-12s\n", name, module->name, ma->version);
+	    g_print("%-20s %-15s %-12s\n", name, module->name, ma->version);
 
 	    g_free(name);
 	}

--- a/hardinfo/hardinfo.c
+++ b/hardinfo/hardinfo.c
@@ -46,7 +46,7 @@ int main(int argc, char **argv)
     if (params.show_version) {
         g_print("HardInfo version " VERSION "\n");
         g_print
-            (_(/*/ %d will be latest year of copyright*/ "Copyright (C) 2003-%d Leandro A. F. Pereira. See COPYING for details.\n\n"), 2017);
+            (_(/*/ %d will be latest year of copyright*/ "Copyright (C) 2003-%d Leandro A. F. Pereira. See COPYING for details.\n\n"), HARDINFO_COPYRIGHT_LATEST_YEAR );
 
 	g_print(_("Compile-time options:\n"
 		"  Release version:   %s (%s)\n"

--- a/includes/hardinfo.h
+++ b/includes/hardinfo.h
@@ -25,6 +25,8 @@
 #include "vendor.h"
 #include "gettext.h"
 
+#define HARDINFO_COPYRIGHT_LATEST_YEAR 2017
+
 #ifndef LOCALEDIR
 #define LOCALEDIR "/usr/share/locale"
 #endif

--- a/po/de.po
+++ b/po/de.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-07-30 05:41-0500\n"
+"POT-Creation-Date: 2017-08-01 01:16-0500\n"
 "PO-Revision-Date: 2016-06-10 12:11+0200\n"
 "Last-Translator: Alexander Münch <git@thehacker.biz>\n"
 "Language-Team: German\n"
@@ -20,13 +20,15 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 1.8.7.1\n"
 
-#: hardinfo/hardinfo.c:48
+#. / %d will be latest year of copyright
+#: hardinfo/hardinfo.c:49
+#, c-format
 msgid ""
-"Copyright (C) 2003-2009 Leandro A. F. Pereira. See COPYING for details.\n"
+"Copyright (C) 2003-%d Leandro A. F. Pereira. See COPYING for details.\n"
 "\n"
 msgstr ""
 
-#: hardinfo/hardinfo.c:50
+#: hardinfo/hardinfo.c:51
 #, c-format
 msgid ""
 "Compile-time options:\n"
@@ -37,16 +39,16 @@ msgid ""
 "  Compiled for:      %s\n"
 msgstr ""
 
-#: hardinfo/hardinfo.c:56 hardinfo/hardinfo.c:57 modules/computer.c:565
+#: hardinfo/hardinfo.c:57 hardinfo/hardinfo.c:58 modules/computer.c:565
 #: modules/devices/printers.c:138
 msgid "Yes"
 msgstr "Ja"
 
-#: hardinfo/hardinfo.c:57 modules/computer.c:565 modules/devices/printers.c:138
+#: hardinfo/hardinfo.c:58 modules/computer.c:565 modules/devices/printers.c:138
 msgid "No"
 msgstr "Nein"
 
-#: hardinfo/hardinfo.c:68
+#: hardinfo/hardinfo.c:69
 #, c-format
 msgid ""
 "Failed to find runtime data.\n"
@@ -55,34 +57,34 @@ msgid ""
 "• See if %s and %s exists and you have read permission."
 msgstr ""
 
-#: hardinfo/hardinfo.c:75
+#: hardinfo/hardinfo.c:76
 #, c-format
 msgid ""
 "Modules:\n"
-"%-20s%-15s%-12s\n"
+"%-20s %-15s %-12s\n"
 msgstr ""
 
-#: hardinfo/hardinfo.c:76
+#: hardinfo/hardinfo.c:77
 msgid "File Name"
 msgstr ""
 
-#: hardinfo/hardinfo.c:76 modules/computer.c:493 modules/computer.c:515
+#: hardinfo/hardinfo.c:77 modules/computer.c:493 modules/computer.c:515
 #: modules/computer.c:586 modules/devices/ia64/processor.c:152
 #: modules/devices/sh/processor.c:76 modules/network.c:331
 msgid "Name"
 msgstr "Name"
 
-#: hardinfo/hardinfo.c:76 modules/computer.c:291 modules/computer.c:466
+#: hardinfo/hardinfo.c:77 modules/computer.c:291 modules/computer.c:466
 #: modules/computer.c:468 modules/computer.c:556 modules/computer.c:564
 msgid "Version"
 msgstr ""
 
-#: hardinfo/hardinfo.c:123
+#: hardinfo/hardinfo.c:124
 #, c-format
 msgid "Unknown benchmark ``%s'' or libbenchmark.so not loaded"
 msgstr ""
 
-#: hardinfo/hardinfo.c:151
+#: hardinfo/hardinfo.c:152
 msgid "Don't know what to do. Exiting."
 msgstr ""
 
@@ -144,112 +146,112 @@ msgstr "%.1f TiB"
 msgid "%.1f PiB"
 msgstr "%.1f PiB"
 
-#: hardinfo/util.c:352
+#: hardinfo/util.c:367
 msgid "Error"
 msgstr "Fehler"
 
-#: hardinfo/util.c:352 hardinfo/util.c:368
+#: hardinfo/util.c:367 hardinfo/util.c:383
 msgid "Warning"
 msgstr "Warnung"
 
-#: hardinfo/util.c:367
+#: hardinfo/util.c:382
 msgid "Fatal Error"
 msgstr "Kritischer Fehler"
 
-#: hardinfo/util.c:392
+#: hardinfo/util.c:407
 msgid "creates a report and prints to standard output"
 msgstr ""
 
-#: hardinfo/util.c:398
+#: hardinfo/util.c:413
 msgid "chooses a report format (text, html)"
 msgstr ""
 
-#: hardinfo/util.c:404
+#: hardinfo/util.c:419
 msgid "run benchmark; requires benchmark.so to be loaded"
 msgstr ""
 
-#: hardinfo/util.c:410
+#: hardinfo/util.c:425
 msgid "lists modules"
 msgstr ""
 
-#: hardinfo/util.c:416
+#: hardinfo/util.c:431
 msgid "specify module to load"
 msgstr ""
 
-#: hardinfo/util.c:422
+#: hardinfo/util.c:437
 msgid "automatically load module dependencies"
 msgstr ""
 
-#: hardinfo/util.c:429
+#: hardinfo/util.c:444
 msgid "run in XML-RPC server mode"
 msgstr ""
 
-#: hardinfo/util.c:436
+#: hardinfo/util.c:451
 msgid "shows program version and quit"
 msgstr ""
 
-#: hardinfo/util.c:441
+#: hardinfo/util.c:456
 msgid "- System Profiler and Benchmark tool"
 msgstr "- System-Profiler und Benchmark-Werkzeug"
 
-#: hardinfo/util.c:451
+#: hardinfo/util.c:466
 #, c-format
 msgid ""
 "Unrecognized arguments.\n"
 "Try ``%s --help'' for more information.\n"
 msgstr ""
 
-#: hardinfo/util.c:517
+#: hardinfo/util.c:532
 #, c-format
 msgid "Couldn't find a Web browser to open URL %s."
 msgstr "Konnte keinen Web-Browser finden, um die URL %s zu öffnen."
 
-#: hardinfo/util.c:866
+#: hardinfo/util.c:881
 #, c-format
 msgid "Module \"%s\" depends on module \"%s\", load it?"
 msgstr ""
 
-#: hardinfo/util.c:889
+#: hardinfo/util.c:904
 #, c-format
 msgid "Module \"%s\" depends on module \"%s\"."
 msgstr ""
 
-#: hardinfo/util.c:934
+#: hardinfo/util.c:949
 #, c-format
 msgid "No module could be loaded. Check permissions on \"%s\" and try again."
 msgstr ""
 
-#: hardinfo/util.c:938
+#: hardinfo/util.c:953
 msgid ""
 "No module could be loaded. Please use hardinfo -l to list all available "
 "modules and try again with a valid module list."
 msgstr ""
 
-#: hardinfo/util.c:1114
+#: hardinfo/util.c:1133
 #, c-format
 msgid "Scanning: %s..."
 msgstr ""
 
-#: hardinfo/util.c:1124 shell/callbacks.c:67 shell/shell.c:303
-#: shell/shell.c:721 shell/shell.c:1701 modules/benchmark.c:445
+#: hardinfo/util.c:1143 shell/callbacks.c:77 shell/shell.c:307
+#: shell/shell.c:766 shell/shell.c:1808 modules/benchmark.c:445
 #: modules/benchmark.c:453
 msgid "Done."
 msgstr "Fertig."
 
-#: shell/callbacks.c:47
+#: shell/callbacks.c:48 shell/callbacks.c:56
 msgid "Save Image"
 msgstr ""
 
-#: shell/callbacks.c:63
+#: shell/callbacks.c:73
 msgid "Saving image..."
 msgstr ""
 
-#: shell/callbacks.c:153
+#: shell/callbacks.c:163
 #, c-format
 msgid "%s Module"
 msgstr ""
 
-#: shell/callbacks.c:160
+#: shell/callbacks.c:174
 #, c-format
 msgid ""
 "Written by %s\n"
@@ -258,80 +260,80 @@ msgstr ""
 "Programmiert von %s\n"
 "Lizenziert unter %s"
 
-#: shell/callbacks.c:174
+#: shell/callbacks.c:188
 #, c-format
 msgid "No about information is associated with the %s module."
 msgstr ""
 
-#: shell/callbacks.c:189
+#: shell/callbacks.c:203
 msgid "Author:"
 msgstr ""
 
-#: shell/callbacks.c:192
+#: shell/callbacks.c:206
 msgid "Contributors:"
 msgstr "Mitwirkende:"
 
-#: shell/callbacks.c:196
+#: shell/callbacks.c:210
 msgid "Based on work by:"
 msgstr ""
 
-#: shell/callbacks.c:197
+#: shell/callbacks.c:211
 msgid "MD5 implementation by Colin Plumb (see md5.c for details)"
 msgstr ""
 
-#: shell/callbacks.c:198
+#: shell/callbacks.c:212
 msgid "SHA1 implementation by Steve Reid (see sha1.c for details)"
 msgstr ""
 
-#: shell/callbacks.c:199
+#: shell/callbacks.c:213
 msgid "Blowfish implementation by Paul Kocher (see blowfich.c for details)"
 msgstr ""
 
-#: shell/callbacks.c:200
+#: shell/callbacks.c:214
 msgid "Raytracing benchmark by John Walker (see fbench.c for details)"
 msgstr ""
 
-#: shell/callbacks.c:201
+#: shell/callbacks.c:215
 msgid "FFT benchmark by Scott Robert Ladd (see fftbench.c for details)"
 msgstr ""
 
-#: shell/callbacks.c:202
+#: shell/callbacks.c:216
 msgid "Some code partly based on x86cpucaps by Osamu Kayasono"
 msgstr ""
 
-#: shell/callbacks.c:203
+#: shell/callbacks.c:217
 msgid "Vendor list based on GtkSysInfo by Pissens Sebastien"
 msgstr ""
 
-#: shell/callbacks.c:204
+#: shell/callbacks.c:218
 msgid "DMI support based on code by Stewart Adam"
 msgstr ""
 
-#: shell/callbacks.c:205
+#: shell/callbacks.c:219
 msgid "SCSI support based on code by Pascal F. Martin"
 msgstr ""
 
-#: shell/callbacks.c:209
+#: shell/callbacks.c:223
 msgid "Jakub Szypulka"
 msgstr "Jakub Szypulka"
 
-#: shell/callbacks.c:210
+#: shell/callbacks.c:224
 msgid "Tango Project"
 msgstr ""
 
-#: shell/callbacks.c:211
+#: shell/callbacks.c:225
 msgid "The GNOME Project"
 msgstr ""
 
-#: shell/callbacks.c:212
+#: shell/callbacks.c:226
 msgid "VMWare, Inc. (USB icon from VMWare Workstation 6)"
 msgstr ""
 
-#: shell/callbacks.c:224
+#: shell/callbacks.c:244
 msgid "System information and benchmark tool"
 msgstr "System-Informationen und Benchmark-Werkzeug"
 
-#: shell/callbacks.c:229
+#: shell/callbacks.c:249
 msgid ""
 "HardInfo is free software; you can redistribute it and/or modify it under "
 "the terms of the GNU General Public License as published by the Free "
@@ -427,35 +429,35 @@ msgstr ""
 msgid "_Toolbar"
 msgstr "_Symbolleiste"
 
-#: shell/report.c:493
+#: shell/report.c:494 shell/report.c:502
 msgid "Save File"
 msgstr "Datei speichern"
 
-#: shell/report.c:619
+#: shell/report.c:629
 msgid "Cannot create ReportContext. Programming bug?"
 msgstr ""
 
-#: shell/report.c:638
+#: shell/report.c:648
 msgid "Open the report with your web browser?"
 msgstr "Den Bericht in deinem Webbrowser öffnen?"
 
-#: shell/report.c:666
+#: shell/report.c:682
 msgid "Generating report..."
 msgstr "Generiere Bericht…"
 
-#: shell/report.c:676
+#: shell/report.c:692
 msgid "Report saved."
 msgstr "Bericht gespeichert."
 
-#: shell/report.c:678
+#: shell/report.c:694
 msgid "Error while creating the report."
 msgstr "Fehler beim Erzeugen des Berichts."
 
-#: shell/report.c:780
+#: shell/report.c:796
 msgid "Generate Report"
 msgstr "Bericht generieren"
 
-#: shell/report.c:797
+#: shell/report.c:821
 msgid ""
 "<big><b>Generate Report</b></big>\n"
 "Please choose the information that you wish to view in your report:"
@@ -463,37 +465,41 @@ msgstr ""
 "<big><b>Bericht generieren</b></big>\n"
 "Bitte wähle die Informationen, die du in deinen Bereich einbeziehen möchtest:"
 
-#: shell/report.c:857
+#: shell/report.c:893
 msgid "Select _None"
 msgstr "_Nichts auswählen"
 
-#: shell/report.c:864
+#: shell/report.c:904
 msgid "Select _All"
 msgstr "_Alles auswählen"
 
-#: shell/report.c:882
+#: shell/report.c:930
+msgid "_Cancel"
+msgstr ""
+
+#: shell/report.c:943
 msgid "_Generate"
 msgstr "_Generieren"
 
-#: shell/shell.c:396
+#: shell/shell.c:408
 #, c-format
 msgid "%s - System Information"
 msgstr "%s - System-Informationen"
 
-#: shell/shell.c:401
+#: shell/shell.c:413
 msgid "System Information"
 msgstr "System-Informationen"
 
-#: shell/shell.c:708
+#: shell/shell.c:753
 msgid "Loading modules..."
 msgstr ""
 
-#: shell/shell.c:1571
+#: shell/shell.c:1673
 #, c-format
 msgid "<b>%s → Summary</b>"
 msgstr "<b>%s → Zusammenfassung</b>"
 
-#: shell/shell.c:1679
+#: shell/shell.c:1782
 msgid "Updating..."
 msgstr "Aktualisiere…"
 

--- a/po/de.po
+++ b/po/de.po
@@ -92,15 +92,15 @@ msgstr ""
 #, c-format
 msgid "%d day"
 msgid_plural "%d days"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "%d Tag"
+msgstr[1] "%d Tage"
 
 #: hardinfo/util.c:105 modules/computer/uptime.c:54
 #, c-format
 msgid "%d hour"
 msgid_plural "%d hours"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "%d Stunde"
+msgstr[1] "%d Stunden"
 
 #: hardinfo/util.c:106 modules/computer/uptime.c:55
 #, c-format
@@ -113,8 +113,8 @@ msgstr[1] "%d Minuten"
 #, c-format
 msgid "%d second"
 msgid_plural "%d seconds"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "%d Sekunde"
+msgstr[1] "%d Sekunden"
 
 #: hardinfo/util.c:128
 #, c-format
@@ -4040,21 +4040,6 @@ msgstr ""
 
 #~ msgid "Y_es"
 #~ msgstr "_Ja"
-
-#~ msgid "%d day, "
-#~ msgid_plural "%d days, "
-#~ msgstr[0] "%d Tag, "
-#~ msgstr[1] "%d Tage, "
-
-#~ msgid "%d hour, "
-#~ msgid_plural "%d hours, "
-#~ msgstr[0] "%d Stunde, "
-#~ msgstr[1] "%d Stunden, "
-
-#~ msgid "%d hour and "
-#~ msgid_plural "%d hours and "
-#~ msgstr[0] "%d Stunde und "
-#~ msgstr[1] "%d Stunden und "
 
 #~ msgid "Contents"
 #~ msgstr "Inhalt"

--- a/po/es.po
+++ b/po/es.po
@@ -104,15 +104,15 @@ msgstr "No se puede determinar que hacer. Saliendo."
 #, c-format
 msgid "%d day"
 msgid_plural "%d days"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "%d día"
+msgstr[1] "%d días"
 
 #: hardinfo/util.c:105 modules/computer/uptime.c:54
 #, c-format
 msgid "%d hour"
 msgid_plural "%d hours"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "%d hora"
+msgstr[1] "%d horas"
 
 #: hardinfo/util.c:106 modules/computer/uptime.c:55
 #, c-format
@@ -125,8 +125,8 @@ msgstr[1] "%d minutos"
 #, c-format
 msgid "%d second"
 msgid_plural "%d seconds"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "%d segundo"
+msgstr[1] "%d segundos"
 
 #: hardinfo/util.c:128
 #, c-format
@@ -4071,13 +4071,6 @@ msgstr ""
 msgid "Broadcast Address"
 msgstr ""
 
-#~ msgid ""
-#~ "Modules:\n"
-#~ "%-20s%-15s%-12s\n"
-#~ msgstr ""
-#~ "Módulos:\n"
-#~ "%-20s%-15s%-12s\n"
-
 #~ msgid "Y_es"
 #~ msgstr "_Sí"
 
@@ -4086,16 +4079,6 @@ msgstr ""
 
 #~ msgid "Unknown distribution"
 #~ msgstr "Distribución desconocida"
-
-#~ msgid "%d day, "
-#~ msgid_plural "%d days, "
-#~ msgstr[0] "%d día, "
-#~ msgstr[1] "%d días, "
-
-#~ msgid "%d hour, "
-#~ msgid_plural "%d hours, "
-#~ msgstr[0] "%d hora, "
-#~ msgstr[1] "%d horas, "
 
 #~ msgid "_Connect to..."
 #~ msgstr "_Conectar a..."
@@ -4141,8 +4124,3 @@ msgstr ""
 
 #~ msgid "XFree86 version"
 #~ msgstr "Versión de XFree86"
-
-#~ msgid "%d hour and "
-#~ msgid_plural "%d hours and "
-#~ msgstr[0] "%d hora y "
-#~ msgstr[1] "%d horas y "

--- a/po/es.po
+++ b/po/es.po
@@ -7,26 +7,28 @@ msgid ""
 msgstr ""
 "Project-Id-Version: hardinfo\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-07-30 05:41-0500\n"
+"POT-Creation-Date: 2017-08-01 01:16-0500\n"
 "PO-Revision-Date: 2013-02-18 17:11-0300\n"
 "Last-Translator: Fernando López <flopez@linti.unlp.edu.ar>\n"
 "Language-Team: Fernando López <soportelihuen@linti.unlp.edu.ar>\n"
 "Language: es\n"
+"X-Poedit-Basepath: ../\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Poedit-Language: Spanish\n"
 
-#: hardinfo/hardinfo.c:48
+#. / %d will be latest year of copyright
+#: hardinfo/hardinfo.c:49
+#, c-format
 msgid ""
-"Copyright (C) 2003-2009 Leandro A. F. Pereira. See COPYING for details.\n"
+"Copyright (C) 2003-%d Leandro A. F. Pereira. See COPYING for details.\n"
 "\n"
 msgstr ""
-"Copyright (C) 2003-2009 Leandro A. F. Pereira. Vea COPYING para más "
-"detalles.\n"
+"Copyright (C) 2003-%d Leandro A. F. Pereira. Vea COPYING para más detalles.\n"
 "\n"
 
-#: hardinfo/hardinfo.c:50
+#: hardinfo/hardinfo.c:51
 #, c-format
 msgid ""
 "Compile-time options:\n"
@@ -36,17 +38,23 @@ msgid ""
 "  Library prefix:    %s\n"
 "  Compiled for:      %s\n"
 msgstr ""
+"Opciones de compilado:\n"
+"  \"Release\" versión:      %s (%s)\n"
+"  BinReloc habilitado:    %s\n"
+"  Prefijo de datos:       %s\n"
+"  Prefijo de bibliotecas: %s\n"
+"  Compilado en:           %s\n"
 
-#: hardinfo/hardinfo.c:56 hardinfo/hardinfo.c:57 modules/computer.c:565
+#: hardinfo/hardinfo.c:57 hardinfo/hardinfo.c:58 modules/computer.c:565
 #: modules/devices/printers.c:138
 msgid "Yes"
 msgstr "Sí"
 
-#: hardinfo/hardinfo.c:57 modules/computer.c:565 modules/devices/printers.c:138
+#: hardinfo/hardinfo.c:58 modules/computer.c:565 modules/devices/printers.c:138
 msgid "No"
 msgstr "_No"
 
-#: hardinfo/hardinfo.c:68
+#: hardinfo/hardinfo.c:69
 #, c-format
 msgid ""
 "Failed to find runtime data.\n"
@@ -59,36 +67,36 @@ msgstr ""
 "• ¿HardInfo está correctamente instalado?\n"
 "• Vea si %s y %s existen y usted tiene permisos de lectura."
 
-#: hardinfo/hardinfo.c:75
+#: hardinfo/hardinfo.c:76
 #, c-format
 msgid ""
 "Modules:\n"
-"%-20s%-15s%-12s\n"
+"%-20s %-15s %-12s\n"
 msgstr ""
 "Módulos:\n"
-"%-20s%-15s%-12s\n"
+"%-20s %-15s %-12s\n"
 
-#: hardinfo/hardinfo.c:76
+#: hardinfo/hardinfo.c:77
 msgid "File Name"
 msgstr "Nombre de archivo"
 
-#: hardinfo/hardinfo.c:76 modules/computer.c:493 modules/computer.c:515
+#: hardinfo/hardinfo.c:77 modules/computer.c:493 modules/computer.c:515
 #: modules/computer.c:586 modules/devices/ia64/processor.c:152
 #: modules/devices/sh/processor.c:76 modules/network.c:331
 msgid "Name"
 msgstr "Nombre"
 
-#: hardinfo/hardinfo.c:76 modules/computer.c:291 modules/computer.c:466
+#: hardinfo/hardinfo.c:77 modules/computer.c:291 modules/computer.c:466
 #: modules/computer.c:468 modules/computer.c:556 modules/computer.c:564
 msgid "Version"
 msgstr "Versión"
 
-#: hardinfo/hardinfo.c:123
+#: hardinfo/hardinfo.c:124
 #, c-format
 msgid "Unknown benchmark ``%s'' or libbenchmark.so not loaded"
 msgstr "Benchmark desconocido ``%s'' o no se cargó libbenchmark.so"
 
-#: hardinfo/hardinfo.c:151
+#: hardinfo/hardinfo.c:152
 msgid "Don't know what to do. Exiting."
 msgstr "No se puede determinar que hacer. Saliendo."
 
@@ -150,55 +158,55 @@ msgstr ""
 msgid "%.1f PiB"
 msgstr ""
 
-#: hardinfo/util.c:352
+#: hardinfo/util.c:367
 msgid "Error"
 msgstr "Error"
 
-#: hardinfo/util.c:352 hardinfo/util.c:368
+#: hardinfo/util.c:367 hardinfo/util.c:383
 msgid "Warning"
 msgstr "Advertencia"
 
-#: hardinfo/util.c:367
+#: hardinfo/util.c:382
 msgid "Fatal Error"
 msgstr "Error fatal"
 
-#: hardinfo/util.c:392
+#: hardinfo/util.c:407
 msgid "creates a report and prints to standard output"
 msgstr "crea un reporte y lo imprime en la salida estándar"
 
-#: hardinfo/util.c:398
+#: hardinfo/util.c:413
 msgid "chooses a report format (text, html)"
 msgstr "elige un formato para el reporte (texto, html)"
 
-#: hardinfo/util.c:404
+#: hardinfo/util.c:419
 msgid "run benchmark; requires benchmark.so to be loaded"
 msgstr "correr benchmark; requiere benchmark.so para ser cargado"
 
-#: hardinfo/util.c:410
+#: hardinfo/util.c:425
 msgid "lists modules"
 msgstr "lista los módulos"
 
-#: hardinfo/util.c:416
+#: hardinfo/util.c:431
 msgid "specify module to load"
 msgstr "especificar módulo a cargar"
 
-#: hardinfo/util.c:422
+#: hardinfo/util.c:437
 msgid "automatically load module dependencies"
 msgstr "cargar automáticamente las dependencias de los módulos"
 
-#: hardinfo/util.c:429
+#: hardinfo/util.c:444
 msgid "run in XML-RPC server mode"
 msgstr "correr en modo servidor XML-RPC"
 
-#: hardinfo/util.c:436
+#: hardinfo/util.c:451
 msgid "shows program version and quit"
 msgstr "muestra la versión del programa y sale"
 
-#: hardinfo/util.c:441
+#: hardinfo/util.c:456
 msgid "- System Profiler and Benchmark tool"
 msgstr "- Analizador de sistema y herramienta de benchmark"
 
-#: hardinfo/util.c:451
+#: hardinfo/util.c:466
 #, c-format
 msgid ""
 "Unrecognized arguments.\n"
@@ -207,29 +215,29 @@ msgstr ""
 "Argumentos no reconocidos.\n"
 "Intente ``%s --help'' para más información.\n"
 
-#: hardinfo/util.c:517
+#: hardinfo/util.c:532
 #, c-format
 msgid "Couldn't find a Web browser to open URL %s."
 msgstr "No se pudo encontrar un navegador Web para abrir la URL %s."
 
-#: hardinfo/util.c:866
+#: hardinfo/util.c:881
 #, c-format
 msgid "Module \"%s\" depends on module \"%s\", load it?"
 msgstr "El módulo \"%s\" depende del módulo \"%s\", ¿desea cargarlo?"
 
-#: hardinfo/util.c:889
+#: hardinfo/util.c:904
 #, c-format
 msgid "Module \"%s\" depends on module \"%s\"."
 msgstr "El módulo \"%s\" depende del módulo \"%s\"."
 
-#: hardinfo/util.c:934
+#: hardinfo/util.c:949
 #, c-format
 msgid "No module could be loaded. Check permissions on \"%s\" and try again."
 msgstr ""
 "No se puede cargar ningún módulo. Verifique los permisos en \"%s\" y pruebe "
 "de nuevo."
 
-#: hardinfo/util.c:938
+#: hardinfo/util.c:953
 msgid ""
 "No module could be loaded. Please use hardinfo -l to list all available "
 "modules and try again with a valid module list."
@@ -238,31 +246,31 @@ msgstr ""
 "todoslos módulos disponibles e intente de nuevo con una lista válida de "
 "módulos."
 
-#: hardinfo/util.c:1114
+#: hardinfo/util.c:1133
 #, c-format
 msgid "Scanning: %s..."
 msgstr "Escaneando: %s..."
 
-#: hardinfo/util.c:1124 shell/callbacks.c:67 shell/shell.c:303
-#: shell/shell.c:721 shell/shell.c:1701 modules/benchmark.c:445
+#: hardinfo/util.c:1143 shell/callbacks.c:77 shell/shell.c:307
+#: shell/shell.c:766 shell/shell.c:1808 modules/benchmark.c:445
 #: modules/benchmark.c:453
 msgid "Done."
 msgstr "Hecho."
 
-#: shell/callbacks.c:47
+#: shell/callbacks.c:48 shell/callbacks.c:56
 msgid "Save Image"
 msgstr "Guardar imagen"
 
-#: shell/callbacks.c:63
+#: shell/callbacks.c:73
 msgid "Saving image..."
 msgstr "Guardando imagen"
 
-#: shell/callbacks.c:153
+#: shell/callbacks.c:163
 #, c-format
 msgid "%s Module"
 msgstr "%s módulo"
 
-#: shell/callbacks.c:160
+#: shell/callbacks.c:174
 #, c-format
 msgid ""
 "Written by %s\n"
@@ -271,82 +279,82 @@ msgstr ""
 "Escrito por %s\n"
 "Licencia %s"
 
-#: shell/callbacks.c:174
+#: shell/callbacks.c:188
 #, c-format
 msgid "No about information is associated with the %s module."
 msgstr "No hay información \"acerca de\" asociada al módulo %s."
 
-#: shell/callbacks.c:189
+#: shell/callbacks.c:203
 msgid "Author:"
 msgstr "Autor:"
 
-#: shell/callbacks.c:192
+#: shell/callbacks.c:206
 msgid "Contributors:"
 msgstr "Contribuyentes:"
 
-#: shell/callbacks.c:196
+#: shell/callbacks.c:210
 msgid "Based on work by:"
 msgstr "Basado en el trabajo de:"
 
-#: shell/callbacks.c:197
+#: shell/callbacks.c:211
 msgid "MD5 implementation by Colin Plumb (see md5.c for details)"
 msgstr "Implementación de MD5 por Colin Plumb (ver md5.c para detalles)"
 
-#: shell/callbacks.c:198
+#: shell/callbacks.c:212
 msgid "SHA1 implementation by Steve Reid (see sha1.c for details)"
 msgstr "Implementación de SHA1 por Steve Reid (ver sha1.c para detalles)"
 
-#: shell/callbacks.c:199
+#: shell/callbacks.c:213
 msgid "Blowfish implementation by Paul Kocher (see blowfich.c for details)"
 msgstr ""
 "Implementación de Blowfish por Paul Kocher (ver blowfich.c para detalles)"
 
-#: shell/callbacks.c:200
+#: shell/callbacks.c:214
 msgid "Raytracing benchmark by John Walker (see fbench.c for details)"
 msgstr ""
 "Benchmark de trazado de rayos por John Walker (ver fbench.c para detalles)"
 
-#: shell/callbacks.c:201
+#: shell/callbacks.c:215
 msgid "FFT benchmark by Scott Robert Ladd (see fftbench.c for details)"
 msgstr "Benchmark  de FFT por Scott Robert Ladd (ver fftbench.c para detalles)"
 
-#: shell/callbacks.c:202
+#: shell/callbacks.c:216
 msgid "Some code partly based on x86cpucaps by Osamu Kayasono"
 msgstr "Parte del código parcialmente basado en x86cpucaps por Osamu Kayasono"
 
-#: shell/callbacks.c:203
+#: shell/callbacks.c:217
 msgid "Vendor list based on GtkSysInfo by Pissens Sebastien"
 msgstr "Lista de proveedores basada en GtkSysInfo por Pissens Sebastien"
 
-#: shell/callbacks.c:204
+#: shell/callbacks.c:218
 msgid "DMI support based on code by Stewart Adam"
 msgstr "Soporte DMI basado en código de Stewart Adam"
 
-#: shell/callbacks.c:205
+#: shell/callbacks.c:219
 msgid "SCSI support based on code by Pascal F. Martin"
 msgstr "Soporte SCSI basado en código de Pascal F. Martin"
 
-#: shell/callbacks.c:209
+#: shell/callbacks.c:223
 msgid "Jakub Szypulka"
 msgstr ""
 
-#: shell/callbacks.c:210
+#: shell/callbacks.c:224
 msgid "Tango Project"
 msgstr "Proyecto Tango"
 
-#: shell/callbacks.c:211
+#: shell/callbacks.c:225
 msgid "The GNOME Project"
 msgstr "El proyecto GNOME"
 
-#: shell/callbacks.c:212
+#: shell/callbacks.c:226
 msgid "VMWare, Inc. (USB icon from VMWare Workstation 6)"
 msgstr "VMWare, Inc. (icono USB de VMWare Workstation 6)"
 
-#: shell/callbacks.c:224
+#: shell/callbacks.c:244
 msgid "System information and benchmark tool"
 msgstr "Herramienta de información del sistema y benchmark"
 
-#: shell/callbacks.c:229
+#: shell/callbacks.c:249
 msgid ""
 "HardInfo is free software; you can redistribute it and/or modify it under "
 "the terms of the GNU General Public License as published by the Free "
@@ -442,35 +450,35 @@ msgstr "Cambia la visibilidad del panel lateral"
 msgid "_Toolbar"
 msgstr "_Barra de herramientas"
 
-#: shell/report.c:493
+#: shell/report.c:494 shell/report.c:502
 msgid "Save File"
 msgstr "Guardar archivo"
 
-#: shell/report.c:619
+#: shell/report.c:629
 msgid "Cannot create ReportContext. Programming bug?"
 msgstr "No se puede crear ReportContext. ¿Error del programa?"
 
-#: shell/report.c:638
+#: shell/report.c:648
 msgid "Open the report with your web browser?"
 msgstr "¿Abrir el reporte en el navegador web?"
 
-#: shell/report.c:666
+#: shell/report.c:682
 msgid "Generating report..."
 msgstr "Generando reporte..."
 
-#: shell/report.c:676
+#: shell/report.c:692
 msgid "Report saved."
 msgstr "Reporte guardado."
 
-#: shell/report.c:678
+#: shell/report.c:694
 msgid "Error while creating the report."
 msgstr "Error creando el reporte."
 
-#: shell/report.c:780
+#: shell/report.c:796
 msgid "Generate Report"
 msgstr "Generar reporte"
 
-#: shell/report.c:797
+#: shell/report.c:821
 msgid ""
 "<big><b>Generate Report</b></big>\n"
 "Please choose the information that you wish to view in your report:"
@@ -478,37 +486,41 @@ msgstr ""
 "<big><b>Generar reporte</b></big>\n"
 "Por favor elija la información que desea ver en el reporte:"
 
-#: shell/report.c:857
+#: shell/report.c:893
 msgid "Select _None"
 msgstr "_Deseleccionar todo"
 
-#: shell/report.c:864
+#: shell/report.c:904
 msgid "Select _All"
 msgstr "_Seleccionar todo"
 
-#: shell/report.c:882
+#: shell/report.c:930
+msgid "_Cancel"
+msgstr ""
+
+#: shell/report.c:943
 msgid "_Generate"
 msgstr "_Generar"
 
-#: shell/shell.c:396
+#: shell/shell.c:408
 #, c-format
 msgid "%s - System Information"
 msgstr "%s - Información del sistema"
 
-#: shell/shell.c:401
+#: shell/shell.c:413
 msgid "System Information"
 msgstr "Información del sistema"
 
-#: shell/shell.c:708
+#: shell/shell.c:753
 msgid "Loading modules..."
 msgstr "Cargando módulos..."
 
-#: shell/shell.c:1571
+#: shell/shell.c:1673
 #, c-format
 msgid "<b>%s → Summary</b>"
 msgstr "<b>%s → Resumen</b>"
 
-#: shell/shell.c:1679
+#: shell/shell.c:1782
 msgid "Updating..."
 msgstr "Actualizando..."
 
@@ -4060,19 +4072,11 @@ msgid "Broadcast Address"
 msgstr ""
 
 #~ msgid ""
-#~ "Compile-time options:\n"
-#~ "  Release version:   %s (%s)\n"
-#~ "  BinReloc enabled:  %s\n"
-#~ "  Data prefix:       %s\n"
-#~ "  Library prefix:    %s\n"
-#~ "  Compiled on:       %s %s (%s)\n"
+#~ "Modules:\n"
+#~ "%-20s%-15s%-12s\n"
 #~ msgstr ""
-#~ "Opciones de compilado:\n"
-#~ "  Versión:                %s (%s)\n"
-#~ "  BinReloc habilitado:    %s\n"
-#~ "  Prefijo de datos:       %s\n"
-#~ "  Prefijo de bibliotecas: %s\n"
-#~ "  Compilado en:           %s %s (%s)\n"
+#~ "Módulos:\n"
+#~ "%-20s%-15s%-12s\n"
 
 #~ msgid "Y_es"
 #~ msgstr "_Sí"

--- a/po/fr.po
+++ b/po/fr.po
@@ -6,27 +6,29 @@ msgid ""
 msgstr ""
 "Project-Id-Version: hardinfo\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-07-30 05:41-0500\n"
+"POT-Creation-Date: 2017-08-01 01:16-0500\n"
 "PO-Revision-Date: 2014-09-03\n"
 "Last-Translator: yolateng0 @olala22000\n"
 "Language-Team: LeFlood\n"
 "Language: fr\n"
+"X-Poedit-Basepath: ../\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
 "X-Generator: Poedit 1.5.4\n"
 
-#: hardinfo/hardinfo.c:48
+#. / %d will be latest year of copyright
+#: hardinfo/hardinfo.c:49
+#, c-format
 msgid ""
-"Copyright (C) 2003-2009 Leandro A. F. Pereira. See COPYING for details.\n"
+"Copyright (C) 2003-%d Leandro A. F. Pereira. See COPYING for details.\n"
 "\n"
 msgstr ""
-"Copyright (C) 2003-2009 Leandro A. F. Pereira. voir COPYING pour les "
-"details.\n"
+"Copyright (C) 2003-%d Leandro A. F. Pereira. voir COPYING pour les details.\n"
 "\n"
 
-#: hardinfo/hardinfo.c:50
+#: hardinfo/hardinfo.c:51
 #, c-format
 msgid ""
 "Compile-time options:\n"
@@ -36,17 +38,23 @@ msgid ""
 "  Library prefix:    %s\n"
 "  Compiled for:      %s\n"
 msgstr ""
+"Compile-time options:\n"
+" \"Release\" version: %s (%s)\n"
+" BinReloc activé:   %s\n"
+" Data prefix:       %s\n"
+" Library prefix:    %s\n"
+" Compilation:       %s\n"
 
-#: hardinfo/hardinfo.c:56 hardinfo/hardinfo.c:57 modules/computer.c:565
+#: hardinfo/hardinfo.c:57 hardinfo/hardinfo.c:58 modules/computer.c:565
 #: modules/devices/printers.c:138
 msgid "Yes"
 msgstr "Oui"
 
-#: hardinfo/hardinfo.c:57 modules/computer.c:565 modules/devices/printers.c:138
+#: hardinfo/hardinfo.c:58 modules/computer.c:565 modules/devices/printers.c:138
 msgid "No"
 msgstr "Non"
 
-#: hardinfo/hardinfo.c:68
+#: hardinfo/hardinfo.c:69
 #, c-format
 msgid ""
 "Failed to find runtime data.\n"
@@ -59,36 +67,34 @@ msgstr ""
 "• Est ce que HardInfo est correctement installé?\n"
 "• Voir si %s et %s existes et que vous avez bien les privilèges."
 
-#: hardinfo/hardinfo.c:75
+#: hardinfo/hardinfo.c:76
 #, c-format
 msgid ""
 "Modules:\n"
-"%-20s%-15s%-12s\n"
+"%-20s %-15s %-12s\n"
 msgstr ""
-"Modules:\n"
-"%-20s%-15s%-12s\n"
 
-#: hardinfo/hardinfo.c:76
+#: hardinfo/hardinfo.c:77
 msgid "File Name"
 msgstr "Nom du fichier"
 
-#: hardinfo/hardinfo.c:76 modules/computer.c:493 modules/computer.c:515
+#: hardinfo/hardinfo.c:77 modules/computer.c:493 modules/computer.c:515
 #: modules/computer.c:586 modules/devices/ia64/processor.c:152
 #: modules/devices/sh/processor.c:76 modules/network.c:331
 msgid "Name"
 msgstr "Nom"
 
-#: hardinfo/hardinfo.c:76 modules/computer.c:291 modules/computer.c:466
+#: hardinfo/hardinfo.c:77 modules/computer.c:291 modules/computer.c:466
 #: modules/computer.c:468 modules/computer.c:556 modules/computer.c:564
 msgid "Version"
 msgstr "Version"
 
-#: hardinfo/hardinfo.c:123
+#: hardinfo/hardinfo.c:124
 #, c-format
 msgid "Unknown benchmark ``%s'' or libbenchmark.so not loaded"
 msgstr "Benchmark inconnu ``%s'' ou libbenchmark.so non chargé"
 
-#: hardinfo/hardinfo.c:151
+#: hardinfo/hardinfo.c:152
 msgid "Don't know what to do. Exiting."
 msgstr "Que faire. Sortie."
 
@@ -150,55 +156,55 @@ msgstr ""
 msgid "%.1f PiB"
 msgstr ""
 
-#: hardinfo/util.c:352
+#: hardinfo/util.c:367
 msgid "Error"
 msgstr "Erreur"
 
-#: hardinfo/util.c:352 hardinfo/util.c:368
+#: hardinfo/util.c:367 hardinfo/util.c:383
 msgid "Warning"
 msgstr "Attention"
 
-#: hardinfo/util.c:367
+#: hardinfo/util.c:382
 msgid "Fatal Error"
 msgstr "Erreur Fatale"
 
-#: hardinfo/util.c:392
+#: hardinfo/util.c:407
 msgid "creates a report and prints to standard output"
 msgstr "crée un rapport et imprime sur la sortie standard"
 
-#: hardinfo/util.c:398
+#: hardinfo/util.c:413
 msgid "chooses a report format (text, html)"
 msgstr "choisir un format de rapport (texte, html)"
 
-#: hardinfo/util.c:404
+#: hardinfo/util.c:419
 msgid "run benchmark; requires benchmark.so to be loaded"
 msgstr "Envoyé le benchmark; nécessite benchmark.so"
 
-#: hardinfo/util.c:410
+#: hardinfo/util.c:425
 msgid "lists modules"
 msgstr "Listes des modules"
 
-#: hardinfo/util.c:416
+#: hardinfo/util.c:431
 msgid "specify module to load"
 msgstr "spécifie les modules à charger"
 
-#: hardinfo/util.c:422
+#: hardinfo/util.c:437
 msgid "automatically load module dependencies"
 msgstr "charger automatiquement les dépendances entre modules"
 
-#: hardinfo/util.c:429
+#: hardinfo/util.c:444
 msgid "run in XML-RPC server mode"
 msgstr "fonctionner en mode serveur XML-RPC"
 
-#: hardinfo/util.c:436
+#: hardinfo/util.c:451
 msgid "shows program version and quit"
 msgstr "Affiche la version du programme et quitter"
 
-#: hardinfo/util.c:441
+#: hardinfo/util.c:456
 msgid "- System Profiler and Benchmark tool"
 msgstr "- Profil du Systeme et outil d'évaluation Benchmark"
 
-#: hardinfo/util.c:451
+#: hardinfo/util.c:466
 #, c-format
 msgid ""
 "Unrecognized arguments.\n"
@@ -207,29 +213,29 @@ msgstr ""
 "commandes inconnues.\n"
 "taper ``%s --help'' pour plus d'informations.\n"
 
-#: hardinfo/util.c:517
+#: hardinfo/util.c:532
 #, c-format
 msgid "Couldn't find a Web browser to open URL %s."
 msgstr "Impossible de trouver un navigateur Web pour ouvrir l'URL %s."
 
-#: hardinfo/util.c:866
+#: hardinfo/util.c:881
 #, c-format
 msgid "Module \"%s\" depends on module \"%s\", load it?"
 msgstr "Module \"%s\" depends du module \"%s\", le charger?"
 
-#: hardinfo/util.c:889
+#: hardinfo/util.c:904
 #, c-format
 msgid "Module \"%s\" depends on module \"%s\"."
 msgstr "Module \"%s\" depends du module \"%s\"."
 
-#: hardinfo/util.c:934
+#: hardinfo/util.c:949
 #, c-format
 msgid "No module could be loaded. Check permissions on \"%s\" and try again."
 msgstr ""
 "Aucun module peut être chargé. Vérifiez les permissions sur \"%s\" et "
 "essayez à nouveau."
 
-#: hardinfo/util.c:938
+#: hardinfo/util.c:953
 msgid ""
 "No module could be loaded. Please use hardinfo -l to list all available "
 "modules and try again with a valid module list."
@@ -238,31 +244,31 @@ msgstr ""
 "répertorier tous les modules disponibles et essayez à nouveau avec une liste "
 "de modules valides."
 
-#: hardinfo/util.c:1114
+#: hardinfo/util.c:1133
 #, c-format
 msgid "Scanning: %s..."
 msgstr "Scanne: %s..."
 
-#: hardinfo/util.c:1124 shell/callbacks.c:67 shell/shell.c:303
-#: shell/shell.c:721 shell/shell.c:1701 modules/benchmark.c:445
+#: hardinfo/util.c:1143 shell/callbacks.c:77 shell/shell.c:307
+#: shell/shell.c:766 shell/shell.c:1808 modules/benchmark.c:445
 #: modules/benchmark.c:453
 msgid "Done."
 msgstr "Réalisé."
 
-#: shell/callbacks.c:47
+#: shell/callbacks.c:48 shell/callbacks.c:56
 msgid "Save Image"
 msgstr "Sauvergarder l'image"
 
-#: shell/callbacks.c:63
+#: shell/callbacks.c:73
 msgid "Saving image..."
 msgstr "Sauvegarde de l'image"
 
-#: shell/callbacks.c:153
+#: shell/callbacks.c:163
 #, c-format
 msgid "%s Module"
 msgstr "%s Module"
 
-#: shell/callbacks.c:160
+#: shell/callbacks.c:174
 #, c-format
 msgid ""
 "Written by %s\n"
@@ -271,84 +277,84 @@ msgstr ""
 "Ecrit par %s\n"
 "Sous Licence %s"
 
-#: shell/callbacks.c:174
+#: shell/callbacks.c:188
 #, c-format
 msgid "No about information is associated with the %s module."
 msgstr "Pas d'information associée au module %s."
 
-#: shell/callbacks.c:189
+#: shell/callbacks.c:203
 msgid "Author:"
 msgstr "Auteur:"
 
-#: shell/callbacks.c:192
+#: shell/callbacks.c:206
 msgid "Contributors:"
 msgstr "Contributeurs:"
 
-#: shell/callbacks.c:196
+#: shell/callbacks.c:210
 msgid "Based on work by:"
 msgstr "Basé sur le travail de:"
 
-#: shell/callbacks.c:197
+#: shell/callbacks.c:211
 msgid "MD5 implementation by Colin Plumb (see md5.c for details)"
 msgstr "Implémentation  MD5 par Colin Plumb (voir md5.c pour les détails)"
 
-#: shell/callbacks.c:198
+#: shell/callbacks.c:212
 msgid "SHA1 implementation by Steve Reid (see sha1.c for details)"
 msgstr "implémentation  SHA1 par Steve Reid (voir sha1.c pour les détails)"
 
-#: shell/callbacks.c:199
+#: shell/callbacks.c:213
 msgid "Blowfish implementation by Paul Kocher (see blowfich.c for details)"
 msgstr ""
 "Implémentation Blowfish par Paul Kocher (voir blowchih.c pour de plus amples "
 "détails"
 
-#: shell/callbacks.c:200
+#: shell/callbacks.c:214
 msgid "Raytracing benchmark by John Walker (see fbench.c for details)"
 msgstr ""
 "Raytracing benchmark par John Walker (voir fbench.c pour de plus amples "
 "détails)"
 
-#: shell/callbacks.c:201
+#: shell/callbacks.c:215
 msgid "FFT benchmark by Scott Robert Ladd (see fftbench.c for details)"
 msgstr "FFT benchmark par Scott Robert Ladd (voir fftbench.c pour les détails)"
 
-#: shell/callbacks.c:202
+#: shell/callbacks.c:216
 msgid "Some code partly based on x86cpucaps by Osamu Kayasono"
 msgstr "Une partie du code est basé sur x86cpucaps par Osamu Kayasono"
 
-#: shell/callbacks.c:203
+#: shell/callbacks.c:217
 msgid "Vendor list based on GtkSysInfo by Pissens Sebastien"
 msgstr "La liste des fabricants est basée sur GtkSysInfo par Pissens Sebastien"
 
-#: shell/callbacks.c:204
+#: shell/callbacks.c:218
 msgid "DMI support based on code by Stewart Adam"
 msgstr "Les supports DMI sont basés sur le code de Stewart Adam"
 
-#: shell/callbacks.c:205
+#: shell/callbacks.c:219
 msgid "SCSI support based on code by Pascal F. Martin"
 msgstr "Les supports SCSI sont basés sur le code de Pascal F. Martin"
 
-#: shell/callbacks.c:209
+#: shell/callbacks.c:223
 msgid "Jakub Szypulka"
 msgstr "Jakub Szypulka"
 
-#: shell/callbacks.c:210
+#: shell/callbacks.c:224
 msgid "Tango Project"
 msgstr "Projet Tango"
 
-#: shell/callbacks.c:211
+#: shell/callbacks.c:225
 msgid "The GNOME Project"
 msgstr "Le Projet Gnome"
 
-#: shell/callbacks.c:212
+#: shell/callbacks.c:226
 msgid "VMWare, Inc. (USB icon from VMWare Workstation 6)"
 msgstr "VMWare, Inc. (USB icône sur VMWare Workstation 6)"
 
-#: shell/callbacks.c:224
+#: shell/callbacks.c:244
 msgid "System information and benchmark tool"
 msgstr "Information du systeme et outil d'évaluation"
 
-#: shell/callbacks.c:229
+#: shell/callbacks.c:249
 msgid ""
 "HardInfo is free software; you can redistribute it and/or modify it under "
 "the terms of the GNU General Public License as published by the Free "
@@ -444,35 +450,35 @@ msgstr "Basculer visibilité du panneau latéral "
 msgid "_Toolbar"
 msgstr "_Barre d'outils"
 
-#: shell/report.c:493
+#: shell/report.c:494 shell/report.c:502
 msgid "Save File"
 msgstr "Sauvegarder le fichier"
 
-#: shell/report.c:619
+#: shell/report.c:629
 msgid "Cannot create ReportContext. Programming bug?"
 msgstr "Impossible de créer un rapport général. Bug?"
 
-#: shell/report.c:638
+#: shell/report.c:648
 msgid "Open the report with your web browser?"
 msgstr "Ouvrez le rapport avec votre navigateur Web?"
 
-#: shell/report.c:666
+#: shell/report.c:682
 msgid "Generating report..."
 msgstr "Création du rapport..."
 
-#: shell/report.c:676
+#: shell/report.c:692
 msgid "Report saved."
 msgstr "Rapport sauvegardé"
 
-#: shell/report.c:678
+#: shell/report.c:694
 msgid "Error while creating the report."
 msgstr "Erreur lors de la création du rapport."
 
-#: shell/report.c:780
+#: shell/report.c:796
 msgid "Generate Report"
 msgstr "Réalisation du Rapport"
 
-#: shell/report.c:797
+#: shell/report.c:821
 msgid ""
 "<big><b>Generate Report</b></big>\n"
 "Please choose the information that you wish to view in your report:"
@@ -481,37 +487,41 @@ msgstr ""
 " S'il vous plaît choisissez les informations que vous souhaitez afficher "
 "dans votre rapport:"
 
-#: shell/report.c:857
+#: shell/report.c:893
 msgid "Select _None"
 msgstr "Désélectionner _Tout"
 
-#: shell/report.c:864
+#: shell/report.c:904
 msgid "Select _All"
 msgstr "Sélectionner _Tout"
 
-#: shell/report.c:882
+#: shell/report.c:930
+msgid "_Cancel"
+msgstr ""
+
+#: shell/report.c:943
 msgid "_Generate"
 msgstr "_Création"
 
-#: shell/shell.c:396
+#: shell/shell.c:408
 #, c-format
 msgid "%s - System Information"
 msgstr "%s - Informations du Système"
 
-#: shell/shell.c:401
+#: shell/shell.c:413
 msgid "System Information"
 msgstr "Informations du Système"
 
-#: shell/shell.c:708
+#: shell/shell.c:753
 msgid "Loading modules..."
 msgstr "Chargement des modules..."
 
-#: shell/shell.c:1571
+#: shell/shell.c:1673
 #, c-format
 msgid "<b>%s → Summary</b>"
 msgstr "<b>%s → Résumé</b>"
 
-#: shell/shell.c:1679
+#: shell/shell.c:1782
 msgid "Updating..."
 msgstr "Mise à jour..."
 
@@ -4148,21 +4158,6 @@ msgstr ""
 
 #~ msgid "XFree86 version"
 #~ msgstr "version de XFree86 "
-
-#~ msgid ""
-#~ "Compile-time options:\n"
-#~ " Release version: %s (%s)\n"
-#~ " BinReloc enabled: %s\n"
-#~ " Data prefix: %s\n"
-#~ " Library prefix: %s\n"
-#~ " Compiled on: %s %s (%s)\n"
-#~ msgstr ""
-#~ "Compile-time options:\n"
-#~ " Version: %s (%s)\n"
-#~ " BinReloc activé: %s\n"
-#~ " Data prefix: %s\n"
-#~ " Library prefix: %s\n"
-#~ " Compilation: %s %s (%s)\n"
 
 #~ msgid "%d hour and "
 #~ msgid_plural "%d hours and "

--- a/po/fr.po
+++ b/po/fr.po
@@ -102,15 +102,15 @@ msgstr "Que faire. Sortie."
 #, c-format
 msgid "%d day"
 msgid_plural "%d days"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "%d jour"
+msgstr[1] "%d jours"
 
 #: hardinfo/util.c:105 modules/computer/uptime.c:54
 #, c-format
 msgid "%d hour"
 msgid_plural "%d hours"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "%d heure"
+msgstr[1] "%d heures"
 
 #: hardinfo/util.c:106 modules/computer/uptime.c:55
 #, c-format
@@ -123,8 +123,8 @@ msgstr[1] "%d minutes"
 #, c-format
 msgid "%d second"
 msgid_plural "%d seconds"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "%d seconde"
+msgstr[1] "%d secondes"
 
 #: hardinfo/util.c:128
 #, c-format
@@ -4077,16 +4077,6 @@ msgstr ""
 #~ msgid "Y_es"
 #~ msgstr "O_ui"
 
-#~ msgid "%d day, "
-#~ msgid_plural "%d days, "
-#~ msgstr[0] "%d jour, "
-#~ msgstr[1] "%d jours, "
-
-#~ msgid "%d hour, "
-#~ msgid_plural "%d hours, "
-#~ msgstr[0] "%d heure, "
-#~ msgstr[1] "%d heures, "
-
 #~ msgid "Remote: <b>%s</b>"
 #~ msgstr "Accès: <b>%s</b>"
 
@@ -4158,8 +4148,3 @@ msgstr ""
 
 #~ msgid "XFree86 version"
 #~ msgstr "version de XFree86 "
-
-#~ msgid "%d hour and "
-#~ msgid_plural "%d hours and "
-#~ msgstr[0] "%d  heure et "
-#~ msgstr[1] "%d  heures et "

--- a/po/hardinfo.pot
+++ b/po/hardinfo.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-07-30 05:41-0500\n"
+"POT-Creation-Date: 2017-08-01 01:16-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,13 +18,15 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
 
-#: hardinfo/hardinfo.c:48
+#. / %d will be latest year of copyright
+#: hardinfo/hardinfo.c:49
+#, c-format
 msgid ""
-"Copyright (C) 2003-2009 Leandro A. F. Pereira. See COPYING for details.\n"
+"Copyright (C) 2003-%d Leandro A. F. Pereira. See COPYING for details.\n"
 "\n"
 msgstr ""
 
-#: hardinfo/hardinfo.c:50
+#: hardinfo/hardinfo.c:51
 #, c-format
 msgid ""
 "Compile-time options:\n"
@@ -35,16 +37,16 @@ msgid ""
 "  Compiled for:      %s\n"
 msgstr ""
 
-#: hardinfo/hardinfo.c:56 hardinfo/hardinfo.c:57 modules/computer.c:565
+#: hardinfo/hardinfo.c:57 hardinfo/hardinfo.c:58 modules/computer.c:565
 #: modules/devices/printers.c:138
 msgid "Yes"
 msgstr ""
 
-#: hardinfo/hardinfo.c:57 modules/computer.c:565 modules/devices/printers.c:138
+#: hardinfo/hardinfo.c:58 modules/computer.c:565 modules/devices/printers.c:138
 msgid "No"
 msgstr ""
 
-#: hardinfo/hardinfo.c:68
+#: hardinfo/hardinfo.c:69
 #, c-format
 msgid ""
 "Failed to find runtime data.\n"
@@ -53,34 +55,34 @@ msgid ""
 "• See if %s and %s exists and you have read permission."
 msgstr ""
 
-#: hardinfo/hardinfo.c:75
+#: hardinfo/hardinfo.c:76
 #, c-format
 msgid ""
 "Modules:\n"
-"%-20s%-15s%-12s\n"
+"%-20s %-15s %-12s\n"
 msgstr ""
 
-#: hardinfo/hardinfo.c:76
+#: hardinfo/hardinfo.c:77
 msgid "File Name"
 msgstr ""
 
-#: hardinfo/hardinfo.c:76 modules/computer.c:493 modules/computer.c:515
+#: hardinfo/hardinfo.c:77 modules/computer.c:493 modules/computer.c:515
 #: modules/computer.c:586 modules/devices/ia64/processor.c:152
 #: modules/devices/sh/processor.c:76 modules/network.c:331
 msgid "Name"
 msgstr ""
 
-#: hardinfo/hardinfo.c:76 modules/computer.c:291 modules/computer.c:466
+#: hardinfo/hardinfo.c:77 modules/computer.c:291 modules/computer.c:466
 #: modules/computer.c:468 modules/computer.c:556 modules/computer.c:564
 msgid "Version"
 msgstr ""
 
-#: hardinfo/hardinfo.c:123
+#: hardinfo/hardinfo.c:124
 #, c-format
 msgid "Unknown benchmark ``%s'' or libbenchmark.so not loaded"
 msgstr ""
 
-#: hardinfo/hardinfo.c:151
+#: hardinfo/hardinfo.c:152
 msgid "Don't know what to do. Exiting."
 msgstr ""
 
@@ -142,192 +144,192 @@ msgstr ""
 msgid "%.1f PiB"
 msgstr ""
 
-#: hardinfo/util.c:352
+#: hardinfo/util.c:367
 msgid "Error"
 msgstr ""
 
-#: hardinfo/util.c:352 hardinfo/util.c:368
+#: hardinfo/util.c:367 hardinfo/util.c:383
 msgid "Warning"
 msgstr ""
 
-#: hardinfo/util.c:367
+#: hardinfo/util.c:382
 msgid "Fatal Error"
 msgstr ""
 
-#: hardinfo/util.c:392
+#: hardinfo/util.c:407
 msgid "creates a report and prints to standard output"
 msgstr ""
 
-#: hardinfo/util.c:398
+#: hardinfo/util.c:413
 msgid "chooses a report format (text, html)"
 msgstr ""
 
-#: hardinfo/util.c:404
+#: hardinfo/util.c:419
 msgid "run benchmark; requires benchmark.so to be loaded"
 msgstr ""
 
-#: hardinfo/util.c:410
+#: hardinfo/util.c:425
 msgid "lists modules"
 msgstr ""
 
-#: hardinfo/util.c:416
+#: hardinfo/util.c:431
 msgid "specify module to load"
 msgstr ""
 
-#: hardinfo/util.c:422
+#: hardinfo/util.c:437
 msgid "automatically load module dependencies"
 msgstr ""
 
-#: hardinfo/util.c:429
+#: hardinfo/util.c:444
 msgid "run in XML-RPC server mode"
 msgstr ""
 
-#: hardinfo/util.c:436
+#: hardinfo/util.c:451
 msgid "shows program version and quit"
 msgstr ""
 
-#: hardinfo/util.c:441
+#: hardinfo/util.c:456
 msgid "- System Profiler and Benchmark tool"
 msgstr ""
 
-#: hardinfo/util.c:451
+#: hardinfo/util.c:466
 #, c-format
 msgid ""
 "Unrecognized arguments.\n"
 "Try ``%s --help'' for more information.\n"
 msgstr ""
 
-#: hardinfo/util.c:517
+#: hardinfo/util.c:532
 #, c-format
 msgid "Couldn't find a Web browser to open URL %s."
 msgstr ""
 
-#: hardinfo/util.c:866
+#: hardinfo/util.c:881
 #, c-format
 msgid "Module \"%s\" depends on module \"%s\", load it?"
 msgstr ""
 
-#: hardinfo/util.c:889
+#: hardinfo/util.c:904
 #, c-format
 msgid "Module \"%s\" depends on module \"%s\"."
 msgstr ""
 
-#: hardinfo/util.c:934
+#: hardinfo/util.c:949
 #, c-format
 msgid "No module could be loaded. Check permissions on \"%s\" and try again."
 msgstr ""
 
-#: hardinfo/util.c:938
+#: hardinfo/util.c:953
 msgid ""
 "No module could be loaded. Please use hardinfo -l to list all available "
 "modules and try again with a valid module list."
 msgstr ""
 
-#: hardinfo/util.c:1114
+#: hardinfo/util.c:1133
 #, c-format
 msgid "Scanning: %s..."
 msgstr ""
 
-#: hardinfo/util.c:1124 shell/callbacks.c:67 shell/shell.c:303
-#: shell/shell.c:721 shell/shell.c:1701 modules/benchmark.c:445
+#: hardinfo/util.c:1143 shell/callbacks.c:77 shell/shell.c:307
+#: shell/shell.c:766 shell/shell.c:1808 modules/benchmark.c:445
 #: modules/benchmark.c:453
 msgid "Done."
 msgstr ""
 
-#: shell/callbacks.c:47
+#: shell/callbacks.c:48 shell/callbacks.c:56
 msgid "Save Image"
 msgstr ""
 
-#: shell/callbacks.c:63
+#: shell/callbacks.c:73
 msgid "Saving image..."
 msgstr ""
 
-#: shell/callbacks.c:153
+#: shell/callbacks.c:163
 #, c-format
 msgid "%s Module"
 msgstr ""
 
-#: shell/callbacks.c:160
+#: shell/callbacks.c:174
 #, c-format
 msgid ""
 "Written by %s\n"
 "Licensed under %s"
 msgstr ""
 
-#: shell/callbacks.c:174
+#: shell/callbacks.c:188
 #, c-format
 msgid "No about information is associated with the %s module."
 msgstr ""
 
-#: shell/callbacks.c:189
+#: shell/callbacks.c:203
 msgid "Author:"
 msgstr ""
 
-#: shell/callbacks.c:192
+#: shell/callbacks.c:206
 msgid "Contributors:"
 msgstr ""
 
-#: shell/callbacks.c:196
+#: shell/callbacks.c:210
 msgid "Based on work by:"
 msgstr ""
 
-#: shell/callbacks.c:197
+#: shell/callbacks.c:211
 msgid "MD5 implementation by Colin Plumb (see md5.c for details)"
 msgstr ""
 
-#: shell/callbacks.c:198
+#: shell/callbacks.c:212
 msgid "SHA1 implementation by Steve Reid (see sha1.c for details)"
 msgstr ""
 
-#: shell/callbacks.c:199
+#: shell/callbacks.c:213
 msgid "Blowfish implementation by Paul Kocher (see blowfich.c for details)"
 msgstr ""
 
-#: shell/callbacks.c:200
+#: shell/callbacks.c:214
 msgid "Raytracing benchmark by John Walker (see fbench.c for details)"
 msgstr ""
 
-#: shell/callbacks.c:201
+#: shell/callbacks.c:215
 msgid "FFT benchmark by Scott Robert Ladd (see fftbench.c for details)"
 msgstr ""
 
-#: shell/callbacks.c:202
+#: shell/callbacks.c:216
 msgid "Some code partly based on x86cpucaps by Osamu Kayasono"
 msgstr ""
 
-#: shell/callbacks.c:203
+#: shell/callbacks.c:217
 msgid "Vendor list based on GtkSysInfo by Pissens Sebastien"
 msgstr ""
 
-#: shell/callbacks.c:204
+#: shell/callbacks.c:218
 msgid "DMI support based on code by Stewart Adam"
 msgstr ""
 
-#: shell/callbacks.c:205
+#: shell/callbacks.c:219
 msgid "SCSI support based on code by Pascal F. Martin"
 msgstr ""
 
-#: shell/callbacks.c:209
+#: shell/callbacks.c:223
 msgid "Jakub Szypulka"
 msgstr ""
 
-#: shell/callbacks.c:210
+#: shell/callbacks.c:224
 msgid "Tango Project"
 msgstr ""
 
-#: shell/callbacks.c:211
+#: shell/callbacks.c:225
 msgid "The GNOME Project"
 msgstr ""
 
-#: shell/callbacks.c:212
+#: shell/callbacks.c:226
 msgid "VMWare, Inc. (USB icon from VMWare Workstation 6)"
 msgstr ""
 
-#: shell/callbacks.c:224
+#: shell/callbacks.c:244
 msgid "System information and benchmark tool"
 msgstr ""
 
-#: shell/callbacks.c:229
+#: shell/callbacks.c:249
 msgid ""
 "HardInfo is free software; you can redistribute it and/or modify it under "
 "the terms of the GNU General Public License as published by the Free "
@@ -423,71 +425,75 @@ msgstr ""
 msgid "_Toolbar"
 msgstr ""
 
-#: shell/report.c:493
+#: shell/report.c:494 shell/report.c:502
 msgid "Save File"
 msgstr ""
 
-#: shell/report.c:619
+#: shell/report.c:629
 msgid "Cannot create ReportContext. Programming bug?"
 msgstr ""
 
-#: shell/report.c:638
+#: shell/report.c:648
 msgid "Open the report with your web browser?"
 msgstr ""
 
-#: shell/report.c:666
+#: shell/report.c:682
 msgid "Generating report..."
 msgstr ""
 
-#: shell/report.c:676
+#: shell/report.c:692
 msgid "Report saved."
 msgstr ""
 
-#: shell/report.c:678
+#: shell/report.c:694
 msgid "Error while creating the report."
 msgstr ""
 
-#: shell/report.c:780
+#: shell/report.c:796
 msgid "Generate Report"
 msgstr ""
 
-#: shell/report.c:797
+#: shell/report.c:821
 msgid ""
 "<big><b>Generate Report</b></big>\n"
 "Please choose the information that you wish to view in your report:"
 msgstr ""
 
-#: shell/report.c:857
+#: shell/report.c:893
 msgid "Select _None"
 msgstr ""
 
-#: shell/report.c:864
+#: shell/report.c:904
 msgid "Select _All"
 msgstr ""
 
-#: shell/report.c:882
+#: shell/report.c:930
+msgid "_Cancel"
+msgstr ""
+
+#: shell/report.c:943
 msgid "_Generate"
 msgstr ""
 
-#: shell/shell.c:396
+#: shell/shell.c:408
 #, c-format
 msgid "%s - System Information"
 msgstr ""
 
-#: shell/shell.c:401
+#: shell/shell.c:413
 msgid "System Information"
 msgstr ""
 
-#: shell/shell.c:708
+#: shell/shell.c:753
 msgid "Loading modules..."
 msgstr ""
 
-#: shell/shell.c:1571
+#: shell/shell.c:1673
 #, c-format
 msgid "<b>%s → Summary</b>"
 msgstr ""
 
-#: shell/shell.c:1679
+#: shell/shell.c:1782
 msgid "Updating..."
 msgstr ""
 

--- a/po/ru.po
+++ b/po/ru.po
@@ -2,11 +2,12 @@ msgid ""
 msgstr ""
 "Project-Id-Version: hardinfo\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-07-30 05:41-0500\n"
+"POT-Creation-Date: 2017-08-01 01:16-0500\n"
 "PO-Revision-Date: \n"
 "Last-Translator: Sergey Rodin <rodin.s@rambler.ru>\n"
 "Language-Team: \n"
 "Language: ru_UA\n"
+"X-Poedit-Basepath: ../\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -16,16 +17,18 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
 "%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2)\n"
 
-#: hardinfo/hardinfo.c:48
+#. / %d will be latest year of copyright
+#: hardinfo/hardinfo.c:49
+#, c-format
 msgid ""
-"Copyright (C) 2003-2009 Leandro A. F. Pereira. See COPYING for details.\n"
+"Copyright (C) 2003-%d Leandro A. F. Pereira. See COPYING for details.\n"
 "\n"
 msgstr ""
-"Copyright (C) 2003-2009 Leandro A. F. Pereira. Смотрите файл COPYING для "
-"более подробной информации.\n"
+"Copyright (C) 2003-%d Leandro A. F. Pereira. Смотрите файл COPYING для более "
+"подробной информации.\n"
 "\n"
 
-#: hardinfo/hardinfo.c:50
+#: hardinfo/hardinfo.c:51
 #, c-format
 msgid ""
 "Compile-time options:\n"
@@ -35,17 +38,23 @@ msgid ""
 "  Library prefix:    %s\n"
 "  Compiled for:      %s\n"
 msgstr ""
+"Настройки компиляции:\n"
+"  Release version:    %s (%s)\n"
+"  BinReloc включен:   %s\n"
+"  Префикс данных:     %s\n"
+"  Префикс библиотеки: %s\n"
+"  Скомпилировано на:  %s\n"
 
-#: hardinfo/hardinfo.c:56 hardinfo/hardinfo.c:57 modules/computer.c:565
+#: hardinfo/hardinfo.c:57 hardinfo/hardinfo.c:58 modules/computer.c:565
 #: modules/devices/printers.c:138
 msgid "Yes"
 msgstr "Да"
 
-#: hardinfo/hardinfo.c:57 modules/computer.c:565 modules/devices/printers.c:138
+#: hardinfo/hardinfo.c:58 modules/computer.c:565 modules/devices/printers.c:138
 msgid "No"
 msgstr "Нет"
 
-#: hardinfo/hardinfo.c:68
+#: hardinfo/hardinfo.c:69
 #, c-format
 msgid ""
 "Failed to find runtime data.\n"
@@ -58,36 +67,36 @@ msgstr ""
 "• Правильно ли установлен HardInfo?\n"
 "• Проверьте, существуют ли %s и %s и есть ли у вас право на чтение."
 
-#: hardinfo/hardinfo.c:75
+#: hardinfo/hardinfo.c:76
 #, c-format
 msgid ""
 "Modules:\n"
-"%-20s%-15s%-12s\n"
+"%-20s %-15s %-12s\n"
 msgstr ""
 "Модули:\n"
-"%-20s%-15s%-12s\n"
+"%-20s %-15s %-12s\n"
 
-#: hardinfo/hardinfo.c:76
+#: hardinfo/hardinfo.c:77
 msgid "File Name"
 msgstr "Имя файла"
 
-#: hardinfo/hardinfo.c:76 modules/computer.c:493 modules/computer.c:515
+#: hardinfo/hardinfo.c:77 modules/computer.c:493 modules/computer.c:515
 #: modules/computer.c:586 modules/devices/ia64/processor.c:152
 #: modules/devices/sh/processor.c:76 modules/network.c:331
 msgid "Name"
 msgstr "Название"
 
-#: hardinfo/hardinfo.c:76 modules/computer.c:291 modules/computer.c:466
+#: hardinfo/hardinfo.c:77 modules/computer.c:291 modules/computer.c:466
 #: modules/computer.c:468 modules/computer.c:556 modules/computer.c:564
 msgid "Version"
 msgstr "Версия"
 
-#: hardinfo/hardinfo.c:123
+#: hardinfo/hardinfo.c:124
 #, c-format
 msgid "Unknown benchmark ``%s'' or libbenchmark.so not loaded"
 msgstr "Тест ``%s'' неизвестен или библиотека libbenchmark.so не загружена"
 
-#: hardinfo/hardinfo.c:151
+#: hardinfo/hardinfo.c:152
 msgid "Don't know what to do. Exiting."
 msgstr "Неизвестно, что делать. Выход."
 
@@ -129,17 +138,17 @@ msgid "%.1f B"
 msgstr "%.1f Б"
 
 #: hardinfo/util.c:130
-#, fuzzy, c-format
+#, c-format
 msgid "%.1f KiB"
 msgstr "%.1f КиБ"
 
 #: hardinfo/util.c:132
-#, fuzzy, c-format
+#, c-format
 msgid "%.1f MiB"
 msgstr "%.1f МиБ"
 
 #: hardinfo/util.c:134
-#, fuzzy, c-format
+#, c-format
 msgid "%.1f GiB"
 msgstr "%.1f ГиБ"
 
@@ -153,55 +162,55 @@ msgstr "%.1f ТиБ"
 msgid "%.1f PiB"
 msgstr "%.1f ПиБ"
 
-#: hardinfo/util.c:352
+#: hardinfo/util.c:367
 msgid "Error"
 msgstr "Ошибка"
 
-#: hardinfo/util.c:352 hardinfo/util.c:368
+#: hardinfo/util.c:367 hardinfo/util.c:383
 msgid "Warning"
 msgstr "Предупреждение"
 
-#: hardinfo/util.c:367
+#: hardinfo/util.c:382
 msgid "Fatal Error"
 msgstr "Фатальная ошибка"
 
-#: hardinfo/util.c:392
+#: hardinfo/util.c:407
 msgid "creates a report and prints to standard output"
 msgstr "создаёт отчёт и выводит на стандартный вывод"
 
-#: hardinfo/util.c:398
+#: hardinfo/util.c:413
 msgid "chooses a report format (text, html)"
 msgstr "выбирает формат отчёта (text, html)"
 
-#: hardinfo/util.c:404
+#: hardinfo/util.c:419
 msgid "run benchmark; requires benchmark.so to be loaded"
 msgstr "запуск теста; требует, чтобы benchmark.so был загружен"
 
-#: hardinfo/util.c:410
+#: hardinfo/util.c:425
 msgid "lists modules"
 msgstr "список модулей"
 
-#: hardinfo/util.c:416
+#: hardinfo/util.c:431
 msgid "specify module to load"
 msgstr "укажите модуль для загрузки"
 
-#: hardinfo/util.c:422
+#: hardinfo/util.c:437
 msgid "automatically load module dependencies"
 msgstr "автоматически загружает зависимости модулей"
 
-#: hardinfo/util.c:429
+#: hardinfo/util.c:444
 msgid "run in XML-RPC server mode"
 msgstr "запуск в режиме сервера XML-RPC"
 
-#: hardinfo/util.c:436
+#: hardinfo/util.c:451
 msgid "shows program version and quit"
 msgstr "показывает версию программы и выходит"
 
-#: hardinfo/util.c:441
+#: hardinfo/util.c:456
 msgid "- System Profiler and Benchmark tool"
 msgstr "- Инструмент для тестирования и проверки свойств системы"
 
-#: hardinfo/util.c:451
+#: hardinfo/util.c:466
 #, c-format
 msgid ""
 "Unrecognized arguments.\n"
@@ -210,29 +219,29 @@ msgstr ""
 "Неизвестные аргументы.\n"
 "Используйте `%s --help' для справки.\n"
 
-#: hardinfo/util.c:517
+#: hardinfo/util.c:532
 #, c-format
 msgid "Couldn't find a Web browser to open URL %s."
 msgstr "Не удаётся найти веб-браузер для открытия URL %s."
 
-#: hardinfo/util.c:866
+#: hardinfo/util.c:881
 #, c-format
 msgid "Module \"%s\" depends on module \"%s\", load it?"
 msgstr "Модуль \"%s\" зависит от модуля \"%s\", загрузить его?"
 
-#: hardinfo/util.c:889
+#: hardinfo/util.c:904
 #, c-format
 msgid "Module \"%s\" depends on module \"%s\"."
 msgstr "Модуль \"%s\" зависит от модуля \"%s\"."
 
-#: hardinfo/util.c:934
+#: hardinfo/util.c:949
 #, c-format
 msgid "No module could be loaded. Check permissions on \"%s\" and try again."
 msgstr ""
 "Модули не могут быть загружены. Проверьте разрешения на \"%s\" и попробуйте "
 "снова."
 
-#: hardinfo/util.c:938
+#: hardinfo/util.c:953
 msgid ""
 "No module could be loaded. Please use hardinfo -l to list all available "
 "modules and try again with a valid module list."
@@ -241,31 +250,31 @@ msgstr ""
 "получения списка доступных модулей и попробуйте снова с правильным списком "
 "модулей."
 
-#: hardinfo/util.c:1114
+#: hardinfo/util.c:1133
 #, c-format
 msgid "Scanning: %s..."
 msgstr "Сканирование: %s..."
 
-#: hardinfo/util.c:1124 shell/callbacks.c:67 shell/shell.c:303
-#: shell/shell.c:721 shell/shell.c:1701 modules/benchmark.c:445
+#: hardinfo/util.c:1143 shell/callbacks.c:77 shell/shell.c:307
+#: shell/shell.c:766 shell/shell.c:1808 modules/benchmark.c:445
 #: modules/benchmark.c:453
 msgid "Done."
 msgstr "Выполнено."
 
-#: shell/callbacks.c:47
+#: shell/callbacks.c:48 shell/callbacks.c:56
 msgid "Save Image"
 msgstr "Сохранить изображение"
 
-#: shell/callbacks.c:63
+#: shell/callbacks.c:73
 msgid "Saving image..."
 msgstr "Сохранение изображения..."
 
-#: shell/callbacks.c:153
+#: shell/callbacks.c:163
 #, c-format
 msgid "%s Module"
 msgstr "%s модуль"
 
-#: shell/callbacks.c:160
+#: shell/callbacks.c:174
 #, c-format
 msgid ""
 "Written by %s\n"
@@ -274,81 +283,80 @@ msgstr ""
 "Автор программы %s\n"
 "Лицензия %s"
 
-#: shell/callbacks.c:174
+#: shell/callbacks.c:188
 #, c-format
 msgid "No about information is associated with the %s module."
 msgstr "Нет информации о модуле %s."
 
-#: shell/callbacks.c:189
+#: shell/callbacks.c:203
 msgid "Author:"
 msgstr "Автор:"
 
-#: shell/callbacks.c:192
+#: shell/callbacks.c:206
 msgid "Contributors:"
 msgstr "Участники:"
 
-#: shell/callbacks.c:196
+#: shell/callbacks.c:210
 msgid "Based on work by:"
 msgstr "Основан на работах:"
 
-#: shell/callbacks.c:197
+#: shell/callbacks.c:211
 msgid "MD5 implementation by Colin Plumb (see md5.c for details)"
 msgstr "Реализация MD5 от Colin Plumb (см. подробности в md5.c)"
 
-#: shell/callbacks.c:198
+#: shell/callbacks.c:212
 msgid "SHA1 implementation by Steve Reid (see sha1.c for details)"
 msgstr "Реализация SHA1 от Steve Reid (см. подробности в sha1.c) "
 
-#: shell/callbacks.c:199
+#: shell/callbacks.c:213
 msgid "Blowfish implementation by Paul Kocher (see blowfich.c for details)"
 msgstr "Реализация Blowfish от Paul Kocher (см. подробности в blowfich.c)"
 
-#: shell/callbacks.c:200
+#: shell/callbacks.c:214
 msgid "Raytracing benchmark by John Walker (see fbench.c for details)"
 msgstr "Тест Raytracing от John Walker (см. подробности в fbench.c)"
 
-#: shell/callbacks.c:201
+#: shell/callbacks.c:215
 msgid "FFT benchmark by Scott Robert Ladd (see fftbench.c for details)"
 msgstr "Тест FFT Скотта от Robert Ladd (см. подробности в fbench.c)"
 
-#: shell/callbacks.c:202
+#: shell/callbacks.c:216
 msgid "Some code partly based on x86cpucaps by Osamu Kayasono"
 msgstr "Часть кода основана на x86cpucaps от Osamu Kayasono"
 
-#: shell/callbacks.c:203
+#: shell/callbacks.c:217
 msgid "Vendor list based on GtkSysInfo by Pissens Sebastien"
 msgstr "Список поставщиков основан на GtkSysInfo от Pissens Sebastien"
 
-#: shell/callbacks.c:204
+#: shell/callbacks.c:218
 msgid "DMI support based on code by Stewart Adam"
 msgstr "Поддержка DMI основана на коде от Stewart Adam"
 
-#: shell/callbacks.c:205
+#: shell/callbacks.c:219
 msgid "SCSI support based on code by Pascal F. Martin"
 msgstr "Поддержка SCSI основана на коде от Pascal F. Martin"
 
-#: shell/callbacks.c:209
-#, fuzzy
+#: shell/callbacks.c:223
 msgid "Jakub Szypulka"
-msgstr "Jakub Szypulka"
+msgstr ""
 
-#: shell/callbacks.c:210
+#: shell/callbacks.c:224
 msgid "Tango Project"
 msgstr "Проект Tango"
 
-#: shell/callbacks.c:211
+#: shell/callbacks.c:225
 msgid "The GNOME Project"
 msgstr "Проект GNOME"
 
-#: shell/callbacks.c:212
+#: shell/callbacks.c:226
 msgid "VMWare, Inc. (USB icon from VMWare Workstation 6)"
 msgstr "VMWare, Inc. (значок USB из VMWare Workstation 6)"
 
-#: shell/callbacks.c:224
+#: shell/callbacks.c:244
 msgid "System information and benchmark tool"
 msgstr "Информация о системе и тестирование"
 
-#: shell/callbacks.c:229
+#: shell/callbacks.c:249
 msgid ""
 "HardInfo is free software; you can redistribute it and/or modify it under "
 "the terms of the GNU General Public License as published by the Free "
@@ -455,35 +463,35 @@ msgstr "Управляет боковой панелью"
 msgid "_Toolbar"
 msgstr "_Панель инструментов"
 
-#: shell/report.c:493
+#: shell/report.c:494 shell/report.c:502
 msgid "Save File"
 msgstr "Сохранить файл"
 
-#: shell/report.c:619
+#: shell/report.c:629
 msgid "Cannot create ReportContext. Programming bug?"
 msgstr "Не могу создать ReportContext. Ошибка программирования?"
 
-#: shell/report.c:638
+#: shell/report.c:648
 msgid "Open the report with your web browser?"
 msgstr "Открыть отчёт в веб-браузере?"
 
-#: shell/report.c:666
+#: shell/report.c:682
 msgid "Generating report..."
 msgstr "Создаётся отчёт..."
 
-#: shell/report.c:676
+#: shell/report.c:692
 msgid "Report saved."
 msgstr "Отчёт сохранён."
 
-#: shell/report.c:678
+#: shell/report.c:694
 msgid "Error while creating the report."
 msgstr "Ошибка во время создания отчёта."
 
-#: shell/report.c:780
+#: shell/report.c:796
 msgid "Generate Report"
 msgstr "Создать отчёт"
 
-#: shell/report.c:797
+#: shell/report.c:821
 msgid ""
 "<big><b>Generate Report</b></big>\n"
 "Please choose the information that you wish to view in your report:"
@@ -491,37 +499,41 @@ msgstr ""
 "<big><b>Создать отчёт</b></big>\n"
 "Пожалуйста выберите информацию для отображения в отчёте:"
 
-#: shell/report.c:857
+#: shell/report.c:893
 msgid "Select _None"
 msgstr "Выбор: нет"
 
-#: shell/report.c:864
+#: shell/report.c:904
 msgid "Select _All"
 msgstr "Выбор: все"
 
-#: shell/report.c:882
+#: shell/report.c:930
+msgid "_Cancel"
+msgstr ""
+
+#: shell/report.c:943
 msgid "_Generate"
 msgstr "_Сгенерировать"
 
-#: shell/shell.c:396
+#: shell/shell.c:408
 #, c-format
 msgid "%s - System Information"
 msgstr "%s - Информация о системе"
 
-#: shell/shell.c:401
+#: shell/shell.c:413
 msgid "System Information"
 msgstr "Информация о системе"
 
-#: shell/shell.c:708
+#: shell/shell.c:753
 msgid "Loading modules..."
 msgstr "Загрузка модулей..."
 
-#: shell/shell.c:1571
+#: shell/shell.c:1673
 #, c-format
 msgid "<b>%s → Summary</b>"
 msgstr "<b>%s → </b>"
 
-#: shell/shell.c:1679
+#: shell/shell.c:1782
 msgid "Updating..."
 msgstr "Обновление..."
 
@@ -802,9 +814,8 @@ msgid "Python3"
 msgstr ""
 
 #: modules/computer.c:204
-#, fuzzy
 msgid "Perl"
-msgstr "Perl"
+msgstr ""
 
 #: modules/computer.c:205
 msgid "Perl6 (VM)"
@@ -4122,21 +4133,6 @@ msgstr ""
 #: modules/network/net.c:479
 msgid "Broadcast Address"
 msgstr ""
-
-#~ msgid ""
-#~ "Compile-time options:\n"
-#~ "  Release version:   %s (%s)\n"
-#~ "  BinReloc enabled:  %s\n"
-#~ "  Data prefix:       %s\n"
-#~ "  Library prefix:    %s\n"
-#~ "  Compiled on:       %s %s (%s)\n"
-#~ msgstr ""
-#~ "Настройки компиляции:\n"
-#~ "  Release version:    %s (%s)\n"
-#~ "  BinReloc включен:   %s\n"
-#~ "  Префикс данных:     %s\n"
-#~ "  Префикс библиотеки: %s\n"
-#~ "  Скомпилировано на:  %s %s (%s)\n"
 
 #~ msgid "Y_es"
 #~ msgstr "Есть"

--- a/po/ru.po
+++ b/po/ru.po
@@ -128,9 +128,9 @@ msgstr[2] "%d минут"
 #, c-format
 msgid "%d second"
 msgid_plural "%d seconds"
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
+msgstr[0] "секунда"
+msgstr[1] "секунды"
+msgstr[2] "секунд"
 
 #: hardinfo/util.c:128
 #, c-format
@@ -4187,12 +4187,6 @@ msgstr ""
 
 #~ msgid "XFree86 version"
 #~ msgstr "Версия XFree86"
-
-#~ msgid "%d hour and "
-#~ msgid_plural "%d hours and "
-#~ msgstr[0] "%d час и"
-#~ msgstr[1] "%d часа и"
-#~ msgstr[2] "%d часов и"
 
 #~ msgid "HardInfo cannot run without loading the additional module."
 #~ msgstr "HardInfo не может быть запущен без дополнительного модуля."

--- a/shell/callbacks.c
+++ b/shell/callbacks.c
@@ -199,32 +199,34 @@ void cb_about()
 {
     Shell *shell = shell_get_main_shell();
     GtkWidget *about;
+    gchar *copyright = NULL;
     const gchar *authors[] = {
-	_("Author:"),
-	"Leandro A. F. Pereira",
-	"",
-	_("Contributors:"),
-	"Agney Lopes Roth Ferraz",
-	"Andrey Esin",
-	"",
-	_("Based on work by:"),
-	_("MD5 implementation by Colin Plumb (see md5.c for details)"),
-	_("SHA1 implementation by Steve Reid (see sha1.c for details)"),
-	_("Blowfish implementation by Paul Kocher (see blowfich.c for details)"),
-	_("Raytracing benchmark by John Walker (see fbench.c for details)"),
-	_("FFT benchmark by Scott Robert Ladd (see fftbench.c for details)"),
-	_("Some code partly based on x86cpucaps by Osamu Kayasono"),
-	_("Vendor list based on GtkSysInfo by Pissens Sebastien"),
-	_("DMI support based on code by Stewart Adam"),
-	_("SCSI support based on code by Pascal F. Martin"),
-	NULL
+        _("Author:"),
+        "Leandro A. F. Pereira",
+        "",
+        _("Contributors:"),
+        "Agney Lopes Roth Ferraz",
+        "Andrey Esin",
+        "Burt P.",
+        "",
+        _("Based on work by:"),
+        _("MD5 implementation by Colin Plumb (see md5.c for details)"),
+        _("SHA1 implementation by Steve Reid (see sha1.c for details)"),
+        _("Blowfish implementation by Paul Kocher (see blowfich.c for details)"),
+        _("Raytracing benchmark by John Walker (see fbench.c for details)"),
+        _("FFT benchmark by Scott Robert Ladd (see fftbench.c for details)"),
+        _("Some code partly based on x86cpucaps by Osamu Kayasono"),
+        _("Vendor list based on GtkSysInfo by Pissens Sebastien"),
+        _("DMI support based on code by Stewart Adam"),
+        _("SCSI support based on code by Pascal F. Martin"),
+        NULL
     };
     const gchar *artists[] = {
-	_("Jakub Szypulka"),
-	_("Tango Project"),
-	_("The GNOME Project"),
-	_("VMWare, Inc. (USB icon from VMWare Workstation 6)"),
-	NULL
+        "Jakub Szypulka",
+        _("Tango Project"),
+        _("The GNOME Project"),
+        _("VMWare, Inc. (USB icon from VMWare Workstation 6)"),
+        NULL
     };
 
     about = gtk_about_dialog_new();
@@ -236,10 +238,10 @@ void cb_about()
     gtk_about_dialog_set_name(GTK_ABOUT_DIALOG(about), "HardInfo");
 #endif
 
+    copyright = g_strdup_printf("Copyright \302\251 2003-%d Leandro A. F. Pereira", HARDINFO_COPYRIGHT_LATEST_YEAR);
+
     gtk_about_dialog_set_version(GTK_ABOUT_DIALOG(about), VERSION);
-    gtk_about_dialog_set_copyright(GTK_ABOUT_DIALOG(about),
-				   "Copyright \302\251 2003-2016 "
-				   "Leandro A. F. Pereira");
+    gtk_about_dialog_set_copyright(GTK_ABOUT_DIALOG(about), copyright);
     gtk_about_dialog_set_comments(GTK_ABOUT_DIALOG(about),
 				  _("System information and benchmark tool"));
     gtk_about_dialog_set_logo(GTK_ABOUT_DIALOG(about),
@@ -265,6 +267,8 @@ void cb_about()
 
     gtk_dialog_run(GTK_DIALOG(about));
     gtk_widget_destroy(about);
+
+    g_free(copyright);
 }
 
 void cb_generate_report()


### PR DESCRIPTION
* Makes the copyright line a c-format with the latest year as %d so the line doesn't have to be retranslated each year.
* Restores the Compile-Time Options translations
* Adds a space between columns in the module list table.

And some changes to the about dialog:
* Use a define for copyright latest year, also used by
  `hardinfo --version`
* Don't translate Jakub Szypulka
* Add myself to contributors list

And make sure that the entire set of (Days, Hours, Minutes, Seconds) exists for all languages so they are not mixed with English. The Russian form of "second/seconds" are from Google Translate, so feel free to correct them if wrong.