### PR TITLE
x86,arm: cpu clocks list in package information

### DIFF
--- a/hardinfo/cpu_util.c
+++ b/hardinfo/cpu_util.c
@@ -128,6 +128,11 @@ void cpufreq_update(cpufreq_data *cpufd, int cur_only)
         cpufd->cpukhz_max = get_cpu_int("cpufreq/scaling_max_freq", cpufd->id, 0);
         if (cpufd->scaling_driver == NULL) cpufd->scaling_driver = g_strdup("(Unknown)");
         if (cpufd->scaling_governor == NULL) cpufd->scaling_governor = g_strdup("(Unknown)");
+
+        /* x86 uses freqdomain_cpus, all others use affected_cpus */
+        cpufd->shared_list = get_cpu_str("cpufreq/freqdomain_cpus", cpufd->id);
+        if (cpufd->shared_list == NULL) cpufd->shared_list = get_cpu_str("cpufreq/affected_cpus", cpufd->id);
+        if (cpufd->shared_list == NULL) cpufd->shared_list = g_strdup_printf("%d", cpufd->id);
     }
 }
 

--- a/includes/cpu_util.h
+++ b/includes/cpu_util.h
@@ -25,6 +25,7 @@ typedef struct {
     gint cpukhz_max, cpukhz_min, cpukhz_cur;
     gchar *scaling_driver, *scaling_governor;
     gint transition_latency;
+    gchar *shared_list;
 } cpufreq_data;
 
 typedef struct {

--- a/includes/x86/processor-platform.h
+++ b/includes/x86/processor-platform.h
@@ -31,6 +31,7 @@ struct _ProcessorCache {
     gchar *type;
     gint ways_of_associativity;
     gint uid; /* uid is unique among caches with the same (type, level) */
+    gchar *shared_cpu_list; /* some kernel's don't give a uid, so try shared_cpu_list */
     gint phy_sock;
 };
 

--- a/modules/devices/x86/processor.c
+++ b/modules/devices/x86/processor.c
@@ -226,6 +226,7 @@ static void __cache_obtain_info(Processor *processor)
         cache->uid = atoi(uref);
       else
         cache->uid = -1;
+      g_free(uref);
       entry = g_strconcat(index, "shared_cpu_list", NULL);
       cache->shared_cpu_list = h_sysfs_read_string(endpoint, entry);
       g_free(entry);

--- a/modules/devices/x86/processor.c
+++ b/modules/devices/x86/processor.c
@@ -234,6 +234,97 @@ fail:
     g_free(endpoint);
 }
 
+#define khzint_to_mhzdouble(k) (((double)k)/1000)
+#define cmp_clocks_test(f) if (a->f < b->f) return -1; if (a->f > b->f) return 1;
+
+static gint cmp_cpufreq_data(cpufreq_data *a, cpufreq_data *b) {
+        gint i = 0;
+        i = g_strcmp0(a->shared_list, b->shared_list); if (i!=0) return i;
+        cmp_clocks_test(cpukhz_max);
+        cmp_clocks_test(cpukhz_min);
+        return 0;
+}
+
+static gint cmp_cpufreq_data_ignore_affected(cpufreq_data *a, cpufreq_data *b) {
+        gint i = 0;
+        cmp_clocks_test(cpukhz_max);
+        cmp_clocks_test(cpukhz_min);
+        return 0;
+}
+
+gchar *clocks_summary(GSList * processors)
+{
+    gchar *ret = g_strdup("[Clocks]\n");
+    GSList *all_clocks = NULL, *uniq_clocks = NULL;
+    GSList *tmp, *l;
+    Processor *p;
+    cpufreq_data *c, *cur = NULL;
+    gint cur_count = 0, i = 0;
+
+    /* create list of all clock references */
+    for (l = processors; l; l = l->next) {
+        p = (Processor*)l->data;
+        if (p->cpufreq) {
+            all_clocks = g_slist_prepend(all_clocks, p->cpufreq);
+        }
+    }
+
+    if (g_slist_length(all_clocks) == 0) {
+        ret = h_strdup_cprintf("%s=\n", ret, _("(Not Available)") );
+        g_slist_free(all_clocks);
+        return ret;
+    }
+
+    /* ignore duplicate references */
+    all_clocks = g_slist_sort(all_clocks, (GCompareFunc)cmp_cpufreq_data);
+    for (l = all_clocks; l; l = l->next) {
+        c = (cpufreq_data*)l->data;
+        if (!cur) {
+            cur = c;
+        } else {
+            if (cmp_cpufreq_data(cur, c) != 0) {
+                uniq_clocks = g_slist_prepend(uniq_clocks, cur);
+                cur = c;
+            }
+        }
+    }
+    uniq_clocks = g_slist_prepend(uniq_clocks, cur);
+    uniq_clocks = g_slist_reverse(uniq_clocks);
+    cur = 0, cur_count = 0;
+
+    /* count and list clocks */
+    for (l = uniq_clocks; l; l = l->next) {
+        c = (cpufreq_data*)l->data;
+        if (!cur) {
+            cur = c;
+            cur_count = 1;
+        } else {
+            if (cmp_cpufreq_data_ignore_affected(cur, c) != 0) {
+                ret = h_strdup_cprintf(_("%.2f-%.2f %s=%dx\n"),
+                                ret,
+                                khzint_to_mhzdouble(cur->cpukhz_min),
+                                khzint_to_mhzdouble(cur->cpukhz_max),
+                                _("MHz"),
+                                cur_count);
+                cur = c;
+                cur_count = 1;
+            } else {
+                cur_count++;
+            }
+        }
+    }
+    ret = h_strdup_cprintf(_("%.2f-%.2f %s=%dx\n"),
+                    ret,
+                    khzint_to_mhzdouble(cur->cpukhz_min),
+                    khzint_to_mhzdouble(cur->cpukhz_max),
+                    _("MHz"),
+                    cur_count);
+
+    g_slist_free(all_clocks);
+    g_slist_free(uniq_clocks);
+    return ret;
+}
+
 #define cmp_cache_test(f) if (a->f < b->f) return -1; if (a->f > b->f) return 1;
 
 static gint cmp_cache(ProcessorCache *a, ProcessorCache *b) {
@@ -257,7 +348,7 @@ static gint cmp_cache_ignore_id(ProcessorCache *a, ProcessorCache *b) {
 
 gchar *caches_summary(GSList * processors)
 {
-    gchar *ret = g_strdup("[Caches]\n");
+    gchar *ret = g_strdup_printf("[%s]\n", _("Caches"));
     GSList *all_cache = NULL, *uniq_cache = NULL;
     GSList *tmp, *l;
     Processor *p;
@@ -278,7 +369,7 @@ gchar *caches_summary(GSList * processors)
     }
 
     if (g_slist_length(all_cache) == 0) {
-        ret = h_strdup_cprintf("%s", ret, _("(Not Available)") );
+        ret = h_strdup_cprintf("%s=\n", ret, _("(Not Available)") );
         g_slist_free(all_cache);
         return ret;
     }
@@ -570,18 +661,26 @@ gchar *processor_describe(GSList * processors) {
 gchar *processor_meta(GSList * processors) {
     gchar *meta_cpu_name = processor_name(processors);
     gchar *meta_cpu_desc = processor_describe(processors);
+    gchar *meta_freq_desc = processor_frequency_desc(processors);
+    gchar *meta_clocks = clocks_summary(processors);
     gchar *meta_caches = caches_summary(processors);
     gchar *ret = NULL;
     UNKIFNULL(meta_cpu_desc);
     ret = g_strdup_printf("[%s]\n"
                         "%s=%s\n"
                         "%s=%s\n"
+                        "%s=%s\n"
+                        "%s"
                         "%s",
                         _("Package Information"),
                         _("Name"), meta_cpu_name,
-                        _("Description"), meta_cpu_desc,
+                        _("Topology"), meta_cpu_desc,
+                        _("Logical CPU Config"), meta_freq_desc,
+                        meta_clocks,
                         meta_caches);
     g_free(meta_cpu_desc);
+    g_free(meta_freq_desc);
+    g_free(meta_clocks);
     g_free(meta_caches);
     return ret;
 }


### PR DESCRIPTION
Show actual clocks where cores or threads share a clock.
Ex: x86 SMT each core has one clock shared by both threads.
Ex: BCM2837 has one clock for all four cores.
![clocks_arm](https://user-images.githubusercontent.com/1758090/33816063-0465f4ce-ddfc-11e7-842e-ddc60fb92904.png)
![clocks_x86](https://user-images.githubusercontent.com/1758090/33816064-0551ed8e-ddfc-11e7-9f09-7c729a7b3da4.png)
