### PR TITLE
Fix for compilation warning

### DIFF
--- a/modules/benchmark.c
+++ b/modules/benchmark.c
@@ -397,7 +397,6 @@ static void do_benchmark(void (*benchmark_function)(void), int entry)
        g_object_set_data(G_OBJECT(bench_dialog), "result", "0.0");
        gtk_dialog_add_buttons(GTK_DIALOG(bench_dialog),
                               _("Cancel"), GTK_RESPONSE_ACCEPT, NULL);
-       gtk_message_dialog_set_image(GTK_MESSAGE_DIALOG(bench_dialog), bench_image);
 
        while (gtk_events_pending()) {
          gtk_main_iteration();


### PR DESCRIPTION
Here is a fix for the compilation warning:
```
/home/max/hardinfo/modules/benchmark.c: In function ‘do_benchmark’:
/home/max/hardinfo/modules/benchmark.c:400:8: warning: ‘gtk_message_dialog_set_image’ is deprecated [-Wdeprecated-declarations]
        gtk_message_dialog_set_image(GTK_MESSAGE_DIALOG(bench_dialog), bench_image);
        ^
In file included from /usr/include/gtk-3.0/gtk/gtk.h:143:0,
                 from /home/max/hardinfo/includes/hardinfo.h:22,
                 from /home/max/hardinfo/modules/benchmark.c:19:
/usr/include/gtk-3.0/gtk/gtkmessagedialog.h:115:12: note: declared here
 void       gtk_message_dialog_set_image    (GtkMessageDialog *dialog,
            ^
[ 65%] Building C object CMakeFiles/benchmark.dir/modules/benchmark/blowfish.c.o
```
I didn't see any difference in GTK2 and GTK3 versions after and before this PR.