### PR TITLE
Fix compilation warning

### DIFF
--- a/shell/stock.c
+++ b/shell/stock.c
@@ -38,6 +38,8 @@ static GtkIconFactory *icon_factory;
 
 void stock_icon_register(gchar * filename, gchar * stock_id)
 {
+#if GTK_CHECK_VERSION(3, 0, 0)
+#else
     GtkIconSet *icon_set;
     GtkIconSource *icon_source;
 
@@ -52,10 +54,13 @@ void stock_icon_register(gchar * filename, gchar * stock_id)
     gtk_icon_factory_add(icon_factory, stock_id, icon_set);
 
     gtk_icon_set_unref(icon_set);
+#endif
 }
 
 void stock_icon_register_pixbuf(GdkPixbuf * pixbuf, gchar * stock_id)
 {
+#if GTK_CHECK_VERSION(3, 0, 0)
+#else
     GtkIconSet *icon_set;
     GtkIconSource *icon_source;
 
@@ -69,6 +74,7 @@ void stock_icon_register_pixbuf(GdkPixbuf * pixbuf, gchar * stock_id)
     gtk_icon_factory_add(icon_factory, stock_id, icon_set);
 
     gtk_icon_set_unref(icon_set);
+#endif
 }
 
 void stock_icons_init(void)
@@ -78,14 +84,20 @@ void stock_icons_init(void)
 
     DEBUG("initializing stock icons");
 
+#if GTK_CHECK_VERSION(3, 0, 0)
+#else
     icon_factory = gtk_icon_factory_new();
+#endif
 
     for (i = 0; i < n_stock_icons; i++) {
 	stock_icon_register(stock_icons[i].filename,
 			    stock_icons[i].stock_id);
     }
 
+#if GTK_CHECK_VERSION(3, 0, 0)
+#else
     gtk_icon_factory_add_default(icon_factory);
+#endif
 
     g_object_unref(icon_factory);
 }


### PR DESCRIPTION
Fix for the compilation warning:
```
[ 60%] Building C object CMakeFiles/hardinfo.dir/shell/stock.c.o
/home/max/hardinfo/shell/stock.c: In function ‘stock_icon_register’:
/home/max/hardinfo/shell/stock.c:44:5: warning: ‘gtk_icon_set_new’ is deprecated [-Wdeprecated-declarations]
     icon_set = gtk_icon_set_new();
     ^
In file included from /usr/include/gtk-3.0/gtk/gtkstyleprovider.h:27:0,
                 from /usr/include/gtk-3.0/gtk/gtkstylecontext.h:27,
                 from /usr/include/gtk-3.0/gtk/gtkicontheme.h:27,
                 from /usr/include/gtk-3.0/gtk/gtk.h:120,
                 from /home/max/hardinfo/shell/stock.c:20:
/usr/include/gtk-3.0/gtk/deprecated/gtkiconfactory.h:138:13: note: declared here
 GtkIconSet* gtk_icon_set_new             (void);
             ^
/home/max/hardinfo/shell/stock.c:45:5: warning: ‘gtk_icon_source_new’ is deprecated [-Wdeprecated-declarations]
     icon_source = gtk_icon_source_new();
     ^
In file included from /usr/include/gtk-3.0/gtk/gtkstyleprovider.h:27:0,
                 from /usr/include/gtk-3.0/gtk/gtkstylecontext.h:27,
                 from /usr/include/gtk-3.0/gtk/gtkicontheme.h:27,
                 from /usr/include/gtk-3.0/gtk/gtk.h:120,
                 from /home/max/hardinfo/shell/stock.c:20:
/usr/include/gtk-3.0/gtk/deprecated/gtkiconfactory.h:170:16: note: declared here
 GtkIconSource* gtk_icon_source_new                      (void);
                ^
/home/max/hardinfo/shell/stock.c:47:5: warning: ‘gtk_icon_source_set_pixbuf’ is deprecated [-Wdeprecated-declarations]
     gtk_icon_source_set_pixbuf(icon_source,
     ^
In file included from /usr/include/gtk-3.0/gtk/gtkstyleprovider.h:27:0,
                 from /usr/include/gtk-3.0/gtk/gtkstylecontext.h:27,
                 from /usr/include/gtk-3.0/gtk/gtkicontheme.h:27,
                 from /usr/include/gtk-3.0/gtk/gtk.h:120,
                 from /home/max/hardinfo/shell/stock.c:20:
/usr/include/gtk-3.0/gtk/deprecated/gtkiconfactory.h:183:16: note: declared here
 void           gtk_icon_source_set_pixbuf               (GtkIconSource       *source,
                ^
/home/max/hardinfo/shell/stock.c:49:5: warning: ‘gtk_icon_set_add_source’ is deprecated [-Wdeprecated-declarations]
     gtk_icon_set_add_source(icon_set, icon_source);
     ^
In file included from /usr/include/gtk-3.0/gtk/gtkstyleprovider.h:27:0,
                 from /usr/include/gtk-3.0/gtk/gtkstylecontext.h:27,
                 from /usr/include/gtk-3.0/gtk/gtkicontheme.h:27,
                 from /usr/include/gtk-3.0/gtk/gtk.h:120,
                 from /home/max/hardinfo/shell/stock.c:20:
/usr/include/gtk-3.0/gtk/deprecated/gtkiconfactory.h:159:16: note: declared here
 void           gtk_icon_set_add_source   (GtkIconSet          *icon_set,
                ^
/home/max/hardinfo/shell/stock.c:50:5: warning: ‘gtk_icon_source_free’ is deprecated [-Wdeprecated-declarations]
     gtk_icon_source_free(icon_source);
     ^
In file included from /usr/include/gtk-3.0/gtk/gtkstyleprovider.h:27:0,
                 from /usr/include/gtk-3.0/gtk/gtkstylecontext.h:27,
                 from /usr/include/gtk-3.0/gtk/gtkicontheme.h:27,
                 from /usr/include/gtk-3.0/gtk/gtk.h:120,
                 from /home/max/hardinfo/shell/stock.c:20:
/usr/include/gtk-3.0/gtk/deprecated/gtkiconfactory.h:174:16: note: declared here
 void           gtk_icon_source_free                     (GtkIconSource       *source);
                ^
/home/max/hardinfo/shell/stock.c:52:5: warning: ‘gtk_icon_factory_add’ is deprecated [-Wdeprecated-declarations]
     gtk_icon_factory_add(icon_factory, stock_id, icon_set);
     ^
In file included from /usr/include/gtk-3.0/gtk/gtkstyleprovider.h:27:0,
                 from /usr/include/gtk-3.0/gtk/gtkstylecontext.h:27,
                 from /usr/include/gtk-3.0/gtk/gtkicontheme.h:27,
                 from /usr/include/gtk-3.0/gtk/gtk.h:120,
                 from /home/max/hardinfo/shell/stock.c:20:
/usr/include/gtk-3.0/gtk/deprecated/gtkiconfactory.h:82:17: note: declared here
 void            gtk_icon_factory_add      (GtkIconFactory *factory,
                 ^
/home/max/hardinfo/shell/stock.c:54:5: warning: ‘gtk_icon_set_unref’ is deprecated [-Wdeprecated-declarations]
     gtk_icon_set_unref(icon_set);
     ^
In file included from /usr/include/gtk-3.0/gtk/gtkstyleprovider.h:27:0,
                 from /usr/include/gtk-3.0/gtk/gtkstylecontext.h:27,
                 from /usr/include/gtk-3.0/gtk/gtkicontheme.h:27,
                 from /usr/include/gtk-3.0/gtk/gtk.h:120,
                 from /home/max/hardinfo/shell/stock.c:20:
/usr/include/gtk-3.0/gtk/deprecated/gtkiconfactory.h:145:13: note: declared here
 void        gtk_icon_set_unref           (GtkIconSet      *icon_set);
             ^
/home/max/hardinfo/shell/stock.c: In function ‘stock_icon_register_pixbuf’:
/home/max/hardinfo/shell/stock.c:62:5: warning: ‘gtk_icon_set_new’ is deprecated [-Wdeprecated-declarations]
     icon_set = gtk_icon_set_new();
     ^
In file included from /usr/include/gtk-3.0/gtk/gtkstyleprovider.h:27:0,
                 from /usr/include/gtk-3.0/gtk/gtkstylecontext.h:27,
                 from /usr/include/gtk-3.0/gtk/gtkicontheme.h:27,
                 from /usr/include/gtk-3.0/gtk/gtk.h:120,
                 from /home/max/hardinfo/shell/stock.c:20:
/usr/include/gtk-3.0/gtk/deprecated/gtkiconfactory.h:138:13: note: declared here
 GtkIconSet* gtk_icon_set_new             (void);
             ^
/home/max/hardinfo/shell/stock.c:63:5: warning: ‘gtk_icon_source_new’ is deprecated [-Wdeprecated-declarations]
     icon_source = gtk_icon_source_new();
     ^
In file included from /usr/include/gtk-3.0/gtk/gtkstyleprovider.h:27:0,
                 from /usr/include/gtk-3.0/gtk/gtkstylecontext.h:27,
                 from /usr/include/gtk-3.0/gtk/gtkicontheme.h:27,
                 from /usr/include/gtk-3.0/gtk/gtk.h:120,
                 from /home/max/hardinfo/shell/stock.c:20:
/usr/include/gtk-3.0/gtk/deprecated/gtkiconfactory.h:170:16: note: declared here
 GtkIconSource* gtk_icon_source_new                      (void);
                ^
/home/max/hardinfo/shell/stock.c:65:5: warning: ‘gtk_icon_source_set_pixbuf’ is deprecated [-Wdeprecated-declarations]
     gtk_icon_source_set_pixbuf(icon_source, pixbuf);
     ^
In file included from /usr/include/gtk-3.0/gtk/gtkstyleprovider.h:27:0,
                 from /usr/include/gtk-3.0/gtk/gtkstylecontext.h:27,
                 from /usr/include/gtk-3.0/gtk/gtkicontheme.h:27,
                 from /usr/include/gtk-3.0/gtk/gtk.h:120,
                 from /home/max/hardinfo/shell/stock.c:20:
/usr/include/gtk-3.0/gtk/deprecated/gtkiconfactory.h:183:16: note: declared here
 void           gtk_icon_source_set_pixbuf               (GtkIconSource       *source,
                ^
/home/max/hardinfo/shell/stock.c:66:5: warning: ‘gtk_icon_set_add_source’ is deprecated [-Wdeprecated-declarations]
     gtk_icon_set_add_source(icon_set, icon_source);
     ^
In file included from /usr/include/gtk-3.0/gtk/gtkstyleprovider.h:27:0,
                 from /usr/include/gtk-3.0/gtk/gtkstylecontext.h:27,
                 from /usr/include/gtk-3.0/gtk/gtkicontheme.h:27,
                 from /usr/include/gtk-3.0/gtk/gtk.h:120,
                 from /home/max/hardinfo/shell/stock.c:20:
/usr/include/gtk-3.0/gtk/deprecated/gtkiconfactory.h:159:16: note: declared here
 void           gtk_icon_set_add_source   (GtkIconSet          *icon_set,
                ^
/home/max/hardinfo/shell/stock.c:67:5: warning: ‘gtk_icon_source_free’ is deprecated [-Wdeprecated-declarations]
     gtk_icon_source_free(icon_source);
     ^
In file included from /usr/include/gtk-3.0/gtk/gtkstyleprovider.h:27:0,
                 from /usr/include/gtk-3.0/gtk/gtkstylecontext.h:27,
                 from /usr/include/gtk-3.0/gtk/gtkicontheme.h:27,
                 from /usr/include/gtk-3.0/gtk/gtk.h:120,
                 from /home/max/hardinfo/shell/stock.c:20:
/usr/include/gtk-3.0/gtk/deprecated/gtkiconfactory.h:174:16: note: declared here
 void           gtk_icon_source_free                     (GtkIconSource       *source);
                ^
/home/max/hardinfo/shell/stock.c:69:5: warning: ‘gtk_icon_factory_add’ is deprecated [-Wdeprecated-declarations]
     gtk_icon_factory_add(icon_factory, stock_id, icon_set);
     ^
In file included from /usr/include/gtk-3.0/gtk/gtkstyleprovider.h:27:0,
                 from /usr/include/gtk-3.0/gtk/gtkstylecontext.h:27,
                 from /usr/include/gtk-3.0/gtk/gtkicontheme.h:27,
                 from /usr/include/gtk-3.0/gtk/gtk.h:120,
                 from /home/max/hardinfo/shell/stock.c:20:
/usr/include/gtk-3.0/gtk/deprecated/gtkiconfactory.h:82:17: note: declared here
 void            gtk_icon_factory_add      (GtkIconFactory *factory,
                 ^
/home/max/hardinfo/shell/stock.c:71:5: warning: ‘gtk_icon_set_unref’ is deprecated [-Wdeprecated-declarations]
     gtk_icon_set_unref(icon_set);
     ^
In file included from /usr/include/gtk-3.0/gtk/gtkstyleprovider.h:27:0,
                 from /usr/include/gtk-3.0/gtk/gtkstylecontext.h:27,
                 from /usr/include/gtk-3.0/gtk/gtkicontheme.h:27,
                 from /usr/include/gtk-3.0/gtk/gtk.h:120,
                 from /home/max/hardinfo/shell/stock.c:20:
/usr/include/gtk-3.0/gtk/deprecated/gtkiconfactory.h:145:13: note: declared here
 void        gtk_icon_set_unref           (GtkIconSet      *icon_set);
             ^
/home/max/hardinfo/shell/stock.c: In function ‘stock_icons_init’:
/home/max/hardinfo/shell/stock.c:81:5: warning: ‘gtk_icon_factory_new’ is deprecated [-Wdeprecated-declarations]
     icon_factory = gtk_icon_factory_new();
     ^
In file included from /usr/include/gtk-3.0/gtk/gtkstyleprovider.h:27:0,
                 from /usr/include/gtk-3.0/gtk/gtkstylecontext.h:27,
                 from /usr/include/gtk-3.0/gtk/gtkicontheme.h:27,
                 from /usr/include/gtk-3.0/gtk/gtk.h:120,
                 from /home/max/hardinfo/shell/stock.c:20:
/usr/include/gtk-3.0/gtk/deprecated/gtkiconfactory.h:80:17: note: declared here
 GtkIconFactory* gtk_icon_factory_new      (void);
                 ^
/home/max/hardinfo/shell/stock.c:88:5: warning: ‘gtk_icon_factory_add_default’ is deprecated [-Wdeprecated-declarations]
     gtk_icon_factory_add_default(icon_factory);
     ^
In file included from /usr/include/gtk-3.0/gtk/gtkstyleprovider.h:27:0,
                 from /usr/include/gtk-3.0/gtk/gtkstylecontext.h:27,
                 from /usr/include/gtk-3.0/gtk/gtkicontheme.h:27,
                 from /usr/include/gtk-3.0/gtk/gtk.h:120,
                 from /home/max/hardinfo/shell/stock.c:20:
/usr/include/gtk-3.0/gtk/deprecated/gtkiconfactory.h:92:13: note: declared here
 void        gtk_icon_factory_add_default     (GtkIconFactory  *factory);
             ^
```