### PR TITLE
A trail of related things

### DIFF
--- a/benchmark.conf
+++ b/benchmark.conf
@@ -51,6 +51,8 @@ AMD Athlon(tm) XP 2200+=22.197|1782 MHz|Unknown
 2x Intel(R) Pentium(R) 4 CPU 3.06GHz=7.454|3065 MHz|Unknown
 2x AMD Processor model unknown=5.242|3006 MHz|Unknown
 2x AMD Turion(tm) 64 X2 Mobile Technology TL-62=7.519|800 MHz|Unknown
+4x ARM Cortex-A53 r0p4 (Aarch32)=11.95|1200 MHz|Unknown
+ARM ARM1176 r0p7 (Aarch32)=114.57|900 MHz|Unknown
 [CPU CryptoHash]
 4x Intel(R) Atom(TM) CPU330 @ 1.60GHz=105.569|1596 MHz|Unknown
 2x Intel(R) Core(TM)2 Duo CPU T5250@ 1.50GHz=102.949|1000 MHz|Unknown
@@ -308,4 +310,6 @@ AMD Sempron(tm) Processor 3600+=5.696|1000 MHz|Unknown
 AMD Athlon(tm)=4.475|2305 MHz|Unknown
 2x AMD Athlon(tm) X2 Dual Core Processor BE-2300=4.373|1899 MHz|Unknown
 2x Intel(R) Core(TM)2 Duo CPU E6750@ 2.66GHz=4.096|2671 MHz|Unknown
-[CPU ZLib]
+[CPU Zlib]
+4x ARM Cortex-A53 r0p4 (Aarch32)=0.18|1200 MHz|Unknown
+ARM ARM1176 r0p7 (Aarch32)=0.01|900 MHz|Unknown

--- a/includes/arm/processor-platform.h
+++ b/includes/arm/processor-platform.h
@@ -23,7 +23,7 @@
 
 struct _Processor {
     gchar *model_name;
-    gchar *decoded_name;
+    gchar *linux_name;
     gchar *flags;
     gfloat bogomips;
 

--- a/includes/devices.h
+++ b/includes/devices.h
@@ -40,6 +40,7 @@ GSList *processor_scan(void);
 void get_processor_strfamily(Processor * processor);
 gchar *processor_get_detailed_info(Processor * processor);
 gchar *processor_get_info(GSList * processors);
+gchar *processor_describe(GSList * processors);
 
 /* Memory */
 void init_memory_labels(void);

--- a/includes/dt_util.h
+++ b/includes/dt_util.h
@@ -31,9 +31,9 @@ enum {
     DTP_DMAS,    /* dma-specifier list */
 };
 
-/* simplest, no aliases.
+/* simplest, no aliases, doesn't require an existing dt.
  * use dtr_get_prop_str() for complete. */
-char* dtr_get_string(const char *p);
+char* dtr_get_string(const char *p, int decode);
 
 typedef uint32_t dt_uint; /* big-endian */
 

--- a/modules/devices.c
+++ b/modules/devices.c
@@ -248,7 +248,7 @@ gchar *get_motherboard(void)
 #endif
 
     /* use device tree "model" */
-    board_vendor = dtr_get_string("/model");
+    board_vendor = dtr_get_string("/model", 0);
     if (board_vendor != NULL)
         return board_vendor;
 

--- a/modules/devices.c
+++ b/modules/devices.c
@@ -126,19 +126,45 @@ gchar *lginterval = NULL;
 
 #include <vendor.h>
 
+gint proc_cmp (Processor *a, Processor *b) {
+    return g_strcmp0(a->model_name, b->model_name);
+}
+
+gchar *processor_describe(GSList * processors)
+{
+    gchar *ret = g_strdup("");
+    GSList *tmp, *l;
+    Processor *p;
+    gchar *cur_str = NULL;
+    gint cur_count = 0;
+
+    tmp = g_slist_copy(processors);
+    tmp = g_slist_sort(tmp, (GCompareFunc)proc_cmp);
+
+    for (l = tmp; l; l = l->next) {
+        p = (Processor*)l->data;
+        if (cur_str == NULL) {
+            cur_str = p->model_name;
+            cur_count = 1;
+        } else {
+            if(g_strcmp0(cur_str, p->model_name)) {
+                ret = h_strdup_cprintf("%s%dx %s", ret, strlen(ret) ? " + " : "", cur_count, cur_str);
+                cur_str = p->model_name;
+                cur_count = 1;
+            } else {
+                cur_count++;
+            }
+        }
+    }
+    ret = h_strdup_cprintf("%s%dx %s", ret, strlen(ret) ? " + " : "", cur_count, cur_str);
+    g_slist_free(tmp);
+    return ret;
+}
+
 gchar *get_processor_name(void)
 {
     scan_processors(FALSE);
-
-    Processor *p = (Processor *) processors->data;
-
-    if (g_slist_length(processors) > 1) {
-	return idle_free(g_strdup_printf("%dx %s",
-					 g_slist_length(processors),
-					 p->model_name));
-    } else {
-	return p->model_name;
-    }
+    return processor_describe(processors);
 }
 
 gchar *get_storage_devices(void)

--- a/modules/devices/arm/processor.c
+++ b/modules/devices/arm/processor.c
@@ -73,7 +73,7 @@ processor_scan(void)
             processor->id = atol(tmp[1]);
 
             if (rep_pname)
-                processor->model_name = g_strdup(rep_pname);
+                processor->linux_name = g_strdup(rep_pname);
 
             g_strfreev(tmp);
             continue;
@@ -89,11 +89,11 @@ processor_scan(void)
             processor->id = 0;
 
             if (rep_pname)
-                processor->model_name = g_strdup(rep_pname);
+                processor->linux_name = g_strdup(rep_pname);
         }
 
         if (processor) {
-            get_str("model name", processor->model_name);
+            get_str("model name", processor->linux_name);
             get_str("Features", processor->flags);
             get_float("BogoMIPS", processor->bogomips);
 
@@ -138,7 +138,7 @@ processor_scan(void)
         processor = (Processor *) pi->data;
 
         /* strings can't be null or segfault later */
-        STRIFNULL(processor->model_name, _("ARM Processor") );
+        STRIFNULL(processor->linux_name, _("ARM Processor") );
         EMPIFNULL(processor->flags);
         UNKIFNULL(processor->cpu_implementer);
         UNKIFNULL(processor->cpu_architecture);
@@ -146,11 +146,11 @@ processor_scan(void)
         UNKIFNULL(processor->cpu_part);
         UNKIFNULL(processor->cpu_revision);
 
-        processor->decoded_name = arm_decoded_name(
+        processor->model_name = arm_decoded_name(
             processor->cpu_implementer, processor->cpu_part,
             processor->cpu_variant, processor->cpu_revision,
-            processor->cpu_architecture, processor->model_name);
-        UNKIFNULL(processor->decoded_name);
+            processor->cpu_architecture, processor->linux_name);
+        UNKIFNULL(processor->model_name);
 
         /* topo & freq */
         processor->cpufreq = cpufreq_new(processor->id);
@@ -233,8 +233,8 @@ processor_get_detailed_info(Processor *processor)
                        "%s"
                        "%s",    /* empty */
                    _("Processor"),
-                   _("Linux Name"), processor->model_name,
-                   _("Decoded Name"), processor->decoded_name,
+                   _("Linux Name"), processor->linux_name,
+                   _("Decoded Name"), processor->model_name,
                    _("Mode"), arm_mode_str[processor->mode],
                    _("Frequency"), processor->cpu_mhz, _("MHz"),
                    _("BogoMips"), processor->bogomips,

--- a/modules/devices/devicetree.c
+++ b/modules/devices/devicetree.c
@@ -148,6 +148,7 @@ gchar *get_node(char *np) {
     return ret;
 }
 
+/* different from  dtr_get_string() in that it re-uses the existing dt */
 char *get_dt_string(char *path, int decode) {
     dtr_obj *obj;
     char *ret = NULL;

--- a/modules/devices/devicetree/dt_util.c
+++ b/modules/devices/devicetree/dt_util.c
@@ -441,10 +441,16 @@ char *dtr_get_prop_str(dtr *s, dtr_obj *node, const char *name) {
     return ret;
 }
 
-char *dtr_get_string(const char *p) {
+char *dtr_get_string(const char *p, int decode) {
     dtr *dt = dtr_new_x(NULL, 1);
-    char *ret;
-    ret = dtr_get_prop_str(dt, NULL, p);
+    dtr_obj *obj;
+    char *ret = NULL;
+    if (decode) {
+        obj = dtr_get_prop_obj(dt, NULL, p);
+        ret = dtr_str(obj);
+        dtr_obj_free(obj);
+    } else
+        ret = dtr_get_prop_str(dt, NULL, p);
     dtr_free(dt);
     return ret;
 }


### PR DESCRIPTION
* Benchmark: fix zlib section name, add some ARM results
* ... leads to using the decoded name for ARM instead of the generic one
* ... leads to needing better support from get_processor_name() when there are a mix of different cores
