### PR TITLE
Fix compilation warning

### DIFF
--- a/shell/shell.c
+++ b/shell/shell.c
@@ -447,7 +447,7 @@ static void create_window(void)
 
     shell->status = gtk_label_new("");
 #if GTK_CHECK_VERSION(3, 0, 0)
-    gtk_widget_set_valign(GTK_MISC(shell->status), GTK_ALIGN_CENTER);
+    gtk_widget_set_valign(GTK_WIDGET(shell->status), GTK_ALIGN_CENTER);
 #else
     gtk_misc_set_alignment(GTK_MISC(shell->status), 0.0, 0.5);
 #endif
@@ -1640,15 +1640,22 @@ static void shell_summary_add_item(ShellSummary *summary,
      gtk_box_pack_start(GTK_BOX(frame_label_box), frame_image, FALSE, FALSE, 0);
      gtk_box_pack_start(GTK_BOX(frame_label_box), frame_label, FALSE, FALSE, 0);
 
+     content = gtk_label_new(temp);
      /* TODO:GTK3 gtk_alignment_new(), etc is deprecated from 3.14 */
+#if GTK_CHECK_VERSION(3, 0, 0)
+     GtkWidget *frame_box;
+     frame_box = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 5);
+     gtk_widget_set_margin_start(GTK_BOX(frame_box), 48);
+     gtk_box_pack_start(GTK_BOX(frame_box), content, FALSE, FALSE, 0);
+     gtk_container_add(GTK_CONTAINER(frame), frame_box);
+#else
      alignment = gtk_alignment_new(0.5, 0.5, 1, 1);
      gtk_alignment_set_padding(GTK_ALIGNMENT(alignment), 0, 0, 48, 0);
      gtk_widget_show(alignment);
      gtk_container_add(GTK_CONTAINER(frame), alignment);
-
-     content = gtk_label_new(temp);
      gtk_misc_set_alignment(GTK_MISC(content), 0.0, 0.5);
      gtk_container_add(GTK_CONTAINER(alignment), content);
+#endif
 
      gtk_widget_show_all(frame);
      gtk_widget_show_all(frame_label_box);


### PR DESCRIPTION
Fix for compilation warnings:
```
/home/max/hardinfo/shell/shell.c: In function ‘create_window’:
/home/max/hardinfo/shell/shell.c:450:5: warning: ‘gtk_misc_get_type’ is deprecated [-Wdeprecated-declarations]
     gtk_widget_set_valign(GTK_MISC(shell->status), GTK_ALIGN_CENTER);
     ^
In file included from /usr/include/gtk-3.0/gtk/gtklabel.h:33:0,
                 from /usr/include/gtk-3.0/gtk/gtkaccellabel.h:36,
                 from /usr/include/gtk-3.0/gtk/gtk.h:33,
                 from /home/max/hardinfo/shell/shell.c:21:
/usr/include/gtk-3.0/gtk/deprecated/gtkmisc.h:70:9: note: declared here
 GType   gtk_misc_get_type      (void) G_GNUC_CONST;
         ^
/usr/include/gtk-3.0/gtk/deprecated/gtkmisc.h:39:31: warning: passing argument 1 of ‘gtk_widget_set_valign’ from incompatible pointer type [-Wincompatible-pointer-types]
 #define GTK_MISC(obj)         (G_TYPE_CHECK_INSTANCE_CAST ((obj), GTK_TYPE_MISC, GtkMisc))
                               ^
/home/max/hardinfo/shell/shell.c:450:27: note: in expansion of macro ‘GTK_MISC’
     gtk_widget_set_valign(GTK_MISC(shell->status), GTK_ALIGN_CENTER);
                           ^
In file included from /usr/include/gtk-3.0/gtk/gtkapplication.h:27:0,
                 from /usr/include/gtk-3.0/gtk/gtkwindow.h:33,
                 from /usr/include/gtk-3.0/gtk/gtkdialog.h:33,
                 from /usr/include/gtk-3.0/gtk/gtkaboutdialog.h:30,
                 from /usr/include/gtk-3.0/gtk/gtk.h:31,
                 from /home/max/hardinfo/shell/shell.c:21:
/usr/include/gtk-3.0/gtk/gtkwidget.h:1070:10: note: expected ‘GtkWidget * {aka struct _GtkWidget *}’ but argument is of type ‘GtkMisc * {aka struct _GtkMisc *}’
 void     gtk_widget_set_valign        (GtkWidget *widget,
          ^
```
and
```
/home/max/hardinfo/shell/shell.c: In function ‘shell_summary_add_item’:
/home/max/hardinfo/shell/shell.c:1644:6: warning: ‘gtk_alignment_new’ is deprecated [-Wdeprecated-declarations]
      alignment = gtk_alignment_new(0.5, 0.5, 1, 1);
      ^
In file included from /usr/include/gtk-3.0/gtk/gtk.h:241:0,
                 from /home/max/hardinfo/shell/shell.c:21:
/usr/include/gtk-3.0/gtk/deprecated/gtkalignment.h:79:12: note: declared here
 GtkWidget* gtk_alignment_new        (gfloat             xalign,
            ^
/home/max/hardinfo/shell/shell.c:1645:6: warning: ‘gtk_alignment_set_padding’ is deprecated [-Wdeprecated-declarations]
      gtk_alignment_set_padding(GTK_ALIGNMENT(alignment), 0, 0, 48, 0);
      ^
In file included from /usr/include/gtk-3.0/gtk/gtk.h:241:0,
                 from /home/max/hardinfo/shell/shell.c:21:
/usr/include/gtk-3.0/gtk/deprecated/gtkalignment.h:91:12: note: declared here
 void       gtk_alignment_set_padding (GtkAlignment      *alignment,
            ^
/home/max/hardinfo/shell/shell.c:1645:6: warning: ‘gtk_alignment_get_type’ is deprecated [-Wdeprecated-declarations]
      gtk_alignment_set_padding(GTK_ALIGNMENT(alignment), 0, 0, 48, 0);
      ^
In file included from /usr/include/gtk-3.0/gtk/gtk.h:241:0,
                 from /home/max/hardinfo/shell/shell.c:21:
/usr/include/gtk-3.0/gtk/deprecated/gtkalignment.h:77:12: note: declared here
 GType      gtk_alignment_get_type   (void) G_GNUC_CONST;
            ^
/home/max/hardinfo/shell/shell.c:1650:6: warning: ‘gtk_misc_set_alignment’ is deprecated [-Wdeprecated-declarations]
      gtk_misc_set_alignment(GTK_MISC(content), 0.0, 0.5);
      ^
In file included from /usr/include/gtk-3.0/gtk/gtklabel.h:33:0,
                 from /usr/include/gtk-3.0/gtk/gtkaccellabel.h:36,
                 from /usr/include/gtk-3.0/gtk/gtk.h:33,
                 from /home/max/hardinfo/shell/shell.c:21:
/usr/include/gtk-3.0/gtk/deprecated/gtkmisc.h:72:6: note: declared here
 void gtk_misc_set_alignment (GtkMisc *misc,
      ^
/home/max/hardinfo/shell/shell.c:1650:6: warning: ‘gtk_misc_get_type’ is deprecated [-Wdeprecated-declarations]
      gtk_misc_set_alignment(GTK_MISC(content), 0.0, 0.5);
      ^
In file included from /usr/include/gtk-3.0/gtk/gtklabel.h:33:0,
                 from /usr/include/gtk-3.0/gtk/gtkaccellabel.h:36,
                 from /usr/include/gtk-3.0/gtk/gtk.h:33,
                 from /home/max/hardinfo/shell/shell.c:21:
/usr/include/gtk-3.0/gtk/deprecated/gtkmisc.h:70:9: note: declared here
 GType   gtk_misc_get_type      (void) G_GNUC_CONST;
         ^
```