### PR TITLE
Expanded series based on TotalCaesar659's "Making ... translatable" PR series

### DIFF
--- a/hardinfo/util.c
+++ b/hardinfo/util.c
@@ -1323,3 +1323,59 @@ gboolean g_strv_contains(const gchar * const * strv, const gchar *str) {
     return 0;
 }
 #endif
+
+/* Hardinfo labels that have # are truncated and/or hidden.
+ * Labels can't have $ because that is the delimiter in
+ * moreinfo. */
+gchar *hardinfo_clean_label(const gchar *v, int replacing) {
+    gchar *clean, *p;
+
+    p = clean = g_strdup(v);
+    while (*p != 0) {
+        switch(*p) {
+            case '#': case '$':
+                *p = '_';
+                break;
+            default:
+                break;
+        }
+        p++;
+    }
+    if (replacing)
+        g_free((gpointer)v);
+    return clean;
+}
+
+/* hardinfo uses the values as {ht,x}ml, apparently */
+gchar *hardinfo_clean_value(const gchar *v, int replacing) {
+    gchar *clean, *tmp;
+    gchar **vl;
+    if (v == NULL) return NULL;
+
+    vl = g_strsplit(v, "&", -1);
+    if (g_strv_length(vl) > 1)
+        clean = g_strjoinv("&amp;", vl);
+    else
+        clean = g_strdup(v);
+    g_strfreev(vl);
+
+    vl = g_strsplit(clean, "<", -1);
+    if (g_strv_length(vl) > 1) {
+        tmp = g_strjoinv("&lt;", vl);
+        g_free(clean);
+        clean = tmp;
+    }
+    g_strfreev(vl);
+
+    vl = g_strsplit(clean, ">", -1);
+    if (g_strv_length(vl) > 1) {
+        tmp = g_strjoinv("&gt;", vl);
+        g_free(clean);
+        clean = tmp;
+    }
+    g_strfreev(vl);
+
+    if (replacing)
+        g_free((gpointer)v);
+    return clean;
+}

--- a/hardinfo/vendor.c
+++ b/hardinfo/vendor.c
@@ -94,6 +94,27 @@ static const Vendor vendors[] = {
     {"American Megatrends", "American Megatrends", "www.ami.com"},
     {"Award", "Award Software International", "www.award-bios.com"},
     {"Phoenix", "Phoenix Technologies", "www.phoenix.com"},
+    /* x86 vendor strings */
+    { "AMDisbetter!", "Advanced Micro Devices", "www.amd.com" },
+    { "AuthenticAMD", "Advanced Micro Devices", "www.amd.com" },
+    { "CentaurHauls", "VIA (formerly Centaur Technology)", "www.via.tw" },
+    { "CyrixInstead", "Cyrix", "" },
+    { "GenuineIntel", "Intel", "www.intel.com" },
+    { "TransmetaCPU", "Transmeta", "" },
+    { "GenuineTMx86", "Transmeta", "" },
+    { "Geode by NSC", "National Semiconductor", "" },
+    { "NexGenDriven", "NexGen", "" },
+    { "RiseRiseRise", "Rise Technology", "" },
+    { "SiS SiS SiS", "Silicon Integrated Systems", "" },
+    { "UMC UMC UMC", "United Microelectronics Corporation", "" },
+    { "VIA VIA VIA", "VIA", "www.via.tw" },
+    { "Vortex86 SoC", "DMP Electronics", "" },
+    /* x86 VM vendor strings */
+    { "KVMKVMKVM", "KVM", "" },
+    { "Microsoft Hv", "Microsoft Hyper-V", "www.microsoft.com" },
+    { "lrpepyh vr", "Parallels", "" },
+    { "VMwareVMware", "VMware", "" },
+    { "XenVMMXenVMM", "Xen HVM", "" },
 };
 
 static GSList *vendor_list = NULL;

--- a/hardinfo/vendor.c
+++ b/hardinfo/vendor.c
@@ -28,7 +28,8 @@
 
 static const Vendor vendors[] = {
     {"ATI", "ATI Technologies", "www.ati.com"},
-    {"nVidia", "NVIDIA", "www.nvidia.com"},
+    {"nVidia", "nVidia", "www.nvidia.com"},
+    {"NVidia", "nVidia", "www.nvidia.com"},
     {"3Com", "3Com", "www.3com.com"},
     {"Intel", "Intel", "www.intel.com"},
     {"Cirrus Logic", "Cirrus Logic", "www.cirrus.com"},
@@ -110,48 +111,48 @@ void vendor_init(void)
 
     DEBUG("initializing vendor list");
     sync_manager_add_entry(&se);
-    
+
     path = g_build_filename(g_get_home_dir(), ".hardinfo", "vendor.conf", NULL);
     if (!g_file_test(path, G_FILE_TEST_EXISTS)) {
       DEBUG("local vendor.conf not found, trying system-wise");
       g_free(path);
       path = g_build_filename(params.path_data, "vendor.conf", NULL);
     }
-    
+
     if (g_file_test(path, G_FILE_TEST_EXISTS)) {
       GKeyFile *vendors;
       gchar *tmp;
       gint num_vendors;
-      
+
       DEBUG("loading %s", path);
-      
+
       vendors = g_key_file_new();
       if (g_key_file_load_from_file(vendors, path, 0, NULL)) {
         num_vendors = g_key_file_get_integer(vendors, "vendors", "number", NULL);
-        
+
         for (i = num_vendors - 1; i >= 0; i--) {
           Vendor *v = g_new0(Vendor, 1);
-          
+
           tmp = g_strdup_printf("vendor%d", i);
-          
+
           v->id   = g_key_file_get_string(vendors, tmp, "id", NULL);
           v->name = g_key_file_get_string(vendors, tmp, "name", NULL);
           v->url  = g_key_file_get_string(vendors, tmp, "url", NULL);
-          
+
           vendor_list = g_slist_prepend(vendor_list, v);
-          
+
           g_free(tmp);
         }
       }
-      
+
       g_key_file_free(vendors);
     } else {
       DEBUG("system-wise vendor.conf not found, using internal database");
-      
+
       for (i = G_N_ELEMENTS(vendors) - 1; i >= 0; i--) {
         vendor_list = g_slist_prepend(vendor_list, (gpointer) &vendors[i]);
       }
-    } 
+    }
 
     g_free(path);
 }
@@ -159,20 +160,20 @@ void vendor_init(void)
 const gchar *vendor_get_name(const gchar * id)
 {
     GSList *vendor;
-    
+
     if (!id) {
       return NULL;
     }
-    
+
     for (vendor = vendor_list; vendor; vendor = vendor->next) {
       Vendor *v = (Vendor *)vendor->data;
-      
+
       if (v && v->id && strstr(id, v->id)) {
-        return g_strdup(v->name);
+        return v->name;
       }
     }
 
-    return id;
+    return id; /* What about const? */
 }
 
 const gchar *vendor_get_url(const gchar * id)
@@ -182,12 +183,12 @@ const gchar *vendor_get_url(const gchar * id)
     if (!id) {
       return NULL;
     }
-    
+
     for (vendor = vendor_list; vendor; vendor = vendor->next) {
       Vendor *v = (Vendor *)vendor->data;
-      
+
       if (v && v->id && strstr(id, v->id)) {
-        return g_strdup(v->url);
+        return v->url;
       }
     }
 

--- a/includes/hardinfo.h
+++ b/includes/hardinfo.h
@@ -169,4 +169,12 @@ gchar *moreinfo_lookup(gchar *key);
 gboolean g_strv_contains(const gchar * const * strv, const gchar *str);
 #endif
 
+/* Hardinfo labels that have # are truncated and/or hidden.
+ * Labels can't have $ because that is the delimiter in
+ * moreinfo.
+ * replacing = true will free v */
+gchar *hardinfo_clean_label(const gchar *v, int replacing);
+/* hardinfo uses the values as {ht,x}ml, apparently */
+gchar *hardinfo_clean_value(const gchar *v, int replacing);
+
 #endif				/* __HARDINFO_H__ */

--- a/modules/computer/languages.c
+++ b/modules/computer/languages.c
@@ -20,6 +20,7 @@
 
 #include "hardinfo.h"
 #include "computer.h"
+#include "cpu_util.h" /* for UNKIFNULL() */
 
 void
 scan_languages(OperatingSystem * os)
@@ -67,43 +68,64 @@ scan_languages(OperatingSystem * os)
 
 	    g_strfreev(tmp);
 	} else {
-	    gchar *currlocale;
+        gchar *currlocale;
 
-	    retval = h_strdup_cprintf("$%s$%s=%s\n", retval, name, name, title);
+        retval = h_strdup_cprintf("$%s$%s=%s\n", retval, name, name, title);
 
-#define FIELD(f) f ? f : "(Unknown)"
-	    currlocale = g_strdup_printf(_("[Locale Information]\n"
-					 "Name=%s (%s)\n"
-					 "Source=%s\n"
-					 "Address=%s\n"
-					 "Email=%s\n"
-					 "Language=%s\n"
-					 "Territory=%s\n"
-					 "Revision=%s\n"
-					 "Date=%s\n"
-					 "Codeset=%s\n"),
-					 name, FIELD(title),
-					 FIELD(source), FIELD(address),
-					 FIELD(email), FIELD(language),
-					 FIELD(territory), FIELD(revision),
-					 FIELD(date), FIELD(codeset));
-#undef FIELD
+        UNKIFNULL(title);
+        UNKIFNULL(source);
+        UNKIFNULL(address);
+        UNKIFNULL(email);
+        UNKIFNULL(language);
+        UNKIFNULL(territory);
+        UNKIFNULL(revision);
+        UNKIFNULL(date);
+        UNKIFNULL(codeset);
 
-           moreinfo_add_with_prefix("COMP", name, currlocale);
+        /* values may have & */
+        title = hardinfo_clean_value(title, 1);
+        source = hardinfo_clean_value(source, 1);
+        address = hardinfo_clean_value(address, 1);
+        email = hardinfo_clean_value(email, 1);
+        language = hardinfo_clean_value(language, 1);
+        territory = hardinfo_clean_value(territory, 1);
 
-	    g_free(title);
-	    g_free(source);
-	    g_free(address);
-	    g_free(email);
-	    g_free(language);
-	    g_free(territory);
-	    g_free(revision);
-	    g_free(date);
-	    g_free(codeset);
-	    
-	    title = source = address = email = language = territory = \
-	        revision = date = codeset = NULL;
-	}
+        currlocale = g_strdup_printf("[%s]\n"
+        /* Name */     "%s=%s (%s)\n"
+        /* Source */   "%s=%s\n"
+        /* Address */  "%s=%s\n"
+        /* Email */    "%s=%s\n"
+        /* Language */ "%s=%s\n"
+        /* Territory */"%s=%s\n"
+        /* Revision */ "%s=%s\n"
+        /* Date */     "%s=%s\n"
+        /* Codeset */  "%s=%s\n",
+                     _("Locale Information"),
+                     _("Name"), name, title,
+                     _("Source"), source,
+                     _("Address"), address,
+                     _("E-mail"), email,
+                     _("Language"), language,
+                     _("Territory"), territory,
+                     _("Revision"), revision,
+                     _("Date"), date,
+                     _("Codeset"), codeset );
+
+        moreinfo_add_with_prefix("COMP", name, currlocale);
+
+        g_free(title);
+        g_free(source);
+        g_free(address);
+        g_free(email);
+        g_free(language);
+        g_free(territory);
+        g_free(revision);
+        g_free(date);
+        g_free(codeset);
+
+        title = source = address = email = language = territory = \
+            revision = date = codeset = NULL;
+    }
     }
 
     fclose(locale);

--- a/modules/computer/languages.c
+++ b/modules/computer/languages.c
@@ -72,7 +72,7 @@ scan_languages(OperatingSystem * os)
 	    retval = h_strdup_cprintf("$%s$%s=%s\n", retval, name, name, title);
 
 #define FIELD(f) f ? f : "(Unknown)"
-	    currlocale = g_strdup_printf("[Locale Information]\n"
+	    currlocale = g_strdup_printf(_("[Locale Information]\n"
 					 "Name=%s (%s)\n"
 					 "Source=%s\n"
 					 "Address=%s\n"
@@ -81,7 +81,7 @@ scan_languages(OperatingSystem * os)
 					 "Territory=%s\n"
 					 "Revision=%s\n"
 					 "Date=%s\n"
-					 "Codeset=%s\n",
+					 "Codeset=%s\n"),
 					 name, FIELD(title),
 					 FIELD(source), FIELD(address),
 					 FIELD(email), FIELD(language),

--- a/modules/computer/modules.c
+++ b/modules/computer/modules.c
@@ -124,7 +124,7 @@ scan_modules_do(void)
 #define NONE_IF_NULL(var) (var) ? (var) : "N/A"
 
 	/* create the module information string */
-	strmodule = g_strdup_printf("[Module Information]\n"
+	strmodule = g_strdup_printf(_("[Module Information]\n"
 				    "Path=%s\n"
 				    "Used Memory=%.2fKiB\n"
 				    "[Description]\n"
@@ -133,7 +133,7 @@ scan_modules_do(void)
 				    "Version Magic=%s\n"
 				    "[Copyright]\n"
 				    "Author=%s\n"
-				    "License=%s\n",
+				    "License=%s\n"),
 				    NONE_IF_NULL(filename),
 				    memory / 1024.0,
 				    modname,

--- a/modules/devices/devicetree.c
+++ b/modules/devices/devicetree.c
@@ -24,65 +24,10 @@
 #include <unistd.h>
 #include <sys/types.h>
 #include <stdint.h>
+#include "hardinfo.h"
 #include "devices.h"
 #include "cpu_util.h"
 #include "dt_util.h"
-
-/* Hardinfo labels that have # are truncated and/or hidden.
- * Labels can't have $ because that is the delimiter in
- * moreinfo. */
-gchar *hardinfo_clean_label(const gchar *v, int replacing) {
-    gchar *clean, *p;
-
-    p = clean = g_strdup(v);
-    while (*p != 0) {
-        switch(*p) {
-            case '#': case '$':
-                *p = '_';
-                break;
-            default:
-                break;
-        }
-        p++;
-    }
-    if (replacing)
-        g_free((gpointer)v);
-    return clean;
-}
-
-/* hardinfo uses the values as {ht,x}ml, apparently */
-gchar *hardinfo_clean_value(const gchar *v, int replacing) {
-    gchar *clean, *tmp;
-    gchar **vl;
-    if (v == NULL) return NULL;
-
-    vl = g_strsplit(v, "&", -1);
-    if (g_strv_length(vl) > 1)
-        clean = g_strjoinv("&amp;", vl);
-    else
-        clean = g_strdup(v);
-    g_strfreev(vl);
-
-    vl = g_strsplit(clean, "<", -1);
-    if (g_strv_length(vl) > 1) {
-        tmp = g_strjoinv("&lt;", vl);
-        g_free(clean);
-        clean = tmp;
-    }
-    g_strfreev(vl);
-
-    vl = g_strsplit(clean, ">", -1);
-    if (g_strv_length(vl) > 1) {
-        tmp = g_strjoinv("&gt;", vl);
-        g_free(clean);
-        clean = tmp;
-    }
-    g_strfreev(vl);
-
-    if (replacing)
-        g_free((gpointer)v);
-    return clean;
-}
 
 #include "devicetree/rpi_data.c"
 #include "devicetree/pmac_data.c"

--- a/modules/devices/inputdevices.c
+++ b/modules/devices/inputdevices.c
@@ -94,32 +94,32 @@ __scan_input_devices(void)
 				 	  input_icons,
 					  tmp, name,
 					  input_devices[d].icon);
-	    gchar *strhash = g_strdup_printf("[Device Information]\n"
+	    gchar *strhash = g_strdup_printf(_("[Device Information]\n"
 					     "Name=%s\n"
 					     "Type=%s\n"
-					     "Bus=0x%x\n",
+					     "Bus=0x%x\n"),
 					     name,
 					     input_devices[d].name,
 					     bus);
 
 	    const gchar *url = vendor_get_url(name);
 	    if (url) {
-	    	strhash = h_strdup_cprintf("Vendor=%s (%s)\n",
+	    	strhash = h_strdup_cprintf(_("Vendor=%s (%s)\n"),
 					  strhash,
 					  vendor_get_name(name),
 					  url);
 	    } else {
-	    	strhash = h_strdup_cprintf("Vendor=%x\n",
+	    	strhash = h_strdup_cprintf(_("Vendor=%x\n"),
 					  strhash,
 					  vendor);
 	    }
 
-	    strhash = h_strdup_cprintf("Product=0x%x\n"
-				      "Version=0x%x\n",
+	    strhash = h_strdup_cprintf(_("Product=0x%x\n"
+				      "Version=0x%x\n"),
 				      strhash, product, version);
 	    
             if (phys && phys[1] != 0) {
-                 strhash = h_strdup_cprintf("Connected to=%s\n",
+                 strhash = h_strdup_cprintf(_("Connected to=%s\n"),
                                             strhash, phys);
             }
 

--- a/modules/devices/inputdevices.c
+++ b/modules/devices/inputdevices.c
@@ -85,55 +85,55 @@ __scan_input_devices(void)
 	    if (name && strstr(name, "PC Speaker")) {
 	      d = 3;		// INPUT_PCSPKR
 	    }
-	
-	    tmp = g_strdup_printf("INP%d", ++n);
-	    input_list = h_strdup_cprintf("$%s$%s=\n",
-					 input_list,
-					 tmp, name);
-	    input_icons = h_strdup_cprintf("Icon$%s$%s=%s\n",
-				 	  input_icons,
-					  tmp, name,
-					  input_devices[d].icon);
-	    gchar *strhash = g_strdup_printf(_("[Device Information]\n"
-					     "Name=%s\n"
-					     "Type=%s\n"
-					     "Bus=0x%x\n"),
-					     name,
-					     input_devices[d].name,
-					     bus);
 
-	    const gchar *url = vendor_get_url(name);
-	    if (url) {
-	    	strhash = h_strdup_cprintf(_("Vendor=%s (%s)\n"),
-					  strhash,
-					  vendor_get_name(name),
-					  url);
-	    } else {
-	    	strhash = h_strdup_cprintf(_("Vendor=%x\n"),
-					  strhash,
-					  vendor);
-	    }
+        tmp = g_strdup_printf("INP%d", ++n);
+        input_list = h_strdup_cprintf("$%s$%s=\n",
+                     input_list,
+                     tmp, name);
+        input_icons = h_strdup_cprintf("Icon$%s$%s=%s\n",
+                      input_icons,
+                      tmp, name,
+                      input_devices[d].icon);
 
-	    strhash = h_strdup_cprintf(_("Product=0x%x\n"
-				      "Version=0x%x\n"),
-				      strhash, product, version);
-	    
-            if (phys && phys[1] != 0) {
-                 strhash = h_strdup_cprintf(_("Connected to=%s\n"),
-                                            strhash, phys);
-            }
+        const gchar *v_url = (gchar*)vendor_get_url(name);
+        const gchar *v_name = (gchar*)vendor_get_name(name);
+        gchar *v_str = NULL;
+        if (v_url != NULL)
+            v_str = g_strdup_printf("[0x%x] %s (%s)", vendor, v_name, v_url);
+        else
+            v_str = g_strdup_printf("0x%x", vendor);
+        v_str = hardinfo_clean_value(v_str, 1);
+        name = hardinfo_clean_value(name, 1);
 
-	    if (phys && strstr(phys, "ir")) {
-		 strhash = h_strdup_cprintf("InfraRed port=yes\n",
-				 	     strhash);
-	    }
-	    
-	    moreinfo_add_with_prefix("DEV", tmp, strhash);
-	    g_free(tmp);
+        gchar *strhash = g_strdup_printf("[%s]\n"
+                /* Name */   "%s=%s\n"
+                /* Type */   "%s=%s\n"
+                /* Bus */    "%s=0x%x\n"
+                /* Vendor */ "%s=%s\n"
+                /* Product */"%s=0x%x\n"
+                /* Version */"%s=0x%x\n",
+                        _("Device Information"),
+                        _("Name"), name,
+                        _("Type"), input_devices[d].name,
+                        _("Bus"), bus,
+                        _("Vendor"), v_str,
+                        _("Product"), product,
+                        _("Version"), version );
 
-	    g_free(phys);
-	    g_free(name);
-	}
+        if (phys && phys[1] != 0) {
+             strhash = h_strdup_cprintf("%s=%s\n", strhash, _("Connected to"), phys);
+        }
+
+        if (phys && strstr(phys, "ir")) {
+            strhash = h_strdup_cprintf("%s=%s\n", strhash, _("InfraRed port"), _("Yes") );
+        }
+
+        moreinfo_add_with_prefix("DEV", tmp, strhash);
+        g_free(tmp);
+        g_free(v_str);
+        g_free(phys);
+        g_free(name);
+    }
     }
 
     fclose(dev);

--- a/modules/devices/pci.c
+++ b/modules/devices/pci.c
@@ -107,9 +107,9 @@ scan_pci_do(void)
 	    if (freq)
 		strdevice = h_strdup_cprintf("Frequency=%dMHz\n", strdevice, freq);
 	    if (latency)
-		strdevice = h_strdup_cprintf("Latency=%d\n", strdevice, latency);
+		strdevice = h_strdup_cprintf(_("Latency=%d\n"), strdevice, latency);
 
-	    strdevice = h_strdup_cprintf("Bus Master=%s\n", strdevice, bus_master ? "Yes" : "No");
+	    strdevice = h_strdup_cprintf(_("Bus Master=%s\n"), strdevice, bus_master ? "Yes" : "No");
 	} else if (!strncmp(buf, "Kernel modules", 14)) {
 	    WALK_UNTIL(' ');
 	    WALK_UNTIL(':');
@@ -121,7 +121,7 @@ scan_pci_do(void)
 	    buf++;
 	    const gchar *oem_vendor_url = vendor_get_url(buf);
             if (oem_vendor_url) 
-                strdevice = h_strdup_cprintf("OEM Vendor=%s (%s)\n",
+                strdevice = h_strdup_cprintf(_("OEM Vendor=%s (%s)\n"),
                                             strdevice,
                                             vendor_get_name(buf),
                                             oem_vendor_url);
@@ -204,17 +204,17 @@ scan_pci_do(void)
                                 name);
 
 	    strhash = g_strdup_printf("PCI%d", n);
-	    strdevice = g_strdup_printf("[Device Information]\n"
+	    strdevice = g_strdup_printf(_("[Device Information]\n"
 					"Name=%s\n"
 					"Class=%s\n"
 					"Domain=%d\n"
-					"Bus, device, function=%d, %d, %d\n",
+					"Bus, device, function=%d, %d, %d\n"),
 					name, category, domain, bus,
 					device, function);
             
             const gchar *url = vendor_get_url(name);
             if (url) {
-                strdevice = h_strdup_cprintf("Vendor=%s (%s)\n",
+                strdevice = h_strdup_cprintf(_("Vendor=%s (%s)\n"),
                                             strdevice,
                                             vendor_get_name(name),
                                             url);

--- a/modules/devices/usb.c
+++ b/modules/devices/usb.c
@@ -41,51 +41,59 @@ void __scan_usb_sysfs_add_device(gchar * endpoint, int n)
     version = h_sysfs_read_float(endpoint, "version");
 
     if (!(mxpwr = h_sysfs_read_string(endpoint, "bMaxPower"))) {
-    	mxpwr = g_strdup("0 mA");
+    	mxpwr = g_strdup_printf("%d %s", 0 , _("mA") );
     }
 
     if (!(manufacturer = h_sysfs_read_string(endpoint, "manufacturer"))) {
-    	manufacturer = g_strdup("Unknown");
+    	manufacturer = g_strdup(_("(Unknown)"));
     }
 
     if (!(product = h_sysfs_read_string(endpoint, "product"))) {
-	if (classid == 9) {
-	    product = g_strdup_printf("USB %.2f Hub", version);
-	} else {
-	    product = g_strdup_printf("Unknown USB %.2f Device (class %d)", version, classid);
-	}
+        if (classid == 9) {
+            product = g_strdup_printf(_(/*/%.2f is version*/ "USB %.2f Hub"), version);
+        } else {
+            product = g_strdup_printf(_("Unknown USB %.2f Device (class %d)"), version, classid);
+        }
     }
 
-    const gchar *url = vendor_get_url(manufacturer);
-    if (url) {
-	tmp = g_strdup_printf("%s (%s)", vendor_get_name(manufacturer), url);
-	
-	g_free(manufacturer);
-	manufacturer = tmp;
+    const gchar *v_url = vendor_get_url(manufacturer);
+    const gchar *v_name = vendor_get_name(manufacturer);
+    gchar *v_str;
+    if (v_url != NULL) {
+        v_str = g_strdup_printf("%s (%s)", v_name, v_url);
+    } else {
+        v_str = g_strdup_printf("%s", manufacturer);
     }
 
     tmp = g_strdup_printf("USB%d", n);
     usb_list = h_strdup_cprintf("$%s$%s=\n", usb_list, tmp, product);
 
-    strhash = g_strdup_printf("[Device Information]\n"
-			      "Product=%s\n"
-			      "Manufacturer=%s\n"
-			      "Speed=%.2fMbit/s\n"
-			      "Max Current=%s\n"
-			      "[Misc]\n"
-			      "USB Version=%.2f\n"
-			      "Class=0x%x\n"
-			      "Vendor=0x%x\n"
-			      "Product ID=0x%x\n"
-			      "Bus=%d\n",
-			      product,
-			      manufacturer,
-			      speed,
-			      mxpwr,
-			      version, classid, vendor, prodid, bus);
+    strhash = g_strdup_printf("[%s]\n"
+             /* Product */      "%s=%s\n"
+             /* Manufacturer */ "%s=%s\n"
+             /* Speed */        "%s=%.2f %s\n"
+             /* Max Current */  "%s=%s\n"
+                  "[%s]\n"
+             /* USB Version */  "%s=%.2f\n"
+             /* Class */        "%s=0x%x\n"
+             /* Vendor */       "%s=0x%x\n"
+             /* Product ID */   "%s=0x%x\n"
+             /* Bus */          "%s=%d\n",
+                  _("Device Information"),
+                  _("Product"), product,
+                  _("Manufacturer"), v_str,
+                  _("Speed"), speed, _("Mbit/s"),
+                  _("Max Current"), mxpwr,
+                  _("Misc"),
+                  _("USB Version"), version,
+                  _("Class"), classid,
+                  _("Vendor ID"), vendor,
+                  _("Product ID"), prodid,
+                  _("Bus"), bus);
 
     moreinfo_add_with_prefix("DEV", tmp, strhash);
     g_free(tmp);
+    g_free(v_str);
     g_free(manufacturer);
     g_free(product);
     g_free(mxpwr);
@@ -106,7 +114,7 @@ gboolean __scan_usb_sysfs(void)
        moreinfo_del_with_prefix("DEV:USB");
 	g_free(usb_list);
     }
-    usb_list = g_strdup("[USB Devices]\n");
+    usb_list = g_strdup_printf("[%s]\n", _("USB Devices"));
 
     while ((filename = (gchar *) g_dir_read_name(sysfs))) {
 	gchar *endpoint =
@@ -145,7 +153,7 @@ gboolean __scan_usb_procfs(void)
 	moreinfo_del_with_prefix("DEV:USB");
 	g_free(usb_list);
     }
-    usb_list = g_strdup("[USB Devices]\n");
+    usb_list = g_strdup_printf("[%s]\n", _("USB Devices"));
 
     while (fgets(buffer, 128, dev)) {
 	tmp = buffer;
@@ -179,50 +187,68 @@ gboolean __scan_usb_procfs(void)
 	    if (product && *product == '\0') {
 		g_free(product);
 		if (classid == 9) {
-		    product = g_strdup_printf("USB %.2f Hub", ver);
+		    product = g_strdup_printf(_("USB %.2f Hub"), ver);
 		} else {
-		    product = g_strdup_printf("Unknown USB %.2f Device (class %d)", ver, classid);
+		    product = g_strdup_printf(_("Unknown USB %.2f Device (class %d)"), ver, classid);
 		}
 	    }
 
-	    if (classid == 9) {	/* hub */
-		usb_list = h_strdup_cprintf("[%s#%d]\n", usb_list, product, n);
-	    } else {		/* everything else */
-		usb_list = h_strdup_cprintf("$%s$%s=\n", usb_list, tmp, product);
+        if (classid == 9) {	/* hub */
+            usb_list = h_strdup_cprintf("[%s#%d]\n", usb_list, product, n);
+        } else {		/* everything else */
+            usb_list = h_strdup_cprintf("$%s$%s=\n", usb_list, tmp, product);
 
-		const gchar *url = vendor_get_url(manuf);
-		if (url) {
-		    gchar *tmp = g_strdup_printf("%s (%s)", vendor_get_name(manuf),
-						 url);
-		    g_free(manuf);
-		    manuf = tmp;
-		}
+        EMPIFNULL(manuf);
+        const gchar *v_url = vendor_get_url(manuf);
+        const gchar *v_name = vendor_get_name(manuf);
+        gchar *v_str = NULL;
+        if (strlen(manuf)) {
+            if (v_url != NULL)
+                v_str = g_strdup_printf("%s (%s)", v_name, v_url);
+            else
+                v_str = g_strdup_printf("%s", manuf);
+        }
+        UNKIFNULL(v_str);
+        UNKIFNULL(product);
 
-		gchar *strhash = g_strdup_printf("[Device Information]\n" "Product=%s\n",
-						 product);
-		if (manuf && strlen(manuf))
-		    strhash = h_strdup_cprintf("Manufacturer=%s\n", strhash, manuf);
+        gchar *strhash = g_strdup_printf("[%s]\n" "%s=%s\n" "%s=%s\n",
+                        _("Device Information"),
+                        _("Product"), product,
+                        _("Manufacturer"), v_str);
 
-		strhash = h_strdup_cprintf("[Port #%d]\n"
-					   "Speed=%.2fMbit/s\n"
-					   "Max Current=%s\n"
-					   "[Misc]\n"
-					   "USB Version=%.2f\n"
-					   "Revision=%.2f\n"
-					   "Class=0x%x\n"
-					   "Vendor=0x%x\n"
-					   "Product ID=0x%x\n"
-					   "Bus=%d\n" "Level=%d\n",
-					   strhash, port, speed, mxpwr, ver, rev, classid, vendor, prodid, bus, level);
+        strhash = h_strdup_cprintf("[%s #%d]\n"
+                  /* Speed */       "%s=%.2f %s\n"
+                  /* Max Current */ "%s=%s\n"
+                       "[%s]\n"
+                  /* USB Version */ "%s=%.2f\n"
+                  /* Revision */    "%s=%.2f\n"
+                  /* Class */       "%s=0x%x\n"
+                  /* Vendor */      "%s=0x%x\n"
+                  /* Product ID */  "%s=0x%x\n"
+                  /* Bus */         "%s=%d\n"
+                  /* Level */       "%s=%d\n",
+                       strhash,
+                       _("Port"), port,
+                       _("Speed"), speed, _("Mbit/s"),
+                       _("Max Current"), mxpwr,
+                       _("Misc"),
+                       _("USB Version"), ver,
+                       _("Revision"), rev,
+                       _("Class"), classid,
+                       _("Vendor ID"), vendor,
+                       _("Product ID"), prodid,
+                       _("Bus"), bus,
+                       _("Level"), level);
 
-		moreinfo_add_with_prefix("DEV", tmp, strhash);
-		g_free(tmp);
-	    }
+        moreinfo_add_with_prefix("DEV", tmp, strhash);
+        g_free(v_str);
+        g_free(tmp);
+        }
 
 	    g_free(manuf);
 	    g_free(product);
-	    manuf = g_strdup("");
-	    product = g_strdup("");
+	    manuf = NULL;
+	    product = NULL;
 	    port = classid = 0;
 	}
     }
@@ -274,35 +300,63 @@ void __scan_usb_lsusb_add_device(char *buffer, int bufsize, FILE * lsusb, int us
     }
 
     if (dev_class && strstr(dev_class, "0 (Defined at Interface level)")) {
-	g_free(dev_class);
-	if (int_class) {
-	    dev_class = int_class;
-	} else {
-	    dev_class = g_strdup("Unknown");
-	}
+        g_free(dev_class);
+        if (int_class) {
+            dev_class = int_class;
+        } else {
+            dev_class = g_strdup(_("(Unknown)"));
+        }
     } else
-	dev_class = g_strdup("Unknown");
+    dev_class = g_strdup(_("(Unknown)"));
 
     tmp = g_strdup_printf("USB%d", usb_device_number);
     usb_list = h_strdup_cprintf("$%s$%s=\n", usb_list, tmp, name);
 
-    strhash = g_strdup_printf("[Device Information]\n"
-			      "Product=%s\n"
-			      "Manufacturer=%s\n"
-			      "Max Current=%s\n"
-			      "[Misc]\n"
-			      "USB Version=%s\n"
-			      "Class=%s\n"
-			      "Vendor=0x%x\n"
-			      "Product ID=0x%x\n"
-			      "Bus=%d\n",
-			      product ? g_strstrip(product) : "Unknown",
-			      vendor ? g_strstrip(vendor) : "Unknown",
-			      max_power ? g_strstrip(max_power) : "Unknown",
-			      version ? g_strstrip(version) : "Unknown",
-			      dev_class ? g_strstrip(dev_class) : "Unknown", vendor_id, product_id, bus);
+    const gchar *v_url = vendor_get_url(vendor);
+    const gchar *v_name = vendor_get_name(vendor);
+    gchar *v_str;
+    if (v_url != NULL) {
+        v_str = g_strdup_printf("%s (%s)", v_name, v_url);
+    } else {
+        v_str = g_strdup_printf("%s", g_strstrip(vendor) );
+    }
+
+    if (max_power != NULL) {
+        int mA = atoi(g_strstrip(max_power));
+        gchar *trent_steel = g_strdup_printf("%d %s", mA, _("mA"));
+        g_free(max_power);
+        max_power = trent_steel;
+    }
+
+    UNKIFNULL(product);
+    UNKIFNULL(v_str);
+    UNKIFNULL(max_power);
+    UNKIFNULL(version);
+    UNKIFNULL(dev_class);
+
+    strhash = g_strdup_printf("[%s]\n"
+             /* Product */      "%s=%s\n"
+             /* Manufacturer */ "%s=%s\n"
+             /* Max Current */  "%s=%s\n"
+                            "[%s]\n"
+             /* USB Version */ "%s=%s\n"
+             /* Class */       "%s=%s\n"
+             /* Vendor ID */   "%s=0x%x\n"
+             /* Product ID */  "%s=0x%x\n"
+             /* Bus */         "%s=%d\n",
+                _("Device Information"),
+                _("Product"), g_strstrip(product),
+                _("Vendor"), v_str,
+                _("Max Current"), g_strstrip(max_power),
+                _("Misc"),
+                _("USB Version"), g_strstrip(version),
+                _("Class"), g_strstrip(dev_class),
+                _("Vendor ID"), vendor_id,
+                _("Product ID"), product_id,
+                _("Bus"), bus);
 
     moreinfo_add_with_prefix("DEV", tmp, strhash);
+    g_free(v_str);
     g_free(vendor);
     g_free(product);
     g_free(max_power);
@@ -356,25 +410,25 @@ gboolean __scan_usb_lsusb(void)
 
     if (usb_list) {
        moreinfo_del_with_prefix("DEV:USB");
-	g_free(usb_list);
+        g_free(usb_list);
     }
-    usb_list = g_strdup("[USB Devices]\n");
+    usb_list = g_strdup_printf("[%s]\n", _("USB Devices"));
 
     while (fgets(buffer, sizeof(buffer), temp_lsusb)) {
         if (g_str_has_prefix(buffer, "Bus ")) {
            __scan_usb_lsusb_add_device(buffer, sizeof(buffer), temp_lsusb, ++usb_device_number);
         }
     }
-    
+
     fclose(temp_lsusb);
-    
+
     return usb_device_number > 0;
 }
 
 void __scan_usb(void)
 {
     if (!__scan_usb_procfs()) {
-	if (!__scan_usb_sysfs()) {
+        if (!__scan_usb_sysfs()) {
              __scan_usb_lsusb();
         }
     }


### PR DESCRIPTION
Continuation of @TotalCaesar659's #129, #130, #131, #132.
* more strings are translatable.
* labels are broken out of c-format strings as described at #100.
* some code cleanup and a few bug fixes along the way.

I did similar work on usb.c, but only tested the __scan_usb_lsusb() method. I can't test __scan_usb_procfs() or __scan_usb_sysfs() because those do not work on any machine I have access to.