### PR TITLE
info_add_group_ff(), info.c-related ideas

### DIFF
--- a/hardinfo/info.c
+++ b/hardinfo/info.c
@@ -56,6 +56,33 @@ void info_add_group(struct Info *info, const gchar *group_name, ...)
     g_array_append_val(info->groups, group);
 }
 
+void info_add_group_ff(struct Info *info, const gchar *group_name, ...)
+{
+    struct InfoGroup group = {
+        .name = group_name,
+        .fields = g_array_new(FALSE, FALSE, sizeof(struct InfoField))
+    };
+    va_list ap;
+
+    va_start(ap, group_name);
+    while (1) {
+        struct InfoField field = {
+            .name = va_arg(ap, char *),
+            .value = va_arg(ap, char *),
+            .free_value_on_flatten = TRUE,
+        };
+        if (field.value)
+            field.value = g_strdup(field.value);
+
+        if (!field.name)
+            break;
+        g_array_append_val(group.fields, field);
+    }
+    va_end(ap);
+
+    g_array_append_val(info->groups, group);
+}
+
 struct InfoField info_field(const gchar *name, gchar *value)
 {
     return (struct InfoField) {

--- a/hardinfo/info.c
+++ b/hardinfo/info.c
@@ -181,10 +181,17 @@ static void flatten_group(GString *output, const struct InfoGroup *group)
     if (group->fields) {
         for (i = 0; i < group->fields->len; i++) {
             struct InfoField field;
+            gchar *tag;
 
             field = g_array_index(group->fields, struct InfoField, i);
 
-            g_string_append_printf(output, "%s=%s\n", field.name, field.value);
+            if (field.mark_for_selection || field.tag) {
+                tag = g_strdup_printf("$%s%s$", field.mark_for_selection ? "*" : "", field.tag ? field.tag : "");
+            } else {
+                tag = g_strdup("");
+            }
+
+            g_string_append_printf(output, "%s%s=%s\n", tag, field.name, field.value);
 
             if (field.free_value_on_flatten)
                 g_free(field.value);

--- a/includes/info.h
+++ b/includes/info.h
@@ -44,17 +44,21 @@ struct InfoGroup {
 };
 
 struct InfoField {
+    const gchar *tag;
     const gchar *name;
     gchar *value;
 
     int update_interval;
 
     gboolean free_value_on_flatten;
+    gboolean mark_for_selection;
 };
 
 struct Info *info_new(void);
+struct Info *info_new_from_str(const gchar *str); /* opposite of info_flatten(); */
 
 void info_add_group(struct Info *info, const gchar *group_name, ...);
+void info_add_group_ff(struct Info *info, const gchar *group_name, ...);
 void info_add_computed_group(struct Info *info, const gchar *name, const gchar *value);
 
 struct InfoField info_field(const gchar *name, gchar *value);

--- a/modules/computer.c
+++ b/modules/computer.c
@@ -501,12 +501,13 @@ gchar *callback_os(void)
 {
     struct Info *info = info_new();
 
-    info_add_group(info, _("Version"),
-        info_field(_("Kernel"), computer->os->kernel),
-        info_field(_("Version"), computer->os->kernel_version),
-        info_field(_("C Library"), computer->os->libc),
-        info_field(_("Distribution"), computer->os->distro),
-        info_field_last());
+    info_add_group_ff(info,
+        _("Version"),
+        _("Kernel"), computer->os->kernel,
+        _("Version"), computer->os->kernel_version,
+        _("C Library"), computer->os->libc,
+        _("Distribution"), computer->os->distro
+        );
 
     info_add_group(info, _("Current Session"),
         info_field(_("Computer Name"), computer->os->hostname),


### PR DESCRIPTION
This is an idea to make it easier to convert the existing sprintf()s to using the Info structure. It's just a version of info_add_group() that takes name/value pairs instead of InfoField structures.
All the value strings are duplicated, and freed, so something like idle_free() has to be used for temp strings, but I was thinking maybe we can work that into a formatting function that would serve like info_field_printf().
Would look something like this:
```
info_add_group_ff(info, 
     _("Group"),
     _("Easy One"), some->value_freed_elsewhere, 
     _("Clock"), _fv("%d %s", freq, _("MHz") ), 
     _("Something"), _fv(tmp_value), 
```
And _fv() is the equivalent of:
```
    idle_free(g_strdup_printf(fmt, ...))
```

Part of #180.


