### PR TITLE
Computer/Display: Add X Display Name

### DIFF
--- a/modules/computer.c
+++ b/modules/computer.c
@@ -582,6 +582,7 @@ gchar *callback_display(void)
                 computer->display->width, computer->display->height),
         info_field(_("Vendor"), computer->display->vendor),
         info_field(_("Version"), computer->display->version),
+        info_field(_("Current Display Name"), computer->display->display_name),
         info_field_last());
 
     info_add_computed_group(info, _("Monitors"), computer->display->monitors);

--- a/modules/computer/display.c
+++ b/modules/computer/display.c
@@ -75,8 +75,9 @@ get_x11_info(DisplayInfo *di)
 	g_free(output);
 
 	old = output_lines;
-	while (*(output_lines++)) {
-            gchar **tmp = g_strsplit(*output_lines, ":", 0);
+	while (*output_lines) {
+            gchar **tmp = g_strsplit(*output_lines, ":", 2);
+            output_lines++;
 
             if (tmp[1] && tmp[0]) {
               tmp[1] = g_strchug(tmp[1]);
@@ -84,6 +85,7 @@ get_x11_info(DisplayInfo *di)
               get_str("vendor string", di->vendor);
               get_str("X.Org version", di->version);
               get_str("XFree86 version", di->version);
+              get_str("name of display", di->display_name);
 
               if (g_str_has_prefix(tmp[0], "number of extensions")) {
                 int n;


### PR DESCRIPTION
A field exists in struct _DisplayInfo, but it wasn't being
filled or shown.

Perhaps fix: https://github.com/lpereira/hardinfo/issues/181