### PR TITLE
Fixed compilation warning when building on GTK3

### DIFF
--- a/shell/shell.c
+++ b/shell/shell.c
@@ -1666,7 +1666,7 @@ static void shell_summary_add_item(ShellSummary *summary,
 #if GTK_CHECK_VERSION(3, 0, 0)
      GtkWidget *frame_box;
      frame_box = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 5);
-     gtk_widget_set_margin_start(GTK_BOX(frame_box), 48);
+     gtk_widget_set_margin_start(GTK_WIDGET(frame_box), 48);
      gtk_box_pack_start(GTK_BOX(frame_box), content, FALSE, FALSE, 0);
      gtk_container_add(GTK_CONTAINER(frame), frame_box);
 #else


### PR DESCRIPTION
Fixed compilation warning when building on GTK3:
```
In file included from /usr/include/gtk-3.0/gtk/gtkappchooserwidget.h:32:0,
                 from /usr/include/gtk-3.0/gtk/gtk.h:41,
                 from /home/max/hardinfo/shell/shell.c:21:
/home/max/hardinfo/shell/shell.c: In function ‘shell_summary_add_item’:
/usr/include/gtk-3.0/gtk/gtkbox.h:40:33: warning: passing argument 1 of ‘gtk_widget_set_margin_start’ from incompatible pointer type [-Wincompatible-pointer-types]
 #define GTK_BOX(obj)            (G_TYPE_CHECK_INSTANCE_CAST ((obj), GTK_TYPE_BOX, GtkBox))
                                 ^
/home/max/hardinfo/shell/shell.c:1669:34: note: in expansion of macro ‘GTK_BOX’
      gtk_widget_set_margin_start(GTK_BOX(frame_box), 48);
                                  ^
In file included from /usr/include/gtk-3.0/gtk/gtkapplication.h:27:0,
                 from /usr/include/gtk-3.0/gtk/gtkwindow.h:33,
                 from /usr/include/gtk-3.0/gtk/gtkdialog.h:33,
                 from /usr/include/gtk-3.0/gtk/gtkaboutdialog.h:30,
                 from /usr/include/gtk-3.0/gtk/gtk.h:31,
                 from /home/max/hardinfo/shell/shell.c:21:
/usr/include/gtk-3.0/gtk/gtkwidget.h:1085:10: note: expected ‘GtkWidget * {aka struct _GtkWidget *}’ but argument is of type ‘GtkBox * {aka struct _GtkBox *}’
 void     gtk_widget_set_margin_start  (GtkWidget *widget,
          ^
```