### PR TITLE
Benchmark result details

### DIFF
--- a/benchmark.conf
+++ b/benchmark.conf
@@ -51,8 +51,8 @@ AMD Athlon(tm) XP 2200+=22.197|1782 MHz|Unknown
 Intel(R) Pentium(R) 4 CPU 3.06GHz=7.454|2x 3065 MHz|Unknown
 AMD Processor model unknown=5.242|2x 3006 MHz|Unknown
 AMD Turion(tm) 64 X2 Mobile Technology TL-62=7.519|2x 800 MHz|Unknown
-Raspberry_Pi_3_Model_B_Rev_1_2;Broadcom_BCM2837;4800_00=11.97|4|Raspberry Pi 3 Model B Rev 1.2|Broadcom BCM2837|4x ARM Cortex-A53 r0p4 (AArch32)|4x 1200.00 MHz|945512|4
-Raspberry_Pi_Model_B_Rev_1;Broadcom_BCM2835;900_00=114.42|1|Raspberry Pi Model B Rev 1|Broadcom BCM2835|1x ARM ARM1176 r0p7 (AArch32)|1x 900.00 MHz|233620|1
+Raspberry_Pi_3_Model_B_Rev_1_2;Broadcom_BCM2837;4800_00=11.97|4|Raspberry Pi 3 Model B Rev 1.2|Broadcom BCM2837|4x ARM Cortex-A53 r0p4 (AArch32)|4x 1200.00 MHz|945512|4|Gallium 0.4 on llvmpipe (LLVM 3.9, 128 bits)
+Raspberry_Pi_Model_B_Rev_1;Broadcom_BCM2835;900_00=114.42|1|Raspberry Pi Model B Rev 1|Broadcom BCM2835|1x ARM ARM1176 r0p7 (AArch32)|1x 900.00 MHz|233620|1|
 [CPU CryptoHash]
 Intel(R) Atom(TM) CPU330 @ 1.60GHz=105.569|4x 1596 MHz|Unknown
 Intel(R) Core(TM)2 Duo CPU T5250@ 1.50GHz=102.949|2x 1000 MHz|Unknown
@@ -104,8 +104,8 @@ AMD Turion(tm) 64 Mobile Technology ML-37=42.208|2000 MHz|Unknown
 Intel(R) Xeon(R) CPU3040@ 1.86GHz=127.825|2x 1862 MHz|Unknown
 AMD Athlon(tm) XP 2500+=39.659|1792 MHz|Unknown
 Intel(R) Core(TM)2 Duo CPU T9500@ 2.60GHz=172.640|2x 2593 MHz|Unknown
-Raspberry_Pi_3_Model_B_Rev_1_2;Broadcom_BCM2837;4800_00=98.27|4|Raspberry Pi 3 Model B Rev 1.2|Broadcom BCM2837|4x ARM Cortex-A53 r0p4 (AArch32)|4x 1200.00 MHz|945512|4
-Raspberry_Pi_Model_B_Rev_1;Broadcom_BCM2835;900_00=11.70|1|Raspberry Pi Model B Rev 1|Broadcom BCM2835|1x ARM ARM1176 r0p7 (AArch32)|1x 900.00 MHz|233620|1
+Raspberry_Pi_3_Model_B_Rev_1_2;Broadcom_BCM2837;4800_00=98.27|4|Raspberry Pi 3 Model B Rev 1.2|Broadcom BCM2837|4x ARM Cortex-A53 r0p4 (AArch32)|4x 1200.00 MHz|945512|4|Gallium 0.4 on llvmpipe (LLVM 3.9, 128 bits)
+Raspberry_Pi_Model_B_Rev_1;Broadcom_BCM2835;900_00=11.70|1|Raspberry Pi Model B Rev 1|Broadcom BCM2835|1x ARM ARM1176 r0p7 (AArch32)|1x 900.00 MHz|233620|1|
 [CPU N-Queens]
 AMD Athlon(tm) 64 X2 Dual Core Processor 5400+=15.057|2x 1000 MHz|Unknown
 Genuine Intel(R) CPU T2080@ 1.73GHz=33.309|2x 800 MHz|Unknown
@@ -157,8 +157,8 @@ AMD Athlon(tm) XP processor 1800+=17.547|1533 MHz|Unknown
 Intel(R) Core(TM)2 Duo CPU T5750@ 2.00GHz=11.140|2x 1994 MHz|Unknown
 Intel(R) Core(TM)2 Duo CPU T7250@ 2.00GHz=11.387|2x 2001 MHz|Unknown
 Intel(R) Pentium(R) 4 CPU 1500MHz=28.460|1495 MHz|Unknown
-Raspberry_Pi_3_Model_B_Rev_1_2;Broadcom_BCM2837;4800_00=22.83|4|Raspberry Pi 3 Model B Rev 1.2|Broadcom BCM2837|4x ARM Cortex-A53 r0p4 (AArch32)|4x 1200.00 MHz|945512|4
-Raspberry_Pi_Model_B_Rev_1;Broadcom_BCM2835;900_00=65.80|1|Raspberry Pi Model B Rev 1|Broadcom BCM2835|1x ARM ARM1176 r0p7 (AArch32)|1x 900.00 MHz|233620|1
+Raspberry_Pi_3_Model_B_Rev_1_2;Broadcom_BCM2837;4800_00=22.83|4|Raspberry Pi 3 Model B Rev 1.2|Broadcom BCM2837|4x ARM Cortex-A53 r0p4 (AArch32)|4x 1200.00 MHz|945512|4|Gallium 0.4 on llvmpipe (LLVM 3.9, 128 bits)
+Raspberry_Pi_Model_B_Rev_1;Broadcom_BCM2835;900_00=65.80|1|Raspberry Pi Model B Rev 1|Broadcom BCM2835|1x ARM ARM1176 r0p7 (AArch32)|1x 900.00 MHz|233620|1|
 [FPU Raytracing]
 Intel(R) Core(TM) Duo CPUT2450@ 2.00GHz=28.359|2x 800 MHz|Unknown
 AMD Athlon(tm) XP 2200+=29.739|1782 MHz|Unknown
@@ -210,8 +210,8 @@ Intel(R) Pentium(R) M processor 1.80GHz=27.133|600 MHz|Unknown
 Intel(R) Celeron(R) CPU 2.80GHz=81.047|2793 MHz|Unknown
 Genuine Intel(R) CPU T1350@ 1.86GHz=222.178|1867 MHz|Unknown
 Intel(R) Pentium(R) 4 CPU 2.80GHz=28.658|2791 MHz|Unknown
-Raspberry_Pi_3_Model_B_Rev_1_2;Broadcom_BCM2837;4800_00=16.21|4|Raspberry Pi 3 Model B Rev 1.2|Broadcom BCM2837|4x ARM Cortex-A53 r0p4 (AArch32)|4x 1200.00 MHz|945512|4
-Raspberry_Pi_Model_B_Rev_1;Broadcom_BCM2835;900_00=112.48|1|Raspberry Pi Model B Rev 1|Broadcom BCM2835|1x ARM ARM1176 r0p7 (AArch32)|1x 900.00 MHz|233620|1
+Raspberry_Pi_3_Model_B_Rev_1_2;Broadcom_BCM2837;4800_00=16.21|4|Raspberry Pi 3 Model B Rev 1.2|Broadcom BCM2837|4x ARM Cortex-A53 r0p4 (AArch32)|4x 1200.00 MHz|945512|4|Gallium 0.4 on llvmpipe (LLVM 3.9, 128 bits)
+Raspberry_Pi_Model_B_Rev_1;Broadcom_BCM2835;900_00=112.48|1|Raspberry Pi Model B Rev 1|Broadcom BCM2835|1x ARM ARM1176 r0p7 (AArch32)|1x 900.00 MHz|233620|1|
 PowerPC 740/750=161.312647|280.00 MHz|Unknown
 [CPU Blowfish]
 Intel(R) Pentium(R) D CPU 3.00GHz=10.838|2x 3000 MHz|Unknown
@@ -264,8 +264,8 @@ Intel(R) Core(TM)2 Duo CPU T9400@ 2.53GHz=6.757|2x 800 MHz|Unknown
 AMD Athlon(tm) 64 X2 Dual Core Processor 4800+=8.735|2x 2512 MHz|Unknown
 Intel(R) Celeron(R) M CPU520@ 1.60GHz=22.072|1600 MHz|Unknown
 Intel(R) Core(TM)2 Quad CPUQ8300@ 2.50GHz=3.346|4x 2497 MHz|Unknown
-Raspberry_Pi_3_Model_B_Rev_1_2;Broadcom_BCM2837;4800_00=10.41|4|Raspberry Pi 3 Model B Rev 1.2|Broadcom BCM2837|4x ARM Cortex-A53 r0p4 (AArch32)|4x 1200.00 MHz|945512|4
-Raspberry_Pi_Model_B_Rev_1;Broadcom_BCM2835;900_00=77.47|1|Raspberry Pi Model B Rev 1|Broadcom BCM2835|1x ARM ARM1176 r0p7 (AArch32)|1x 900.00 MHz|233620|1
+Raspberry_Pi_3_Model_B_Rev_1_2;Broadcom_BCM2837;4800_00=10.41|4|Raspberry Pi 3 Model B Rev 1.2|Broadcom BCM2837|4x ARM Cortex-A53 r0p4 (AArch32)|4x 1200.00 MHz|945512|4|Gallium 0.4 on llvmpipe (LLVM 3.9, 128 bits)
+Raspberry_Pi_Model_B_Rev_1;Broadcom_BCM2835;900_00=77.47|1|Raspberry Pi Model B Rev 1|Broadcom BCM2835|1x ARM ARM1176 r0p7 (AArch32)|1x 900.00 MHz|233620|1|
 PowerPC 740/750=172.816713|280.00 MHz|Unknown
 [CPU SHA1]
 [CPU MD5]
@@ -320,10 +320,12 @@ AMD Sempron(tm) Processor 3600+=5.696|1000 MHz|Unknown
 AMD Athlon(tm)=4.475|2305 MHz|Unknown
 AMD Athlon(tm) X2 Dual Core Processor BE-2300=4.373|2x 1899 MHz|Unknown
 Intel(R) Core(TM)2 Duo CPU E6750@ 2.66GHz=4.096|2x 2671 MHz|Unknown
-Raspberry_Pi_3_Model_B_Rev_1_2;Broadcom_BCM2837;4800_00=12.29|4|Raspberry Pi 3 Model B Rev 1.2|Broadcom BCM2837|4x ARM Cortex-A53 r0p4 (AArch32)|4x 1200.00 MHz|945512|4
-Raspberry_Pi_Model_B_Rev_1;Broadcom_BCM2835;900_00=20.15|1|Raspberry Pi Model B Rev 1|Broadcom BCM2835|1x ARM ARM1176 r0p7 (AArch32)|1x 900.00 MHz|233620|1
+Raspberry_Pi_3_Model_B_Rev_1_2;Broadcom_BCM2837;4800_00=12.29|4|Raspberry Pi 3 Model B Rev 1.2|Broadcom BCM2837|4x ARM Cortex-A53 r0p4 (AArch32)|4x 1200.00 MHz|945512|4|Gallium 0.4 on llvmpipe (LLVM 3.9, 128 bits)
+Raspberry_Pi_Model_B_Rev_1;Broadcom_BCM2835;900_00=20.15|1|Raspberry Pi Model B Rev 1|Broadcom BCM2835|1x ARM ARM1176 r0p7 (AArch32)|1x 900.00 MHz|233620|1|
 PowerPC 740/750=58.07682|280.00 MHz|Unknown
 [CPU Zlib]
-Raspberry_Pi_3_Model_B_Rev_1_2;Broadcom_BCM2837;4800_00=0.18|4|Raspberry Pi 3 Model B Rev 1.2|Broadcom BCM2837|4x ARM Cortex-A53 r0p4 (AArch32)|4x 1200.00 MHz|945512|4
-Raspberry_Pi_Model_B_Rev_1;Broadcom_BCM2835;900_00=7169.12|1|Raspberry Pi Model B Rev 1|Broadcom BCM2835|1x ARM ARM1176 r0p7 (AArch32)|1x 900.00 MHz|233620|1
+Raspberry_Pi_3_Model_B_Rev_1_2;Broadcom_BCM2837;4800_00=0.18|4|Raspberry Pi 3 Model B Rev 1.2|Broadcom BCM2837|4x ARM Cortex-A53 r0p4 (AArch32)|4x 1200.00 MHz|945512|4|Gallium 0.4 on llvmpipe (LLVM 3.9, 128 bits)
+Raspberry_Pi_Model_B_Rev_1;Broadcom_BCM2835;900_00=7169.12|1|Raspberry Pi Model B Rev 1|Broadcom BCM2835|1x ARM ARM1176 r0p7 (AArch32)|1x 900.00 MHz|233620|1|
 PowerPC 740/750=2150.597408|280.00 MHz|Unknown
+[GPU Drawing]
+Raspberry_Pi_3_Model_B_Rev_1_2;Broadcom_BCM2837;4800_00=3984.56|4|Raspberry Pi 3 Model B Rev 1.2|Broadcom BCM2837|4x ARM Cortex-A53 r0p4 (AArch32)|4x 1200.00 MHz|945512|4|Gallium 0.4 on llvmpipe (LLVM 3.9, 128 bits)

--- a/benchmark.conf
+++ b/benchmark.conf
@@ -51,7 +51,7 @@ AMD Athlon(tm) XP 2200+=22.197|1782 MHz|Unknown
 Intel(R) Pentium(R) 4 CPU 3.06GHz=7.454|2x 3065 MHz|Unknown
 AMD Processor model unknown=5.242|2x 3006 MHz|Unknown
 AMD Turion(tm) 64 X2 Mobile Technology TL-62=7.519|2x 800 MHz|Unknown
-ARM Cortex-A53 r0p4 (Aarch32)=11.95|4x 1200 MHz|Unknown
+Raspberry_Pi_3_Model_B_Rev_1_2;Broadcom_BCM2837;4800_00=11.97|4|Raspberry Pi 3 Model B Rev 1.2|Broadcom BCM2837|4x ARM Cortex-A53 r0p4 (AArch32)|4x 1200.00 MHz|945512|4
 ARM ARM1176 r0p7 (Aarch32)=114.57|900 MHz|Unknown
 [CPU CryptoHash]
 Intel(R) Atom(TM) CPU330 @ 1.60GHz=105.569|4x 1596 MHz|Unknown
@@ -104,6 +104,7 @@ AMD Turion(tm) 64 Mobile Technology ML-37=42.208|2000 MHz|Unknown
 Intel(R) Xeon(R) CPU3040@ 1.86GHz=127.825|2x 1862 MHz|Unknown
 AMD Athlon(tm) XP 2500+=39.659|1792 MHz|Unknown
 Intel(R) Core(TM)2 Duo CPU T9500@ 2.60GHz=172.640|2x 2593 MHz|Unknown
+Raspberry_Pi_3_Model_B_Rev_1_2;Broadcom_BCM2837;4800_00=98.27|4|Raspberry Pi 3 Model B Rev 1.2|Broadcom BCM2837|4x ARM Cortex-A53 r0p4 (AArch32)|4x 1200.00 MHz|945512|4
 [CPU N-Queens]
 AMD Athlon(tm) 64 X2 Dual Core Processor 5400+=15.057|2x 1000 MHz|Unknown
 Genuine Intel(R) CPU T2080@ 1.73GHz=33.309|2x 800 MHz|Unknown
@@ -155,6 +156,7 @@ AMD Athlon(tm) XP processor 1800+=17.547|1533 MHz|Unknown
 Intel(R) Core(TM)2 Duo CPU T5750@ 2.00GHz=11.140|2x 1994 MHz|Unknown
 Intel(R) Core(TM)2 Duo CPU T7250@ 2.00GHz=11.387|2x 2001 MHz|Unknown
 Intel(R) Pentium(R) 4 CPU 1500MHz=28.460|1495 MHz|Unknown
+Raspberry_Pi_3_Model_B_Rev_1_2;Broadcom_BCM2837;4800_00=22.83|4|Raspberry Pi 3 Model B Rev 1.2|Broadcom BCM2837|4x ARM Cortex-A53 r0p4 (AArch32)|4x 1200.00 MHz|945512|4
 [FPU Raytracing]
 Intel(R) Core(TM) Duo CPUT2450@ 2.00GHz=28.359|2x 800 MHz|Unknown
 AMD Athlon(tm) XP 2200+=29.739|1782 MHz|Unknown
@@ -206,6 +208,7 @@ Intel(R) Pentium(R) M processor 1.80GHz=27.133|600 MHz|Unknown
 Intel(R) Celeron(R) CPU 2.80GHz=81.047|2793 MHz|Unknown
 Genuine Intel(R) CPU T1350@ 1.86GHz=222.178|1867 MHz|Unknown
 Intel(R) Pentium(R) 4 CPU 2.80GHz=28.658|2791 MHz|Unknown
+Raspberry_Pi_3_Model_B_Rev_1_2;Broadcom_BCM2837;4800_00=16.21|4|Raspberry Pi 3 Model B Rev 1.2|Broadcom BCM2837|4x ARM Cortex-A53 r0p4 (AArch32)|4x 1200.00 MHz|945512|4
 [CPU Blowfish]
 Intel(R) Pentium(R) D CPU 3.00GHz=10.838|2x 3000 MHz|Unknown
 Intel(R) Celeron(R) CPU540@ 1.86GHz=25.494|1861 MHz|Unknown
@@ -257,6 +260,7 @@ Intel(R) Core(TM)2 Duo CPU T9400@ 2.53GHz=6.757|2x 800 MHz|Unknown
 AMD Athlon(tm) 64 X2 Dual Core Processor 4800+=8.735|2x 2512 MHz|Unknown
 Intel(R) Celeron(R) M CPU520@ 1.60GHz=22.072|1600 MHz|Unknown
 Intel(R) Core(TM)2 Quad CPUQ8300@ 2.50GHz=3.346|4x 2497 MHz|Unknown
+Raspberry_Pi_3_Model_B_Rev_1_2;Broadcom_BCM2837;4800_00=10.41|4|Raspberry Pi 3 Model B Rev 1.2|Broadcom BCM2837|4x ARM Cortex-A53 r0p4 (AArch32)|4x 1200.00 MHz|945512|4
 [CPU SHA1]
 [CPU MD5]
 [CPU Fibonacci]
@@ -310,6 +314,7 @@ AMD Sempron(tm) Processor 3600+=5.696|1000 MHz|Unknown
 AMD Athlon(tm)=4.475|2305 MHz|Unknown
 AMD Athlon(tm) X2 Dual Core Processor BE-2300=4.373|2x 1899 MHz|Unknown
 Intel(R) Core(TM)2 Duo CPU E6750@ 2.66GHz=4.096|2x 2671 MHz|Unknown
+Raspberry_Pi_3_Model_B_Rev_1_2;Broadcom_BCM2837;4800_00=12.29|4|Raspberry Pi 3 Model B Rev 1.2|Broadcom BCM2837|4x ARM Cortex-A53 r0p4 (AArch32)|4x 1200.00 MHz|945512|4
 [CPU Zlib]
-ARM Cortex-A53 r0p4 (Aarch32)=0.18|4x 1200 MHz|Unknown
+Raspberry_Pi_3_Model_B_Rev_1_2;Broadcom_BCM2837;4800_00=0.18|4|Raspberry Pi 3 Model B Rev 1.2|Broadcom BCM2837|4x ARM Cortex-A53 r0p4 (AArch32)|4x 1200.00 MHz|945512|4
 ARM ARM1176 r0p7 (Aarch32)=0.01|900 MHz|Unknown

--- a/benchmark.conf
+++ b/benchmark.conf
@@ -212,6 +212,7 @@ Genuine Intel(R) CPU T1350@ 1.86GHz=222.178|1867 MHz|Unknown
 Intel(R) Pentium(R) 4 CPU 2.80GHz=28.658|2791 MHz|Unknown
 Raspberry_Pi_3_Model_B_Rev_1_2;Broadcom_BCM2837;4800_00=16.21|4|Raspberry Pi 3 Model B Rev 1.2|Broadcom BCM2837|4x ARM Cortex-A53 r0p4 (AArch32)|4x 1200.00 MHz|945512|4
 Raspberry_Pi_Model_B_Rev_1;Broadcom_BCM2835;900_00=112.48|1|Raspberry Pi Model B Rev 1|Broadcom BCM2835|1x ARM ARM1176 r0p7 (AArch32)|1x 900.00 MHz|233620|1
+PowerPC 740/750=161.312647|280.00 MHz|Unknown
 [CPU Blowfish]
 Intel(R) Pentium(R) D CPU 3.00GHz=10.838|2x 3000 MHz|Unknown
 Intel(R) Celeron(R) CPU540@ 1.86GHz=25.494|1861 MHz|Unknown
@@ -265,6 +266,7 @@ Intel(R) Celeron(R) M CPU520@ 1.60GHz=22.072|1600 MHz|Unknown
 Intel(R) Core(TM)2 Quad CPUQ8300@ 2.50GHz=3.346|4x 2497 MHz|Unknown
 Raspberry_Pi_3_Model_B_Rev_1_2;Broadcom_BCM2837;4800_00=10.41|4|Raspberry Pi 3 Model B Rev 1.2|Broadcom BCM2837|4x ARM Cortex-A53 r0p4 (AArch32)|4x 1200.00 MHz|945512|4
 Raspberry_Pi_Model_B_Rev_1;Broadcom_BCM2835;900_00=77.47|1|Raspberry Pi Model B Rev 1|Broadcom BCM2835|1x ARM ARM1176 r0p7 (AArch32)|1x 900.00 MHz|233620|1
+PowerPC 740/750=172.816713|280.00 MHz|Unknown
 [CPU SHA1]
 [CPU MD5]
 [CPU Fibonacci]
@@ -320,6 +322,8 @@ AMD Athlon(tm) X2 Dual Core Processor BE-2300=4.373|2x 1899 MHz|Unknown
 Intel(R) Core(TM)2 Duo CPU E6750@ 2.66GHz=4.096|2x 2671 MHz|Unknown
 Raspberry_Pi_3_Model_B_Rev_1_2;Broadcom_BCM2837;4800_00=12.29|4|Raspberry Pi 3 Model B Rev 1.2|Broadcom BCM2837|4x ARM Cortex-A53 r0p4 (AArch32)|4x 1200.00 MHz|945512|4
 Raspberry_Pi_Model_B_Rev_1;Broadcom_BCM2835;900_00=20.15|1|Raspberry Pi Model B Rev 1|Broadcom BCM2835|1x ARM ARM1176 r0p7 (AArch32)|1x 900.00 MHz|233620|1
+PowerPC 740/750=58.07682|280.00 MHz|Unknown
 [CPU Zlib]
 Raspberry_Pi_3_Model_B_Rev_1_2;Broadcom_BCM2837;4800_00=0.18|4|Raspberry Pi 3 Model B Rev 1.2|Broadcom BCM2837|4x ARM Cortex-A53 r0p4 (AArch32)|4x 1200.00 MHz|945512|4
 Raspberry_Pi_Model_B_Rev_1;Broadcom_BCM2835;900_00=7169.12|1|Raspberry Pi Model B Rev 1|Broadcom BCM2835|1x ARM ARM1176 r0p7 (AArch32)|1x 900.00 MHz|233620|1
+PowerPC 740/750=2150.597408|280.00 MHz|Unknown

--- a/benchmark.conf
+++ b/benchmark.conf
@@ -51,8 +51,8 @@ AMD Athlon(tm) XP 2200+=22.197|1782 MHz|Unknown
 Intel(R) Pentium(R) 4 CPU 3.06GHz=7.454|2x 3065 MHz|Unknown
 AMD Processor model unknown=5.242|2x 3006 MHz|Unknown
 AMD Turion(tm) 64 X2 Mobile Technology TL-62=7.519|2x 800 MHz|Unknown
-Raspberry_Pi_3_Model_B_Rev_1_2;Broadcom_BCM2837;4800_00=11.97|4|Raspberry Pi 3 Model B Rev 1.2|Broadcom BCM2837|4x ARM Cortex-A53 r0p4 (AArch32)|4x 1200.00 MHz|945512|4|Gallium 0.4 on llvmpipe (LLVM 3.9, 128 bits)
-Raspberry_Pi_Model_B_Rev_1;Broadcom_BCM2835;900_00=114.42|1|Raspberry Pi Model B Rev 1|Broadcom BCM2835|1x ARM ARM1176 r0p7 (AArch32)|1x 900.00 MHz|233620|1|
+Raspberry_Pi_3_Model_B_Rev_1_2;Broadcom_BCM2837;4800_00=11.97|4|Raspberry Pi 3 Model B Rev 1.2|Broadcom BCM2837|4x ARM Cortex-A53 r0p4 (AArch32)|4x 1200.00 MHz|945512|4|4|4|Gallium 0.4 on llvmpipe (LLVM 3.9, 128 bits)
+Raspberry_Pi_Model_B_Rev_1;Broadcom_BCM2835;900_00=114.42|1|Raspberry Pi Model B Rev 1|Broadcom BCM2835|1x ARM ARM1176 r0p7 (AArch32)|1x 900.00 MHz|233620|1|1|1
 [CPU CryptoHash]
 Intel(R) Atom(TM) CPU330 @ 1.60GHz=105.569|4x 1596 MHz|Unknown
 Intel(R) Core(TM)2 Duo CPU T5250@ 1.50GHz=102.949|2x 1000 MHz|Unknown
@@ -104,8 +104,8 @@ AMD Turion(tm) 64 Mobile Technology ML-37=42.208|2000 MHz|Unknown
 Intel(R) Xeon(R) CPU3040@ 1.86GHz=127.825|2x 1862 MHz|Unknown
 AMD Athlon(tm) XP 2500+=39.659|1792 MHz|Unknown
 Intel(R) Core(TM)2 Duo CPU T9500@ 2.60GHz=172.640|2x 2593 MHz|Unknown
-Raspberry_Pi_3_Model_B_Rev_1_2;Broadcom_BCM2837;4800_00=98.27|4|Raspberry Pi 3 Model B Rev 1.2|Broadcom BCM2837|4x ARM Cortex-A53 r0p4 (AArch32)|4x 1200.00 MHz|945512|4|Gallium 0.4 on llvmpipe (LLVM 3.9, 128 bits)
-Raspberry_Pi_Model_B_Rev_1;Broadcom_BCM2835;900_00=11.70|1|Raspberry Pi Model B Rev 1|Broadcom BCM2835|1x ARM ARM1176 r0p7 (AArch32)|1x 900.00 MHz|233620|1|
+Raspberry_Pi_3_Model_B_Rev_1_2;Broadcom_BCM2837;4800_00=98.27|4|Raspberry Pi 3 Model B Rev 1.2|Broadcom BCM2837|4x ARM Cortex-A53 r0p4 (AArch32)|4x 1200.00 MHz|945512|4|4|4|Gallium 0.4 on llvmpipe (LLVM 3.9, 128 bits)
+Raspberry_Pi_Model_B_Rev_1;Broadcom_BCM2835;900_00=11.70|1|Raspberry Pi Model B Rev 1|Broadcom BCM2835|1x ARM ARM1176 r0p7 (AArch32)|1x 900.00 MHz|233620|1|1|1
 [CPU N-Queens]
 AMD Athlon(tm) 64 X2 Dual Core Processor 5400+=15.057|2x 1000 MHz|Unknown
 Genuine Intel(R) CPU T2080@ 1.73GHz=33.309|2x 800 MHz|Unknown
@@ -157,8 +157,8 @@ AMD Athlon(tm) XP processor 1800+=17.547|1533 MHz|Unknown
 Intel(R) Core(TM)2 Duo CPU T5750@ 2.00GHz=11.140|2x 1994 MHz|Unknown
 Intel(R) Core(TM)2 Duo CPU T7250@ 2.00GHz=11.387|2x 2001 MHz|Unknown
 Intel(R) Pentium(R) 4 CPU 1500MHz=28.460|1495 MHz|Unknown
-Raspberry_Pi_3_Model_B_Rev_1_2;Broadcom_BCM2837;4800_00=22.83|4|Raspberry Pi 3 Model B Rev 1.2|Broadcom BCM2837|4x ARM Cortex-A53 r0p4 (AArch32)|4x 1200.00 MHz|945512|4|Gallium 0.4 on llvmpipe (LLVM 3.9, 128 bits)
-Raspberry_Pi_Model_B_Rev_1;Broadcom_BCM2835;900_00=65.80|1|Raspberry Pi Model B Rev 1|Broadcom BCM2835|1x ARM ARM1176 r0p7 (AArch32)|1x 900.00 MHz|233620|1|
+Raspberry_Pi_3_Model_B_Rev_1_2;Broadcom_BCM2837;4800_00=22.83|4|Raspberry Pi 3 Model B Rev 1.2|Broadcom BCM2837|4x ARM Cortex-A53 r0p4 (AArch32)|4x 1200.00 MHz|945512|4|4|4|Gallium 0.4 on llvmpipe (LLVM 3.9, 128 bits)
+Raspberry_Pi_Model_B_Rev_1;Broadcom_BCM2835;900_00=65.80|1|Raspberry Pi Model B Rev 1|Broadcom BCM2835|1x ARM ARM1176 r0p7 (AArch32)|1x 900.00 MHz|233620|1|1|1
 [FPU Raytracing]
 Intel(R) Core(TM) Duo CPUT2450@ 2.00GHz=28.359|2x 800 MHz|Unknown
 AMD Athlon(tm) XP 2200+=29.739|1782 MHz|Unknown
@@ -210,8 +210,8 @@ Intel(R) Pentium(R) M processor 1.80GHz=27.133|600 MHz|Unknown
 Intel(R) Celeron(R) CPU 2.80GHz=81.047|2793 MHz|Unknown
 Genuine Intel(R) CPU T1350@ 1.86GHz=222.178|1867 MHz|Unknown
 Intel(R) Pentium(R) 4 CPU 2.80GHz=28.658|2791 MHz|Unknown
-Raspberry_Pi_3_Model_B_Rev_1_2;Broadcom_BCM2837;4800_00=16.21|4|Raspberry Pi 3 Model B Rev 1.2|Broadcom BCM2837|4x ARM Cortex-A53 r0p4 (AArch32)|4x 1200.00 MHz|945512|4|Gallium 0.4 on llvmpipe (LLVM 3.9, 128 bits)
-Raspberry_Pi_Model_B_Rev_1;Broadcom_BCM2835;900_00=112.48|1|Raspberry Pi Model B Rev 1|Broadcom BCM2835|1x ARM ARM1176 r0p7 (AArch32)|1x 900.00 MHz|233620|1|
+Raspberry_Pi_3_Model_B_Rev_1_2;Broadcom_BCM2837;4800_00=16.21|4|Raspberry Pi 3 Model B Rev 1.2|Broadcom BCM2837|4x ARM Cortex-A53 r0p4 (AArch32)|4x 1200.00 MHz|945512|4|4|4|Gallium 0.4 on llvmpipe (LLVM 3.9, 128 bits)
+Raspberry_Pi_Model_B_Rev_1;Broadcom_BCM2835;900_00=112.48|1|Raspberry Pi Model B Rev 1|Broadcom BCM2835|1x ARM ARM1176 r0p7 (AArch32)|1x 900.00 MHz|233620|1|1|1
 PowerPC 740/750=161.312647|280.00 MHz|Unknown
 [CPU Blowfish]
 Intel(R) Pentium(R) D CPU 3.00GHz=10.838|2x 3000 MHz|Unknown
@@ -264,8 +264,8 @@ Intel(R) Core(TM)2 Duo CPU T9400@ 2.53GHz=6.757|2x 800 MHz|Unknown
 AMD Athlon(tm) 64 X2 Dual Core Processor 4800+=8.735|2x 2512 MHz|Unknown
 Intel(R) Celeron(R) M CPU520@ 1.60GHz=22.072|1600 MHz|Unknown
 Intel(R) Core(TM)2 Quad CPUQ8300@ 2.50GHz=3.346|4x 2497 MHz|Unknown
-Raspberry_Pi_3_Model_B_Rev_1_2;Broadcom_BCM2837;4800_00=10.41|4|Raspberry Pi 3 Model B Rev 1.2|Broadcom BCM2837|4x ARM Cortex-A53 r0p4 (AArch32)|4x 1200.00 MHz|945512|4|Gallium 0.4 on llvmpipe (LLVM 3.9, 128 bits)
-Raspberry_Pi_Model_B_Rev_1;Broadcom_BCM2835;900_00=77.47|1|Raspberry Pi Model B Rev 1|Broadcom BCM2835|1x ARM ARM1176 r0p7 (AArch32)|1x 900.00 MHz|233620|1|
+Raspberry_Pi_3_Model_B_Rev_1_2;Broadcom_BCM2837;4800_00=10.41|4|Raspberry Pi 3 Model B Rev 1.2|Broadcom BCM2837|4x ARM Cortex-A53 r0p4 (AArch32)|4x 1200.00 MHz|945512|4|4|4|Gallium 0.4 on llvmpipe (LLVM 3.9, 128 bits)
+Raspberry_Pi_Model_B_Rev_1;Broadcom_BCM2835;900_00=77.47|1|Raspberry Pi Model B Rev 1|Broadcom BCM2835|1x ARM ARM1176 r0p7 (AArch32)|1x 900.00 MHz|233620|1|1|1
 PowerPC 740/750=172.816713|280.00 MHz|Unknown
 [CPU SHA1]
 [CPU MD5]
@@ -320,12 +320,12 @@ AMD Sempron(tm) Processor 3600+=5.696|1000 MHz|Unknown
 AMD Athlon(tm)=4.475|2305 MHz|Unknown
 AMD Athlon(tm) X2 Dual Core Processor BE-2300=4.373|2x 1899 MHz|Unknown
 Intel(R) Core(TM)2 Duo CPU E6750@ 2.66GHz=4.096|2x 2671 MHz|Unknown
-Raspberry_Pi_3_Model_B_Rev_1_2;Broadcom_BCM2837;4800_00=12.29|4|Raspberry Pi 3 Model B Rev 1.2|Broadcom BCM2837|4x ARM Cortex-A53 r0p4 (AArch32)|4x 1200.00 MHz|945512|4|Gallium 0.4 on llvmpipe (LLVM 3.9, 128 bits)
-Raspberry_Pi_Model_B_Rev_1;Broadcom_BCM2835;900_00=20.15|1|Raspberry Pi Model B Rev 1|Broadcom BCM2835|1x ARM ARM1176 r0p7 (AArch32)|1x 900.00 MHz|233620|1|
+Raspberry_Pi_3_Model_B_Rev_1_2;Broadcom_BCM2837;4800_00=12.29|4|Raspberry Pi 3 Model B Rev 1.2|Broadcom BCM2837|4x ARM Cortex-A53 r0p4 (AArch32)|4x 1200.00 MHz|945512|4|4|4|Gallium 0.4 on llvmpipe (LLVM 3.9, 128 bits)
+Raspberry_Pi_Model_B_Rev_1;Broadcom_BCM2835;900_00=20.15|1|Raspberry Pi Model B Rev 1|Broadcom BCM2835|1x ARM ARM1176 r0p7 (AArch32)|1x 900.00 MHz|233620|1|1|1
 PowerPC 740/750=58.07682|280.00 MHz|Unknown
 [CPU Zlib]
-Raspberry_Pi_3_Model_B_Rev_1_2;Broadcom_BCM2837;4800_00=0.18|4|Raspberry Pi 3 Model B Rev 1.2|Broadcom BCM2837|4x ARM Cortex-A53 r0p4 (AArch32)|4x 1200.00 MHz|945512|4|Gallium 0.4 on llvmpipe (LLVM 3.9, 128 bits)
-Raspberry_Pi_Model_B_Rev_1;Broadcom_BCM2835;900_00=7169.12|1|Raspberry Pi Model B Rev 1|Broadcom BCM2835|1x ARM ARM1176 r0p7 (AArch32)|1x 900.00 MHz|233620|1|
+Raspberry_Pi_3_Model_B_Rev_1_2;Broadcom_BCM2837;4800_00=0.18|4|Raspberry Pi 3 Model B Rev 1.2|Broadcom BCM2837|4x ARM Cortex-A53 r0p4 (AArch32)|4x 1200.00 MHz|945512|4|4|4|Gallium 0.4 on llvmpipe (LLVM 3.9, 128 bits)
+Raspberry_Pi_Model_B_Rev_1;Broadcom_BCM2835;900_00=7169.12|1|Raspberry Pi Model B Rev 1|Broadcom BCM2835|1x ARM ARM1176 r0p7 (AArch32)|1x 900.00 MHz|233620|1|1|1
 PowerPC 740/750=2150.597408|280.00 MHz|Unknown
 [GPU Drawing]
-Raspberry_Pi_3_Model_B_Rev_1_2;Broadcom_BCM2837;4800_00=3984.56|4|Raspberry Pi 3 Model B Rev 1.2|Broadcom BCM2837|4x ARM Cortex-A53 r0p4 (AArch32)|4x 1200.00 MHz|945512|4|Gallium 0.4 on llvmpipe (LLVM 3.9, 128 bits)
+Raspberry_Pi_3_Model_B_Rev_1_2;Broadcom_BCM2837;4800_00=3984.56|4|Raspberry Pi 3 Model B Rev 1.2|Broadcom BCM2837|4x ARM Cortex-A53 r0p4 (AArch32)|4x 1200.00 MHz|945512|4|4|4|Gallium 0.4 on llvmpipe (LLVM 3.9, 128 bits)

--- a/benchmark.conf
+++ b/benchmark.conf
@@ -52,7 +52,7 @@ Intel(R) Pentium(R) 4 CPU 3.06GHz=7.454|2x 3065 MHz|Unknown
 AMD Processor model unknown=5.242|2x 3006 MHz|Unknown
 AMD Turion(tm) 64 X2 Mobile Technology TL-62=7.519|2x 800 MHz|Unknown
 Raspberry_Pi_3_Model_B_Rev_1_2;Broadcom_BCM2837;4800_00=11.97|4|Raspberry Pi 3 Model B Rev 1.2|Broadcom BCM2837|4x ARM Cortex-A53 r0p4 (AArch32)|4x 1200.00 MHz|945512|4
-ARM ARM1176 r0p7 (Aarch32)=114.57|900 MHz|Unknown
+Raspberry_Pi_Model_B_Rev_1;Broadcom_BCM2835;900_00=114.42|1|Raspberry Pi Model B Rev 1|Broadcom BCM2835|1x ARM ARM1176 r0p7 (AArch32)|1x 900.00 MHz|233620|1
 [CPU CryptoHash]
 Intel(R) Atom(TM) CPU330 @ 1.60GHz=105.569|4x 1596 MHz|Unknown
 Intel(R) Core(TM)2 Duo CPU T5250@ 1.50GHz=102.949|2x 1000 MHz|Unknown
@@ -105,6 +105,7 @@ Intel(R) Xeon(R) CPU3040@ 1.86GHz=127.825|2x 1862 MHz|Unknown
 AMD Athlon(tm) XP 2500+=39.659|1792 MHz|Unknown
 Intel(R) Core(TM)2 Duo CPU T9500@ 2.60GHz=172.640|2x 2593 MHz|Unknown
 Raspberry_Pi_3_Model_B_Rev_1_2;Broadcom_BCM2837;4800_00=98.27|4|Raspberry Pi 3 Model B Rev 1.2|Broadcom BCM2837|4x ARM Cortex-A53 r0p4 (AArch32)|4x 1200.00 MHz|945512|4
+Raspberry_Pi_Model_B_Rev_1;Broadcom_BCM2835;900_00=11.70|1|Raspberry Pi Model B Rev 1|Broadcom BCM2835|1x ARM ARM1176 r0p7 (AArch32)|1x 900.00 MHz|233620|1
 [CPU N-Queens]
 AMD Athlon(tm) 64 X2 Dual Core Processor 5400+=15.057|2x 1000 MHz|Unknown
 Genuine Intel(R) CPU T2080@ 1.73GHz=33.309|2x 800 MHz|Unknown
@@ -157,6 +158,7 @@ Intel(R) Core(TM)2 Duo CPU T5750@ 2.00GHz=11.140|2x 1994 MHz|Unknown
 Intel(R) Core(TM)2 Duo CPU T7250@ 2.00GHz=11.387|2x 2001 MHz|Unknown
 Intel(R) Pentium(R) 4 CPU 1500MHz=28.460|1495 MHz|Unknown
 Raspberry_Pi_3_Model_B_Rev_1_2;Broadcom_BCM2837;4800_00=22.83|4|Raspberry Pi 3 Model B Rev 1.2|Broadcom BCM2837|4x ARM Cortex-A53 r0p4 (AArch32)|4x 1200.00 MHz|945512|4
+Raspberry_Pi_Model_B_Rev_1;Broadcom_BCM2835;900_00=65.80|1|Raspberry Pi Model B Rev 1|Broadcom BCM2835|1x ARM ARM1176 r0p7 (AArch32)|1x 900.00 MHz|233620|1
 [FPU Raytracing]
 Intel(R) Core(TM) Duo CPUT2450@ 2.00GHz=28.359|2x 800 MHz|Unknown
 AMD Athlon(tm) XP 2200+=29.739|1782 MHz|Unknown
@@ -209,6 +211,7 @@ Intel(R) Celeron(R) CPU 2.80GHz=81.047|2793 MHz|Unknown
 Genuine Intel(R) CPU T1350@ 1.86GHz=222.178|1867 MHz|Unknown
 Intel(R) Pentium(R) 4 CPU 2.80GHz=28.658|2791 MHz|Unknown
 Raspberry_Pi_3_Model_B_Rev_1_2;Broadcom_BCM2837;4800_00=16.21|4|Raspberry Pi 3 Model B Rev 1.2|Broadcom BCM2837|4x ARM Cortex-A53 r0p4 (AArch32)|4x 1200.00 MHz|945512|4
+Raspberry_Pi_Model_B_Rev_1;Broadcom_BCM2835;900_00=112.48|1|Raspberry Pi Model B Rev 1|Broadcom BCM2835|1x ARM ARM1176 r0p7 (AArch32)|1x 900.00 MHz|233620|1
 [CPU Blowfish]
 Intel(R) Pentium(R) D CPU 3.00GHz=10.838|2x 3000 MHz|Unknown
 Intel(R) Celeron(R) CPU540@ 1.86GHz=25.494|1861 MHz|Unknown
@@ -261,6 +264,7 @@ AMD Athlon(tm) 64 X2 Dual Core Processor 4800+=8.735|2x 2512 MHz|Unknown
 Intel(R) Celeron(R) M CPU520@ 1.60GHz=22.072|1600 MHz|Unknown
 Intel(R) Core(TM)2 Quad CPUQ8300@ 2.50GHz=3.346|4x 2497 MHz|Unknown
 Raspberry_Pi_3_Model_B_Rev_1_2;Broadcom_BCM2837;4800_00=10.41|4|Raspberry Pi 3 Model B Rev 1.2|Broadcom BCM2837|4x ARM Cortex-A53 r0p4 (AArch32)|4x 1200.00 MHz|945512|4
+Raspberry_Pi_Model_B_Rev_1;Broadcom_BCM2835;900_00=77.47|1|Raspberry Pi Model B Rev 1|Broadcom BCM2835|1x ARM ARM1176 r0p7 (AArch32)|1x 900.00 MHz|233620|1
 [CPU SHA1]
 [CPU MD5]
 [CPU Fibonacci]
@@ -315,6 +319,7 @@ AMD Athlon(tm)=4.475|2305 MHz|Unknown
 AMD Athlon(tm) X2 Dual Core Processor BE-2300=4.373|2x 1899 MHz|Unknown
 Intel(R) Core(TM)2 Duo CPU E6750@ 2.66GHz=4.096|2x 2671 MHz|Unknown
 Raspberry_Pi_3_Model_B_Rev_1_2;Broadcom_BCM2837;4800_00=12.29|4|Raspberry Pi 3 Model B Rev 1.2|Broadcom BCM2837|4x ARM Cortex-A53 r0p4 (AArch32)|4x 1200.00 MHz|945512|4
+Raspberry_Pi_Model_B_Rev_1;Broadcom_BCM2835;900_00=20.15|1|Raspberry Pi Model B Rev 1|Broadcom BCM2835|1x ARM ARM1176 r0p7 (AArch32)|1x 900.00 MHz|233620|1
 [CPU Zlib]
 Raspberry_Pi_3_Model_B_Rev_1_2;Broadcom_BCM2837;4800_00=0.18|4|Raspberry Pi 3 Model B Rev 1.2|Broadcom BCM2837|4x ARM Cortex-A53 r0p4 (AArch32)|4x 1200.00 MHz|945512|4
-ARM ARM1176 r0p7 (Aarch32)=0.01|900 MHz|Unknown
+Raspberry_Pi_Model_B_Rev_1;Broadcom_BCM2835;900_00=7169.12|1|Raspberry Pi Model B Rev 1|Broadcom BCM2835|1x ARM ARM1176 r0p7 (AArch32)|1x 900.00 MHz|233620|1

--- a/modules/benchmark.c
+++ b/modules/benchmark.c
@@ -204,13 +204,14 @@ gchar *hi_get_field(gchar * field)
     return g_strdup(field);
 }
 
-static void br_mi_add(char **results_list, bench_result *b) {
+static void br_mi_add(char **results_list, bench_result *b, gboolean select) {
     gchar *ckey, *rkey;
 
     ckey = hardinfo_clean_label(b->machine->cpu_name, 0);
     rkey = strdup(b->machine->mid);
 
-    *results_list = h_strdup_cprintf("$%s$%s=%.2f|%s\n", *results_list, rkey, ckey,
+    *results_list = h_strdup_cprintf("$%s%s$%s=%.2f|%s\n", *results_list,
+        select ? "*" : "", rkey, ckey,
         b->result, b->machine->cpu_config);
 
     moreinfo_add_with_prefix("BENCH", rkey, bench_result_more_info(b) );
@@ -237,7 +238,7 @@ static gchar *__benchmark_include_results(gdouble result,
         g_free(temp); temp = NULL;
 
         b = bench_result_this_machine(benchmark, result, n_threads);
-        br_mi_add(&results, b);
+        br_mi_add(&results, b, 1);
 
         temp = bench_result_benchmarkconf_line(b);
         printf("[%s]\n%s", benchmark, temp);
@@ -264,7 +265,7 @@ static gchar *__benchmark_include_results(gdouble result,
         values = g_key_file_get_string_list(conf, benchmark, machines[i], NULL, NULL);
 
         sbr = bench_result_benchmarkconf(benchmark, machines[i], values);
-        br_mi_add(&results, sbr);
+        br_mi_add(&results, sbr, 0);
 
         bench_result_free(sbr);
         g_strfreev(values);

--- a/modules/benchmark.c
+++ b/modules/benchmark.c
@@ -231,7 +231,7 @@ static gchar *__benchmark_include_results(gdouble result,
 
     moreinfo_del_with_prefix("BENCH");
 
-    if (result != 0.0) {
+    if (result > 0.0) {
         temp = module_call_method("devices::getProcessorCount");
         n_threads = temp ? atoi(temp) : 1;
         g_free(temp); temp = NULL;

--- a/modules/benchmark.c
+++ b/modules/benchmark.c
@@ -207,8 +207,7 @@ gchar *hi_get_field(gchar * field)
 static void br_mi_add(char **results_list, bench_result *b) {
     gchar *ckey, *rkey;
 
-    //ckey = hardinfo_clean_label(b->machine->cpu_name, 0);
-    ckey = strdup(b->machine->cpu_name);
+    ckey = hardinfo_clean_label(b->machine->cpu_name, 0);
     rkey = strdup(b->machine->mid);
 
     *results_list = h_strdup_cprintf("$%s$%s=%.2f|%s\n", *results_list, rkey, ckey,

--- a/modules/benchmark/bench_results.c
+++ b/modules/benchmark/bench_results.c
@@ -1,0 +1,308 @@
+/*
+ *    HardInfo - Displays System Information
+ *    Copyright (C) 2003-2017 Leandro A. F. Pereira <leandro@hardinfo.org>
+ *    This file:
+ *    Copyright (C) 2017 Burt P. <pburt0@gmail.com>
+ *
+ *    This program is free software; you can redistribute it and/or modify
+ *    it under the terms of the GNU General Public License as published by
+ *    the Free Software Foundation, version 2.
+ *
+ *    This program is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU General Public License for more details.
+ *
+ *    You should have received a copy of the GNU General Public License
+ *    along with this program; if not, write to the Free Software
+ *    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+ */
+
+#include "cpu_util.h"
+
+typedef struct {
+    char *board;
+    int memory_kiB;
+    char *cpu_name;
+    char *cpu_desc;
+    char *cpu_config;
+    int threads;
+    char *mid;
+} simple_machine;
+
+typedef struct {
+    char *name;
+    float result;
+    int threads;
+    simple_machine *machine;
+    int legacy; /* an old benchmark.conf result */
+} bench_result;
+
+/* "2x 1400.00 MHz + 2x 800.00 MHz" -> 4400.0 */
+static float cpu_config_val(char *str) {
+    char *c = str;
+    int t;
+    float f, r = 0.0;
+    if (str != NULL) {
+        if (strchr(str, 'x')) {
+            while (c != NULL && sscanf(c, "%dx %f", &t, &f) ) {
+                r += f * t;
+                c = strchr(c+1, '+');
+            }
+        } else {
+            sscanf(c, "%f", &r);
+        }
+    }
+    return r;
+}
+
+static int cpu_config_cmp(char *str0, char *str1) {
+    float r0, r1;
+    r0 = cpu_config_val(str0);
+    r1 = cpu_config_val(str1);
+    if (r0 == r1) return 0;
+    if (r0 < r1) return -1;
+    return 1;
+}
+
+static int cpu_config_is_close(char *str0, char *str1) {
+    float r0, r1, r1n;
+    r0 = cpu_config_val(str0);
+    r1 = cpu_config_val(str1);
+    r1n = r1 * .9;
+    if (r0 > r1n && r0 < r1)
+        return 1;
+    return 0;
+}
+
+static gen_machine_id(simple_machine *m) {
+    char *s;
+    if (m) {
+        if (m->mid != NULL)
+            free(m->mid);
+        m->mid = g_strdup_printf("%s;%s;%.2f",
+            m->board, m->cpu_name, cpu_config_val(m->cpu_config) );
+        s = m->mid;
+        while (*s != 0) {
+            if (!isalnum(*s)) {
+                if (*s != ';'
+                    && *s != '('
+                    && *s != '('
+                    && *s != ')')
+                *s = '_';
+            }
+            s++;
+        }
+    }
+}
+
+
+simple_machine *simple_machine_new() {
+    simple_machine *m = NULL;
+    m = malloc(sizeof(simple_machine));
+    if (m)
+        memset(m, 0, sizeof(simple_machine));
+    return m;
+}
+
+simple_machine *simple_machine_this() {
+    simple_machine *m = NULL;
+    char *tmp;
+    m = simple_machine_new();
+    if (m) {
+        m->board = module_call_method("devices::getMotherboard");
+        m->cpu_name = module_call_method("devices::getProcessorName");
+        m->cpu_desc = module_call_method("devices::getProcessorDesc");
+        m->cpu_config = module_call_method("devices::getProcessorFrequencyDesc");
+        tmp = module_call_method("devices::getMemoryTotal");
+        m->memory_kiB = atoi(tmp);
+        free(tmp);
+        tmp = module_call_method("devices::getProcessorCount");
+        m->threads = atoi(tmp);
+        free(tmp);
+        gen_machine_id(m);
+    }
+    return m;
+}
+
+void simple_machine_free(simple_machine *s) {
+    if (s) {
+        free(s->board);
+        free(s->cpu_name);
+        free(s->cpu_desc);
+        free(s->cpu_config);
+        free(s->mid);
+    }
+}
+
+void bench_result_free(bench_result *s) {
+    if (s) {
+        free(s->name);
+        simple_machine_free(s->machine);
+    }
+}
+
+bench_result *bench_result_this_machine(const char *bench_name, float result, int threads) {
+    bench_result *b = NULL;
+
+    b = malloc(sizeof(bench_result));
+    if (b) {
+        memset(b, 0, sizeof(bench_result));
+        b->machine = simple_machine_this();
+        b->name = strdup(bench_name);
+        b->result = result;
+        b->threads = threads;
+        b->legacy = 0;
+    }
+    return b;
+}
+
+/* -1 for none */
+static int nx_prefix(const char *str) {
+    char *s, *x;
+    if (str != NULL) {
+        s = str;
+        x = strchr(str, 'x');
+        if (x && x-s >= 1) {
+            while(s != x) {
+                if (!isdigit(*s))
+                    return -1;
+                s++;
+            }
+            *x = 0;
+            return atoi(str);
+        }
+    }
+    return -1;
+}
+
+bench_result *bench_result_benchmarkconf(const char *section, const char *key, char **values) {
+    bench_result *b = NULL;
+    char *s0, *s1, *s2;
+    int nx = 0, vl = 0;
+    float n, m;
+
+    vl = g_strv_length(values);
+
+    b = malloc(sizeof(bench_result));
+    if (b) {
+        memset(b, 0, sizeof(bench_result));
+        b->machine = simple_machine_new();
+        b->name = strdup(section);
+
+        if (vl >= 8) {
+            b->machine->mid = strdup(key);
+            b->result = atof(values[0]);
+            b->threads = atoi(values[1]);
+            b->machine->board = strdup(values[2]);
+            b->machine->cpu_name = strdup(values[3]);
+            b->machine->cpu_desc = strdup(values[4]);
+            b->machine->cpu_config = strdup(values[5]);
+            b->machine->memory_kiB = atoi(values[6]);
+            b->machine->threads = atoi(values[7]);
+            b->legacy = 0;
+        } else if (vl >= 2) {
+            b->result = atof(values[0]);
+            b->legacy = 1;
+
+            /* old old format has prefix before cpu name (ex: 4x Pentium...) */
+            nx = nx_prefix(key);
+            if (nx > 0) {
+                b->machine->cpu_name = strdup(strchr(key, 'x') + 1);
+                b->machine->threads = nx;
+                b->threads = nx;
+            } else {
+                b->machine->cpu_name = strdup(key);
+                b->machine->threads = 1;
+                b->threads = 1;
+            }
+
+            b->machine->cpu_config = strdup(values[1]);
+            /* new old format has cpu_config string with nx prefix */
+            nx = nx_prefix(values[1]);
+            if (nx > 0) {
+                b->machine->threads = nx;
+                b->threads = nx;
+            }
+
+            /* If the clock rate in the id string is more than the
+             * config string, use that. Older hardinfo used current cpu freq
+             * instead of max freq.
+             * "...@ 2.00GHz" -> 2000.0 */
+            s0 = b->machine->cpu_name;
+            s2 = strstr(s0, "Hz");
+            if (s2 && s2 != s0) {
+                s1 = s2 - 1;
+                while (s1 > s0) {
+                    if ( isdigit(*s1) || *s1 == '.' || *s1 == ' ')
+                        break;
+                    s1--;
+                }
+
+                if (s1 > s0) {
+                    m = 0; /* assume M */
+                    if (*(s2-1) == 'G')
+                        m = 1000;
+                    n = atof(s1+1);
+                    n *= m;
+
+                    s1 = g_strdup_printf("%dx %.2f %s", b->threads, n, _("MHz"));
+                    if ( cpu_config_cmp(b->machine->cpu_config, s1) == -1
+                         && !cpu_config_is_close(b->machine->cpu_config, s1) ) {
+                        free(b->machine->cpu_config);
+                        b->machine->cpu_config = s1;
+                    } else {
+                        free(s1);
+                    }
+                }
+            }
+        }
+        UNKIFNULL(b->machine->board);
+        UNKIFNULL(b->machine->cpu_desc);
+        gen_machine_id(b->machine);
+    }
+    return b;
+}
+
+char *bench_result_benchmarkconf_line(bench_result *b) {
+    return g_strdup_printf("%s=%.2f|%d|%s|%s|%s|%s|%d|%d\n",
+            b->machine->mid, b->result, b->threads,
+            b->machine->board, b->machine->cpu_name,
+            b->machine->cpu_desc, b->machine->cpu_config,
+            b->machine->memory_kiB, b->machine->threads );
+}
+
+char *bench_result_more_info(bench_result *b) {
+    return g_strdup_printf("[%s]\n"
+        /* bench name */"%s=%s\n"
+        /* result */    "%s=%0.2f\n"
+        /* threads */   "%s=%d\n"
+        /* legacy */    "%s=%s\n"
+                        "[%s]\n"
+        /* board */     "%s=%s\n"
+        /* cpu   */     "%s=%s\n"
+        /* cpudesc */   "%s=%s\n"
+        /* cpucfg */    "%s=%s\n"
+        /* threads */   "%s=%d\n"
+        /* mem */       "%s=%d %s\n"
+                        "[%s]\n"
+        /* mid */       "%s=%s\n"
+        /* cfg_val */   "%s=%.2f\n",
+                        _("Benchmark Result"),
+                        _("Benchmark"), b->name,
+                        _("Result"), b->result,
+                        _("Threads"), b->threads,
+                        b->legacy ? _("Note") : "#Note",
+                        b->legacy ? _("This result is from an old version of Hardinfo.") : "",
+                        _("Machine"),
+                        _("Board"), b->machine->board,
+                        _("CPU Name"), b->machine->cpu_name,
+                        _("CPU Description"), b->machine->cpu_desc,
+                        _("CPU Config"), b->machine->cpu_config,
+                        _("Threads Available"), b->machine->threads,
+                        _("Memory"), b->machine->memory_kiB, _("kiB"),
+                        _("Handles"),
+                        _("mid"), b->machine->mid,
+                        _("cfg_val"), cpu_config_val(b->machine->cpu_config)
+                        );
+}

--- a/modules/benchmark/bench_results.c
+++ b/modules/benchmark/bench_results.c
@@ -96,7 +96,6 @@ static gen_machine_id(simple_machine *m) {
     }
 }
 
-
 simple_machine *simple_machine_new() {
     simple_machine *m = NULL;
     m = malloc(sizeof(simple_machine));
@@ -161,7 +160,7 @@ bench_result *bench_result_this_machine(const char *bench_name, float result, in
 static int nx_prefix(const char *str) {
     char *s, *x;
     if (str != NULL) {
-        s = str;
+        s = (char*)str;
         x = strchr(str, 'x');
         if (x && x-s >= 1) {
             while(s != x) {
@@ -231,18 +230,18 @@ bench_result *bench_result_benchmarkconf(const char *section, const char *key, c
              * "...@ 2.00GHz" -> 2000.0 */
             s0 = b->machine->cpu_name;
             s2 = strstr(s0, "Hz");
-            if (s2 && s2 != s0) {
-                s1 = s2 - 1;
+            if (s2 && s2 > s0 + 2) {
+                m = 1; /* assume M */
+                if (*(s2-1) == 'G')
+                    m = 1000;
+                s1 = s2 - 2;
                 while (s1 > s0) {
-                    if ( isdigit(*s1) || *s1 == '.' || *s1 == ' ')
+                    if (!( isdigit(*s1) || *s1 == '.' || *s1 == ' '))
                         break;
                     s1--;
                 }
 
                 if (s1 > s0) {
-                    m = 0; /* assume M */
-                    if (*(s2-1) == 'G')
-                        m = 1000;
                     n = atof(s1+1);
                     n *= m;
 

--- a/modules/benchmark/bench_results.c
+++ b/modules/benchmark/bench_results.c
@@ -273,6 +273,31 @@ char *bench_result_benchmarkconf_line(bench_result *b) {
 
 char *bench_result_more_info(bench_result *b) {
     return g_strdup_printf("[%s]\n"
+        /* threads */   "%s=%d\n"
+        /* legacy */    "%s=%s\n"
+                        "[%s]\n"
+        /* board */     "%s=%s\n"
+        /* cpu   */     "%s=%s\n"
+        /* cpudesc */   "%s=%s\n"
+        /* cpucfg */    "%s=%s\n"
+        /* threads */   "%s=%d\n"
+        /* mem */       "%s=%d %s\n",
+                        _("Benchmark Result"),
+                        _("Threads"), b->threads,
+                        b->legacy ? _("Note") : "#Note",
+                        b->legacy ? _("This result is from an old version of HardInfo. Results might not be comparable to current version. Some details are missing.") : "",
+                        _("Machine"),
+                        _("Board"), b->machine->board,
+                        _("CPU Name"), b->machine->cpu_name,
+                        _("CPU Description"), b->machine->cpu_desc,
+                        _("CPU Config"), b->machine->cpu_config,
+                        _("Threads Available"), b->machine->threads,
+                        _("Memory"), b->machine->memory_kiB, _("kiB")
+                        );
+}
+
+char *bench_result_more_info_complete(bench_result *b) {
+    return g_strdup_printf("[%s]\n"
         /* bench name */"%s=%s\n"
         /* result */    "%s=%0.2f\n"
         /* threads */   "%s=%d\n"

--- a/modules/computer.c
+++ b/modules/computer.c
@@ -645,6 +645,13 @@ gchar *get_os(void)
     return g_strdup(computer->os->distro);
 }
 
+gchar *get_ogl_renderer(void)
+{
+    scan_display(FALSE);
+
+    return g_strdup(computer->display->ogl_renderer);
+}
+
 gchar *get_display_summary(void)
 {
     scan_display(FALSE);
@@ -689,6 +696,7 @@ ShellModuleMethod *hi_exported_methods(void)
         {"getOSKernel", get_os_kernel},
         {"getOS", get_os},
         {"getDisplaySummary", get_display_summary},
+        {"getOGLRenderer", get_ogl_renderer},
         {"getAudioCards", get_audio_cards},
         {"getKernelModuleDescription", get_kernel_module_description},
         {NULL}


### PR DESCRIPTION
After considering JSON (#142) I decided to just extend the current format, and remain compatible with existing benchmark.conf formats.

* More information can be saved in benchmark.conf, while still being
  compatible with older versions.
* Selecting a result gives additional information about the result
  and the machine that produced it.

Showing an old result:
![newbench_old](https://user-images.githubusercontent.com/1758090/29259724-4ca741ae-808a-11e7-9837-0004a2390562.png)
Showing a new result:
![newbench_new](https://user-images.githubusercontent.com/1758090/29259725-4cbf39f8-808a-11e7-940b-be0279169082.png)
