### PR TITLE
Fix compilation warning

### DIFF
--- a/shell/shell.c
+++ b/shell/shell.c
@@ -512,7 +512,8 @@ static void menu_item_set_icon_always_visible(Shell *shell,
 
     path = g_strdup_printf("%s/%s", parent_path, item_id);
     menuitem = gtk_ui_manager_get_widget(shell->ui_manager, path);
-#if GTK_CHECK_VERSION(2, 18, 0)
+#if GTK_CHECK_VERSION(3, 0, 0)
+#else
     gtk_image_menu_item_set_always_show_image(GTK_IMAGE_MENU_ITEM(menuitem), TRUE);
 #endif
     g_free(path);
@@ -690,7 +691,7 @@ ShellSummary *summary_new(void)
                                    GTK_POLICY_AUTOMATIC,
                                    GTK_POLICY_AUTOMATIC);
 #if GTK_CHECK_VERSION(3, 0, 0)
-    gtk_container_add(GTK_SCROLLED_WINDOW(summary->scroll),
+    gtk_container_add(GTK_CONTAINER(summary->scroll),
                                           summary->view);
 #else
     gtk_scrolled_window_add_with_viewport(GTK_SCROLLED_WINDOW(summary->scroll),
@@ -992,7 +993,10 @@ static void set_view_type(ShellViewType viewtype, gboolean reload)
     }
 
     /* turn off the rules hint */
+#if GTK_CHECK_VERSION(3, 0, 0)
+#else
     gtk_tree_view_set_rules_hint(GTK_TREE_VIEW(shell->info->view), FALSE);
+#endif
 
     close_note(NULL, NULL);
 
@@ -1162,10 +1166,13 @@ group_handle_special(GKeyFile * key_file, ShellModuleEntry * entry,
 		    g_free(file);
 		}
 	    } else if (g_str_equal(key, "Zebra")) {
+#if GTK_CHECK_VERSION(3, 0, 0)
+#else
 		gtk_tree_view_set_rules_hint(GTK_TREE_VIEW
 					     (shell->info->view),
 					     g_key_file_get_boolean
 					     (key_file, group, key, NULL));
+#endif
 	    }
 	}
 


### PR DESCRIPTION
Fix for the compulation warnings:
```
/home/hardinfo/shell/shell.c: In function ‘menu_item_set_icon_always_visible’:
/home/hardinfo/shell/shell.c:514:5: warning: ‘gtk_ui_manager_get_widget’ is deprecated [-Wdeprecated-declarations]
     menuitem = gtk_ui_manager_get_widget(shell->ui_manager, path);
     ^
In file included from /usr/include/gtk-3.0/gtk/gtk.h:270:0,
                 from /home/max/hardinfo/shell/shell.c:21:
/usr/include/gtk-3.0/gtk/deprecated/gtkuimanager.h:149:16: note: declared here
 GtkWidget     *gtk_ui_manager_get_widget          (GtkUIManager          *manager,
                ^
/home/hardinfo/shell/shell.c:516:5: warning: ‘gtk_image_menu_item_set_always_show_image’ is deprecated [-Wdeprecated-declarations]
     gtk_image_menu_item_set_always_show_image(GTK_IMAGE_MENU_ITEM(menuitem), TRUE);
     ^
In file included from /usr/include/gtk-3.0/gtk/gtk.h:255:0,
                 from /home/max/hardinfo/shell/shell.c:21:
/usr/include/gtk-3.0/gtk/deprecated/gtkimagemenuitem.h:87:12: note: declared here
 void       gtk_image_menu_item_set_always_show_image (GtkImageMenuItem *image_menu_item,
            ^
/home/hardinfo/shell/shell.c:516:5: warning: ‘gtk_image_menu_item_get_type’ is deprecated: Use 'gtk_menu_item_get_type' instead [-Wdeprecated-declarations]
     gtk_image_menu_item_set_always_show_image(GTK_IMAGE_MENU_ITEM(menuitem), TRUE);
     ^
In file included from /usr/include/gtk-3.0/gtk/gtk.h:255:0,
                 from /home/max/hardinfo/shell/shell.c:21:
/usr/include/gtk-3.0/gtk/deprecated/gtkimagemenuitem.h:76:10: note: declared here
 GType    gtk_image_menu_item_get_type          (void) G_GNUC_CONST;
          ^
```
and
```
In file included from /usr/include/gtk-3.0/gtk/gtk.h:178:0,
                 from /home/max/hardinfo/shell/shell.c:21:
/home/hardinfo/shell/shell.c: In function ‘summary_new’:
/usr/include/gtk-3.0/gtk/gtkscrolledwindow.h:38:45: warning: passing argument 1 of ‘gtk_container_add’ from incompatible pointer type [-Wincompatible-pointer-types]
 #define GTK_SCROLLED_WINDOW(obj)            (G_TYPE_CHECK_INSTANCE_CAST ((obj), GTK_TYPE_SCROLLED_WINDOW, GtkScrolledWindow))
                                             ^
/home/hardinfo/shell/shell.c:693:23: note: in expansion of macro ‘GTK_SCROLLED_WINDOW’
     gtk_container_add(GTK_SCROLLED_WINDOW(summary->scroll),
                       ^
In file included from /usr/include/gtk-3.0/gtk/gtkbin.h:33:0,
                 from /usr/include/gtk-3.0/gtk/gtkwindow.h:35,
                 from /usr/include/gtk-3.0/gtk/gtkdialog.h:33,
                 from /usr/include/gtk-3.0/gtk/gtkaboutdialog.h:30,
                 from /usr/include/gtk-3.0/gtk/gtk.h:31,
                 from /home/max/hardinfo/shell/shell.c:21:
/usr/include/gtk-3.0/gtk/gtkcontainer.h:149:9: note: expected ‘GtkContainer * {aka struct _GtkContainer *}’ but argument is of type ‘GtkScrolledWindow * {aka struct _GtkScrolledWindow *}’
 void    gtk_container_add   (GtkContainer    *container,
         ^
/home/hardinfo/shell/shell.c: In function ‘set_view_type’:
/home/hardinfo/shell/shell.c:981:5: warning: ‘gtk_tree_view_set_rules_hint’ is deprecated [-Wdeprecated-declarations]
     gtk_tree_view_set_rules_hint(GTK_TREE_VIEW(shell->info->view), FALSE);
     ^
In file included from /usr/include/gtk-3.0/gtk/gtkcombobox.h:27:0,
                 from /usr/include/gtk-3.0/gtk/gtkappchooserbutton.h:29,
                 from /usr/include/gtk-3.0/gtk/gtk.h:42,
                 from /home/max/hardinfo/shell/shell.c:21:
/usr/include/gtk-3.0/gtk/gtktreeview.h:246:24: note: declared here
 void                   gtk_tree_view_set_rules_hint                (GtkTreeView               *tree_view,
                        ^
/home/hardinfo/shell/shell.c: In function ‘group_handle_special’:
/home/hardinfo/shell/shell.c:1151:3: warning: ‘gtk_tree_view_set_rules_hint’ is deprecated [-Wdeprecated-declarations]
   gtk_tree_view_set_rules_hint(GTK_TREE_VIEW
   ^
In file included from /usr/include/gtk-3.0/gtk/gtkcombobox.h:27:0,
                 from /usr/include/gtk-3.0/gtk/gtkappchooserbutton.h:29,
                 from /usr/include/gtk-3.0/gtk/gtk.h:42,
                 from /home/max/hardinfo/shell/shell.c:21:
/usr/include/gtk-3.0/gtk/gtktreeview.h:246:24: note: declared here
 void                   gtk_tree_view_set_rules_hint                (GtkTreeView               *tree_view,
                        ^
```