### PR TITLE
Add Intel cpu_insecure bug workaround flag

### DIFF
--- a/modules/devices/x86/processor.c
+++ b/modules/devices/x86/processor.c
@@ -341,19 +341,23 @@ gchar *caches_summary(GSList * processors)
     return ret;
 }
 
-
+#define PROC_SCAN_READ_BUFFER_SIZE 896
 GSList *processor_scan(void)
 {
     GSList *procs = NULL, *l = NULL;
     Processor *processor = NULL;
     FILE *cpuinfo;
-    gchar buffer[512];
+    gchar buffer[PROC_SCAN_READ_BUFFER_SIZE];
 
     cpuinfo = fopen(PROC_CPUINFO, "r");
     if (!cpuinfo)
         return NULL;
 
-    while (fgets(buffer, 512, cpuinfo)) {
+    while (fgets(buffer, PROC_SCAN_READ_BUFFER_SIZE, cpuinfo)) {
+        int rlen = strlen(buffer);
+        if (rlen >= PROC_SCAN_READ_BUFFER_SIZE - 1) {
+            fprintf(stderr, "Warning: truncated a line (probably flags list) longer than %d bytes while reading %s.\n", PROC_SCAN_READ_BUFFER_SIZE, PROC_CPUINFO);
+        }
         gchar **tmp = g_strsplit(buffer, ":", 2);
         if (!tmp[1] || !tmp[0]) {
             g_strfreev(tmp);

--- a/modules/devices/x86/x86_data.c
+++ b/modules/devices/x86/x86_data.c
@@ -278,7 +278,10 @@ static struct {
     { "bug:swapgs_fence", NC_("x86-flag", /*/bug:swapgs_fence*/  "SWAPGS without input dep on GS") },
     { "bug:monitor",      NC_("x86-flag", /*/bug:monitor*/  "IPI required to wake up remote CPU") },
     { "bug:amd_e400",     NC_("x86-flag", /*/bug:amd_e400*/  "AMD Erratum 400") },
-    { "bug:cpu_insecure",     NC_("x86-flag", /*/bug:cpu_insecure*/  "Page table isolation is being used") },
+    { "bug:cpu_insecure",     NC_("x86-flag", /*/bug:cpu_insecure & bug:cpu_meltdown*/  "CPU is affected by meltdown attack and needs kernel page table isolation") },
+    { "bug:cpu_meltdown",     NC_("x86-flag", /*/bug:cpu_insecure & bug:cpu_meltdown*/  "CPU is affected by meltdown attack and needs kernel page table isolation") },
+    { "bug:spectre_v1",     NC_("x86-flag", /*/bug:spectre_v1*/  "CPU is affected by Spectre variant 1 attack with conditional branches") },
+    { "bug:spectre_v2",     NC_("x86-flag", /*/bug:spectre_v2*/  "CPU is affected by Spectre variant 2 attack with indirect branches") },
 /* power management
  * ... from arch/x86/kernel/cpu/powerflags.h */
     { "pm:ts",            NC_("x86-flag", /*/flag:pm:ts*/  "temperature sensor")     },

--- a/modules/devices/x86/x86_data.c
+++ b/modules/devices/x86/x86_data.c
@@ -278,6 +278,7 @@ static struct {
     { "bug:swapgs_fence", NC_("x86-flag", /*/bug:swapgs_fence*/  "SWAPGS without input dep on GS") },
     { "bug:monitor",      NC_("x86-flag", /*/bug:monitor*/  "IPI required to wake up remote CPU") },
     { "bug:amd_e400",     NC_("x86-flag", /*/bug:amd_e400*/  "AMD Erratum 400") },
+    { "bug:cpu_insecure",     NC_("x86-flag", /*/bug:cpu_insecure*/  "Page table isolation is being used") },
 /* power management
  * ... from arch/x86/kernel/cpu/powerflags.h */
     { "pm:ts",            NC_("x86-flag", /*/flag:pm:ts*/  "temperature sensor")     },


### PR DESCRIPTION
cpu_insecure = page table isolation is being used to work around a security vulnerability in Intel x86 CPUs.
