### PR TITLE
Fix compilation warning

### DIFF
--- a/shell/report.c
+++ b/shell/report.c
@@ -918,7 +918,7 @@ static ReportDialog
  * gtk_dialog_get_action_area has been deprecated since version 3.12 and should not be used in newly-written code.
  * Direct access to the action area is discouraged; use gtk_dialog_add_button(), etc.
  */
-    dialog1_action_area = gtk_dialog_get_action_area(GTK_DIALOG(dialog));
+    dialog1_action_area = gtk_dialog_get_content_area(GTK_DIALOG(dialog));
 #else
     dialog1_action_area = GTK_DIALOG(dialog)->action_area;
 #endif


### PR DESCRIPTION
Fix for the compilation warning:
```
[ 41%] Building C object CMakeFiles/hardinfo.dir/shell/report.c.o
/home/hardinfo/shell/report.c: In function ‘report_dialog_new’:
/home/hardinfo/shell/report.c:944:5: warning: ‘gtk_dialog_get_action_area’ is deprecated [-Wdeprecated-declarations]
     dialog1_action_area = gtk_dialog_get_action_area(GTK_DIALOG(dialog));
     ^
In file included from /usr/include/gtk-3.0/gtk/gtkaboutdialog.h:30:0,
                 from /usr/include/gtk-3.0/gtk/gtk.h:31,
                 from /home/max/hardinfo/includes/report.h:21,
                 from /home/max/hardinfo/shell/report.c:19:
/usr/include/gtk-3.0/gtk/gtkdialog.h:205:13: note: declared here
 GtkWidget * gtk_dialog_get_action_area  (GtkDialog *dialog);
             ^
```