### PR TITLE
cmake: add info.c to gtk3 build/link list

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -221,6 +221,7 @@ add_executable(hardinfo
 	hardinfo/socket.c
 	hardinfo/util.c
 	hardinfo/vendor.c
+	hardinfo/info.c
 	shell/callbacks.c
 	shell/iconcache.c
 	shell/menu.c


### PR DESCRIPTION
Fixes #150.
