### PR TITLE
Fix compilation warning

### DIFF
--- a/hardinfo/util.c
+++ b/hardinfo/util.c
@@ -875,11 +875,19 @@ static GSList *modules_check_deps(GSList * modules)
 							_("Module \"%s\" depends on module \"%s\", load it?"),
 							module->name,
 							deps[i]);
+#if GTK_CHECK_VERSION(3, 0, 0)
+            gtk_dialog_add_buttons(GTK_DIALOG(dialog),
+					       "_No",
+					       GTK_RESPONSE_REJECT,
+					      "_Open",
+					       GTK_RESPONSE_ACCEPT, NULL);
+#else
 			gtk_dialog_add_buttons(GTK_DIALOG(dialog),
 					       GTK_STOCK_NO,
 					       GTK_RESPONSE_REJECT,
 					       GTK_STOCK_OPEN,
 					       GTK_RESPONSE_ACCEPT, NULL);
+#endif
 
 			if (gtk_dialog_run(GTK_DIALOG(dialog)) ==
 			    GTK_RESPONSE_ACCEPT) {


### PR DESCRIPTION
Fox for the compilation warning:
```
/home/hardinfo/hardinfo/util.c: In function ‘modules_check_deps’:
/home/hardinfo/hardinfo/util.c:879:13: warning: ‘GtkStock’ is deprecated [-Wdeprecated-declarations]
             GTK_STOCK_NO,
             ^
/home/hardinfo/hardinfo/util.c:881:13: warning: ‘GtkStock’ is deprecated [-Wdeprecated-declarations]
             GTK_STOCK_OPEN,
             ^
```