### PR TITLE
Remove the appended "Module" from about module dialog title

### DIFF
--- a/shell/callbacks.c
+++ b/shell/callbacks.c
@@ -114,7 +114,7 @@ void cb_about_module(GtkAction * action)
 
 	    gtk_window_set_transient_for(GTK_WINDOW(about), GTK_WINDOW(shell->window));
 
-	    text = g_strdup_printf(_("%s Module"), sm->name);
+	    text = g_strdup(sm->name);
 #if GTK_CHECK_VERSION(2, 12, 0)
 	    gtk_about_dialog_set_program_name(GTK_ABOUT_DIALOG(about), text);
 #else


### PR DESCRIPTION
The string is constructed one word at a time, "About", X, "Module"
and it ends up being very strange in languages other than English.
Cutting out the module makes it a little better, and not much is
lost. A module could add "Module" to it's title, and then at
least that string can be translated as a complete unit. 
See https://github.com/lpereira/hardinfo/issues/38#issuecomment-322625707