### PR TITLE
Fixed possible memory leak

### DIFF
--- a/modules/computer/uptime.c
+++ b/modules/computer/uptime.c
@@ -30,6 +30,7 @@ computer_get_uptime(void)
         ui->minutes = minutes / 60;
         fclose(procuptime);
     } else {
+        g_free(ui);
         return NULL;
     }
 

--- a/modules/devices/usb.c
+++ b/modules/devices/usb.c
@@ -394,6 +394,7 @@ gboolean __scan_usb_lsusb(void)
     if (!temp_lsusb) {
         DEBUG("cannot create temporary file for lsusb");
         pclose(lsusb);
+	g_free(temp);
         return FALSE;
     }
 

--- a/modules/devices/usb.c
+++ b/modules/devices/usb.c
@@ -394,7 +394,7 @@ gboolean __scan_usb_lsusb(void)
     if (!temp_lsusb) {
         DEBUG("cannot create temporary file for lsusb");
         pclose(lsusb);
-	g_free(temp);
+	 g_free(temp);
         return FALSE;
     }
 


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. Warnings, found using PVS-Studio:
hardinfo/modules/devices/usb.c	397	err	V773 The function was exited without releasing the 'temp' pointer. A memory leak is possible.
hardinfo/modules/computer/uptime.c  33      err     V773 The function was exited without releasing the 'ui' pointer. A memory leak is possible.