### PR TITLE
Fix compilation warning

### DIFF
--- a/hardinfo/util.c
+++ b/hardinfo/util.c
@@ -876,9 +876,9 @@ static GSList *modules_check_deps(GSList * modules)
 							module->name,
 							deps[i]);
 			gtk_dialog_add_buttons(GTK_DIALOG(dialog),
-					       GTK_STOCK_NO,
+					       "_No",
 					       GTK_RESPONSE_REJECT,
-					       GTK_STOCK_OPEN,
+					       "_Open",
 					       GTK_RESPONSE_ACCEPT, NULL);
 
 			if (gtk_dialog_run(GTK_DIALOG(dialog)) ==


### PR DESCRIPTION
Fix for the compilation warning:
```
/home/hardinfo/hardinfo/util.c: In function ‘modules_check_deps’:
/home/hardinfo/hardinfo/util.c:879:13: warning: ‘GtkStock’ is deprecated [-Wdeprecated-declarations]
             GTK_STOCK_NO,
             ^
/home/hardinfo/hardinfo/util.c:881:13: warning: ‘GtkStock’ is deprecated [-Wdeprecated-declarations]
             GTK_STOCK_OPEN,
             ^
```