### PR TITLE
x86: add summary of caches to package information

### DIFF
--- a/includes/x86/processor-platform.h
+++ b/includes/x86/processor-platform.h
@@ -30,6 +30,8 @@ struct _ProcessorCache {
     gint size;
     gchar *type;
     gint ways_of_associativity;
+    gint uid; /* uid is unique among caches with the same (type, level) */
+    gint phy_sock;
 };
 
 struct _Processor {


### PR DESCRIPTION
Show actual physical caches by counting only unique references from each "cpu" (hardware thread).

Example: Ryzen's 16MB of L3 cache is actually two 8MB caches on each "core complex" inside the processor.
![caches](https://user-images.githubusercontent.com/1758090/33512495-48deca24-d6f7-11e7-9b38-67670c27d6fc.png)
