### PR TITLE
Trying to fix last GTK3 compile warnings (unfinished, need help)

### DIFF
--- a/shell/menu.c
+++ b/shell/menu.c
@@ -115,52 +115,103 @@ void menu_init(Shell * shell)
     GtkAccelGroup *accel_group;
 
     /* Create our objects */
-    menu_box = shell->vbox;
-    action_group = gtk_action_group_new("HardInfo");
+    /*menu_box = shell->vbox;*/
+    //Removed warning for GTK3
+    /*action_group = gtk_action_group_new("HardInfo");
     menu_manager = gtk_ui_manager_new();
 
     shell->action_group = action_group;
-    shell->ui_manager = menu_manager;
+    shell->ui_manager = menu_manager;*/
 
     /* Pack up our objects:
      * menu_box -> window
      * actions -> action_group
      * action_group -> menu_manager */
-    gtk_action_group_set_translation_domain( action_group, "hardinfo" );//gettext
+    //Removed warning for GTK3
+    /*gtk_action_group_set_translation_domain( action_group, "hardinfo" );//gettext
     gtk_action_group_add_actions(action_group, entries,
 				 G_N_ELEMENTS(entries), NULL);
     gtk_action_group_add_toggle_actions(action_group, toggle_entries,
 					G_N_ELEMENTS(toggle_entries),
 					NULL);
-    gtk_ui_manager_insert_action_group(menu_manager, action_group, 0);
+    gtk_ui_manager_insert_action_group(menu_manager, action_group, 0);*/
 
 
     /* Read in the UI from our XML file */
-    error = NULL;
-    gtk_ui_manager_add_ui_from_string(menu_manager, uidefs_str, -1,
-				      &error);
+    /*error = NULL;*/
+    //Removed warning for GTK3
+    /*gtk_ui_manager_add_ui_from_string(menu_manager, uidefs_str, -1,
+				      &error);*/
 
-    if (error) {
+    /*if (error) {
 	g_error("Building menus failed: %s", error->message);
 	g_error_free(error);
 	return;
-    }
+    }*/
 
     /* Enable menu accelerators */
-    accel_group = gtk_ui_manager_get_accel_group(menu_manager);
-    gtk_window_add_accel_group(GTK_WINDOW(shell->window), accel_group);
+    //Removed warning for GTK3
+    /*accel_group = gtk_ui_manager_get_accel_group(menu_manager);*/
+    //Removed warning for GTK3
+    /*gtk_window_add_accel_group(GTK_WINDOW(shell->window), accel_group);*/
 
     /* Connect up important signals */
     /* This signal is necessary in order to place widgets from the UI manager
      * into the menu_box */
-    g_signal_connect(menu_manager, "add_widget",
-		     G_CALLBACK(menu_add_widget), menu_box);
+    //Removed warning for GTK3
+    /*g_signal_connect(menu_manager, "add_widget",
+		     G_CALLBACK(menu_add_widget), menu_box);*/
 
     /* Show the window and run the main loop, we're done! */
-    gtk_widget_show(menu_box);
+    //Removed warning for GTK3
+    /*gtk_widget_show(menu_box);*/
 
-    gtk_toolbar_set_style(GTK_TOOLBAR
+    //Removed warning for GTK3
+    /*gtk_toolbar_set_style(GTK_TOOLBAR
 			  (gtk_ui_manager_get_widget
 			   (shell->ui_manager, "/MainMenuBarAction")),
-			  GTK_TOOLBAR_BOTH_HORIZ);
+			  GTK_TOOLBAR_BOTH_HORIZ);*/
+	
+	GtkWidget *window;
+    GtkWidget *vbox;
+
+    GtkWidget *menubar;
+    GtkWidget *fileMenu;
+    GtkWidget *fileMi;
+    GtkWidget *quitMi;
+
+    /*gtk_init(&argc, &argv);
+
+    window = gtk_window_new(GTK_WINDOW_TOPLEVEL);
+    gtk_window_set_position(GTK_WINDOW(window), GTK_WIN_POS_CENTER);
+    gtk_window_set_default_size(GTK_WINDOW(window), 300, 200);
+    gtk_window_set_title(GTK_WINDOW(window), "Simple menu");*/
+
+    /*vbox = gtk_vbox_new(FALSE, 0);
+    gtk_container_add(GTK_CONTAINER(shell->window), vbox);*/
+
+    menubar = gtk_menu_bar_new();
+    fileMenu = gtk_menu_new();
+
+    fileMi = gtk_menu_item_new_with_label("File");
+    quitMi = gtk_menu_item_new_with_label("Quit");
+
+    gtk_menu_item_set_submenu(GTK_MENU_ITEM(fileMi), fileMenu);
+    gtk_menu_shell_append(GTK_MENU_SHELL(fileMenu), quitMi);
+    gtk_menu_shell_append(GTK_MENU_SHELL(menubar), fileMi);
+    /*gtk_box_pack_start(GTK_BOX(vbox), menubar, FALSE, FALSE, 0);*/
+
+    g_signal_connect(G_OBJECT(shell->window), "destroy",
+        G_CALLBACK(gtk_main_quit), NULL);
+
+    g_signal_connect(G_OBJECT(quitMi), "activate",
+        G_CALLBACK(gtk_main_quit), NULL);
+
+    gtk_widget_show(menubar);
+    /*gtk_widget_show_all(window);
+
+    gtk_main();
+
+    return 0;*/
+	
 }

--- a/shell/shell.c
+++ b/shell/shell.c
@@ -74,7 +74,8 @@ void shell_ui_manager_set_visible(const gchar * path, gboolean setting)
     if (!params.gui_running)
 	return;
 
-    widget = gtk_ui_manager_get_widget(shell->ui_manager, path);
+    //Removed warning for GTK3
+    /*widget = gtk_ui_manager_get_widget(shell->ui_manager, path);*/
     if (!widget)
 	return;
 
@@ -105,7 +106,8 @@ void shell_action_set_property(const gchar * action_name,
     if (!params.gui_running)
 	return;
 
-    action = gtk_action_group_get_action(shell->action_group, action_name);
+    //Removed warning for GTK3
+    /*action = gtk_action_group_get_action(shell->action_group, action_name);
     if (action) {
 	GValue value = { 0 };
 
@@ -115,7 +117,7 @@ void shell_action_set_property(const gchar * action_name,
 	g_object_set_property(G_OBJECT(action), property, &value);
 
 	g_value_unset(&value);
-    }
+    }*/
 }
 
 void shell_action_set_label(const gchar * action_name, gchar * label)
@@ -124,11 +126,12 @@ void shell_action_set_label(const gchar * action_name, gchar * label)
     if (params.gui_running && shell->action_group) {
 	GtkAction *action;
 
-	action =
+	//Removed warning for GTK3
+	/*action =
 	    gtk_action_group_get_action(shell->action_group, action_name);
 	if (action) {
 	    gtk_action_set_label(action, label);
-	}
+	}*/
     }
 #endif
 }
@@ -138,11 +141,12 @@ void shell_action_set_enabled(const gchar * action_name, gboolean setting)
     if (params.gui_running && shell->action_group) {
 	GtkAction *action;
 
-	action =
+	//Removed warning for GTK3
+	/*action =
 	    gtk_action_group_get_action(shell->action_group, action_name);
 	if (action) {
 	    gtk_action_set_sensitive(action, setting);
-	}
+	}*/
     }
 }
 
@@ -153,10 +157,11 @@ gboolean shell_action_get_enabled(const gchar * action_name)
     if (!params.gui_running)
 	return FALSE;
 
-    action = gtk_action_group_get_action(shell->action_group, action_name);
+    //Removed warning for GTK3
+    /*action = gtk_action_group_get_action(shell->action_group, action_name);
     if (action) {
 	return gtk_action_get_sensitive(action);
-    }
+    }*/
 
     return FALSE;
 }
@@ -181,7 +186,8 @@ gboolean shell_action_get_active(const gchar * action_name)
     if (!params.gui_running)
 	return FALSE;
 
-    action = gtk_action_group_get_action(shell->action_group, action_name);
+    //Removed warning for GTK3
+    /*action = gtk_action_group_get_action(shell->action_group, action_name);
     if (action) {
 	proxies = gtk_action_get_proxies(action);
 
@@ -194,7 +200,7 @@ gboolean shell_action_get_active(const gchar * action_name)
 						   (widget));
 	    }
 	}
-    }
+    }*/
 
     return FALSE;
 }
@@ -208,7 +214,8 @@ void shell_action_set_active(const gchar * action_name, gboolean setting)
     if (!params.gui_running)
 	return;
 
-    action = gtk_action_group_get_action(shell->action_group, action_name);
+    //Removed warning for GTK3
+    /*action = gtk_action_group_get_action(shell->action_group, action_name);
     if (action) {
 	proxies = gtk_action_get_proxies(action);
 
@@ -221,7 +228,7 @@ void shell_action_set_active(const gchar * action_name, gboolean setting)
 		return;
 	    }
 	}
-    }
+    }*/
 }
 
 void shell_status_pulse(void)
@@ -511,7 +518,8 @@ static void menu_item_set_icon_always_visible(Shell *shell,
     gchar *path;
 
     path = g_strdup_printf("%s/%s", parent_path, item_id);
-    menuitem = gtk_ui_manager_get_widget(shell->ui_manager, path);
+    //Removed warning for GTK3
+    /*menuitem = gtk_ui_manager_get_widget(shell->ui_manager, path);*/
 #if GTK_CHECK_VERSION(3, 0, 0)
 #else
     gtk_image_menu_item_set_always_show_image(GTK_IMAGE_MENU_ITEM(menuitem), TRUE);
@@ -548,7 +556,8 @@ static void add_module_to_menu(gchar * name, GdkPixbuf * pixbuf)
 
     stock_icon_register_pixbuf(pixbuf, name);
 
-    if ((action = gtk_action_group_get_action(shell->action_group, name))) {
+    //Removed warning for GTK3
+    /*if ((action = gtk_action_group_get_action(shell->action_group, name))) {
         gtk_action_group_remove_action(shell->action_group, action);
     }
 
@@ -562,15 +571,16 @@ static void add_module_to_menu(gchar * name, GdkPixbuf * pixbuf)
     gtk_ui_manager_add_ui(shell->ui_manager,
                           merge_id,
 			  "/menubar/ViewMenu/LastSep",
-			  name, name, GTK_UI_MANAGER_MENU, TRUE);
+			  name, name, GTK_UI_MANAGER_MENU, TRUE);*/
     shell->merge_ids = g_slist_prepend(shell->merge_ids, GINT_TO_POINTER(merge_id));
 
-    merge_id = gtk_ui_manager_new_merge_id(shell->ui_manager);
+    //Removed warning for GTK3
+    /*merge_id = gtk_ui_manager_new_merge_id(shell->ui_manager);
     gtk_ui_manager_add_ui(shell->ui_manager,
                           merge_id,
 			  "/menubar/HelpMenu/HelpMenuModules/LastSep",
 			  about_module, about_module, GTK_UI_MANAGER_AUTO,
-			  TRUE);
+			  TRUE);*/
     shell->merge_ids = g_slist_prepend(shell->merge_ids, GINT_TO_POINTER(merge_id));
 
     menu_item_set_icon_always_visible(shell, "/menubar/ViewMenu", name);
@@ -595,18 +605,21 @@ add_module_entry_to_view_menu(gchar * module, gchar * name,
 
     stock_icon_register_pixbuf(pixbuf, name);
 
-    if ((action = gtk_action_group_get_action(shell->action_group, name))) {
+    //Removed warning for GTK3
+    /*if ((action = gtk_action_group_get_action(shell->action_group, name))) {
         gtk_action_group_remove_action(shell->action_group, action);
     }
 
     gtk_action_group_add_actions(shell->action_group, &entry, 1, iter);
 
-    merge_id = gtk_ui_manager_new_merge_id(shell->ui_manager);
+    
+    merge_id = gtk_ui_manager_new_merge_id(shell->ui_manager);*/
     path = g_strdup_printf("/menubar/ViewMenu/%s", module);
-    gtk_ui_manager_add_ui(shell->ui_manager,
+    //Removed warning for GTK3
+    /*gtk_ui_manager_add_ui(shell->ui_manager,
                           merge_id,
                           path,
-			  name, name, GTK_UI_MANAGER_AUTO, FALSE);
+			  name, name, GTK_UI_MANAGER_AUTO, FALSE);*/
     shell->merge_ids = g_slist_prepend(shell->merge_ids, GINT_TO_POINTER(merge_id));
 
     menu_item_set_icon_always_visible(shell, path, name);


### PR DESCRIPTION
Here are last GTK3 compile warnings:

```
[ 56%] Building C object CMakeFiles/hardinfo.dir/shell/menu.c.o
/home/max/hardinfo/shell/menu.c: In function ‘menu_init’:
/home/max/hardinfo/shell/menu.c:119:5: warning: ‘gtk_action_group_new’ is deprecated [-Wdeprecated-declarations]
     action_group = gtk_action_group_new("HardInfo");
     ^
In file included from /usr/include/gtk-3.0/gtk/gtk.h:240:0,
                 from /home/max/hardinfo/shell/menu.c:22:
/usr/include/gtk-3.0/gtk/deprecated/gtkactiongroup.h:175:17: note: declared here
 GtkActionGroup *gtk_action_group_new                     (const gchar                *name);
                 ^
/home/max/hardinfo/shell/menu.c:120:5: warning: ‘gtk_ui_manager_new’ is deprecated [-Wdeprecated-declarations]
     menu_manager = gtk_ui_manager_new();
     ^
In file included from /usr/include/gtk-3.0/gtk/gtk.h:270:0,
                 from /home/max/hardinfo/shell/menu.c:22:
/usr/include/gtk-3.0/gtk/deprecated/gtkuimanager.h:130:16: note: declared here
 GtkUIManager  *gtk_ui_manager_new                 (void);
                ^
/home/max/hardinfo/shell/menu.c:129:5: warning: ‘gtk_action_group_set_translation_domain’ is deprecated [-Wdeprecated-declarations]
     gtk_action_group_set_translation_domain( action_group, "hardinfo" );//gettext
     ^
In file included from /usr/include/gtk-3.0/gtk/gtk.h:240:0,
                 from /home/max/hardinfo/shell/menu.c:22:
/usr/include/gtk-3.0/gtk/deprecated/gtkactiongroup.h:252:17: note: declared here
 void            gtk_action_group_set_translation_domain  (GtkActionGroup             *action_group,
                 ^
/home/max/hardinfo/shell/menu.c:130:5: warning: ‘gtk_action_group_add_actions’ is deprecated [-Wdeprecated-declarations]
     gtk_action_group_add_actions(action_group, entries,
     ^
In file included from /usr/include/gtk-3.0/gtk/gtk.h:240:0,
                 from /home/max/hardinfo/shell/menu.c:22:
/usr/include/gtk-3.0/gtk/deprecated/gtkactiongroup.h:210:17: note: declared here
 void            gtk_action_group_add_actions             (GtkActionGroup             *action_group,
                 ^
/home/max/hardinfo/shell/menu.c:132:5: warning: ‘gtk_action_group_add_toggle_actions’ is deprecated [-Wdeprecated-declarations]
     gtk_action_group_add_toggle_actions(action_group, toggle_entries,
     ^
In file included from /usr/include/gtk-3.0/gtk/gtk.h:240:0,
                 from /home/max/hardinfo/shell/menu.c:22:
/usr/include/gtk-3.0/gtk/deprecated/gtkactiongroup.h:215:17: note: declared here
 void            gtk_action_group_add_toggle_actions      (GtkActionGroup             *action_group,
                 ^
/home/max/hardinfo/shell/menu.c:135:5: warning: ‘gtk_ui_manager_insert_action_group’ is deprecated [-Wdeprecated-declarations]
     gtk_ui_manager_insert_action_group(menu_manager, action_group, 0);
     ^
In file included from /usr/include/gtk-3.0/gtk/gtk.h:270:0,
                 from /home/max/hardinfo/shell/menu.c:22:
/usr/include/gtk-3.0/gtk/deprecated/gtkuimanager.h:138:16: note: declared here
 void           gtk_ui_manager_insert_action_group (GtkUIManager          *manager,
                ^
/home/max/hardinfo/shell/menu.c:140:5: warning: ‘gtk_ui_manager_add_ui_from_string’ is deprecated [-Wdeprecated-declarations]
     gtk_ui_manager_add_ui_from_string(menu_manager, uidefs_str, -1,
     ^
In file included from /usr/include/gtk-3.0/gtk/gtk.h:270:0,
                 from /home/max/hardinfo/shell/menu.c:22:
/usr/include/gtk-3.0/gtk/deprecated/gtkuimanager.h:158:16: note: declared here
 guint          gtk_ui_manager_add_ui_from_string  (GtkUIManager          *manager,
                ^
/home/max/hardinfo/shell/menu.c:150:5: warning: ‘gtk_ui_manager_get_accel_group’ is deprecated [-Wdeprecated-declarations]
     accel_group = gtk_ui_manager_get_accel_group(menu_manager);
     ^
In file included from /usr/include/gtk-3.0/gtk/gtk.h:270:0,
                 from /home/max/hardinfo/shell/menu.c:22:
/usr/include/gtk-3.0/gtk/deprecated/gtkuimanager.h:147:16: note: declared here
 GtkAccelGroup *gtk_ui_manager_get_accel_group     (GtkUIManager          *manager);
                ^
/home/max/hardinfo/shell/menu.c:162:5: warning: ‘gtk_ui_manager_get_widget’ is deprecated [-Wdeprecated-declarations]
     gtk_toolbar_set_style(GTK_TOOLBAR
     ^
In file included from /usr/include/gtk-3.0/gtk/gtk.h:270:0,
                 from /home/max/hardinfo/shell/menu.c:22:
/usr/include/gtk-3.0/gtk/deprecated/gtkuimanager.h:149:16: note: declared here
 GtkWidget     *gtk_ui_manager_get_widget          (GtkUIManager          *manager,
                ^
[ 58%] Building C object CMakeFiles/hardinfo.dir/shell/report.c.o
[ 59%] Building C object CMakeFiles/hardinfo.dir/shell/shell.c.o
/home/max/hardinfo/shell/shell.c: In function ‘shell_ui_manager_set_visible’:
/home/max/hardinfo/shell/shell.c:77:5: warning: ‘gtk_ui_manager_get_widget’ is deprecated [-Wdeprecated-declarations]
     widget = gtk_ui_manager_get_widget(shell->ui_manager, path);
     ^
In file included from /usr/include/gtk-3.0/gtk/gtk.h:270:0,
                 from /home/max/hardinfo/shell/shell.c:21:
/usr/include/gtk-3.0/gtk/deprecated/gtkuimanager.h:149:16: note: declared here
 GtkWidget     *gtk_ui_manager_get_widget          (GtkUIManager          *manager,
                ^
/home/max/hardinfo/shell/shell.c: In function ‘shell_action_set_property’:
/home/max/hardinfo/shell/shell.c:108:5: warning: ‘gtk_action_group_get_action’ is deprecated [-Wdeprecated-declarations]
     action = gtk_action_group_get_action(shell->action_group, action_name);
     ^
In file included from /usr/include/gtk-3.0/gtk/gtk.h:240:0,
                 from /home/max/hardinfo/shell/shell.c:21:
/usr/include/gtk-3.0/gtk/deprecated/gtkactiongroup.h:195:17: note: declared here
 GtkAction      *gtk_action_group_get_action              (GtkActionGroup             *action_group,
                 ^
/home/max/hardinfo/shell/shell.c: In function ‘shell_action_set_label’:
/home/max/hardinfo/shell/shell.c:128:6: warning: ‘gtk_action_group_get_action’ is deprecated [-Wdeprecated-declarations]
      gtk_action_group_get_action(shell->action_group, action_name);
      ^
In file included from /usr/include/gtk-3.0/gtk/gtk.h:240:0,
                 from /home/max/hardinfo/shell/shell.c:21:
/usr/include/gtk-3.0/gtk/deprecated/gtkactiongroup.h:195:17: note: declared here
 GtkAction      *gtk_action_group_get_action              (GtkActionGroup             *action_group,
                 ^
/home/max/hardinfo/shell/shell.c:130:6: warning: ‘gtk_action_set_label’ is deprecated [-Wdeprecated-declarations]
      gtk_action_set_label(action, label);
      ^
In file included from /usr/include/gtk-3.0/gtk/deprecated/gtkactivatable.h:25:0,
                 from /usr/include/gtk-3.0/gtk/gtk.h:238,
                 from /home/max/hardinfo/shell/shell.c:21:
/usr/include/gtk-3.0/gtk/deprecated/gtkaction.h:164:23: note: declared here
 void                  gtk_action_set_label              (GtkAction   *action,
                       ^
/home/max/hardinfo/shell/shell.c: In function ‘shell_action_set_enabled’:
/home/max/hardinfo/shell/shell.c:142:6: warning: ‘gtk_action_group_get_action’ is deprecated [-Wdeprecated-declarations]
      gtk_action_group_get_action(shell->action_group, action_name);
      ^
In file included from /usr/include/gtk-3.0/gtk/gtk.h:240:0,
                 from /home/max/hardinfo/shell/shell.c:21:
/usr/include/gtk-3.0/gtk/deprecated/gtkactiongroup.h:195:17: note: declared here
 GtkAction      *gtk_action_group_get_action              (GtkActionGroup             *action_group,
                 ^
/home/max/hardinfo/shell/shell.c:144:6: warning: ‘gtk_action_set_sensitive’ is deprecated [-Wdeprecated-declarations]
      gtk_action_set_sensitive(action, setting);
      ^
In file included from /usr/include/gtk-3.0/gtk/deprecated/gtkactivatable.h:25:0,
                 from /usr/include/gtk-3.0/gtk/gtk.h:238,
                 from /home/max/hardinfo/shell/shell.c:21:
/usr/include/gtk-3.0/gtk/deprecated/gtkaction.h:109:14: note: declared here
 void         gtk_action_set_sensitive          (GtkAction     *action,
              ^
/home/max/hardinfo/shell/shell.c: In function ‘shell_action_get_enabled’:
/home/max/hardinfo/shell/shell.c:156:5: warning: ‘gtk_action_group_get_action’ is deprecated [-Wdeprecated-declarations]
     action = gtk_action_group_get_action(shell->action_group, action_name);
     ^
In file included from /usr/include/gtk-3.0/gtk/gtk.h:240:0,
                 from /home/max/hardinfo/shell/shell.c:21:
/usr/include/gtk-3.0/gtk/deprecated/gtkactiongroup.h:195:17: note: declared here
 GtkAction      *gtk_action_group_get_action              (GtkActionGroup             *action_group,
                 ^
/home/max/hardinfo/shell/shell.c:158:2: warning: ‘gtk_action_get_sensitive’ is deprecated [-Wdeprecated-declarations]
  return gtk_action_get_sensitive(action);
  ^
In file included from /usr/include/gtk-3.0/gtk/deprecated/gtkactivatable.h:25:0,
                 from /usr/include/gtk-3.0/gtk/gtk.h:238,
                 from /home/max/hardinfo/shell/shell.c:21:
/usr/include/gtk-3.0/gtk/deprecated/gtkaction.h:107:14: note: declared here
 gboolean     gtk_action_get_sensitive          (GtkAction     *action);
              ^
/home/max/hardinfo/shell/shell.c: In function ‘shell_action_get_active’:
/home/max/hardinfo/shell/shell.c:184:5: warning: ‘gtk_action_group_get_action’ is deprecated [-Wdeprecated-declarations]
     action = gtk_action_group_get_action(shell->action_group, action_name);
     ^
In file included from /usr/include/gtk-3.0/gtk/gtk.h:240:0,
                 from /home/max/hardinfo/shell/shell.c:21:
/usr/include/gtk-3.0/gtk/deprecated/gtkactiongroup.h:195:17: note: declared here
 GtkAction      *gtk_action_group_get_action              (GtkActionGroup             *action_group,
                 ^
/home/max/hardinfo/shell/shell.c:186:2: warning: ‘gtk_action_get_proxies’ is deprecated [-Wdeprecated-declarations]
  proxies = gtk_action_get_proxies(action);
  ^
In file included from /usr/include/gtk-3.0/gtk/deprecated/gtkactivatable.h:25:0,
                 from /usr/include/gtk-3.0/gtk/gtk.h:238,
                 from /home/max/hardinfo/shell/shell.c:21:
/usr/include/gtk-3.0/gtk/deprecated/gtkaction.h:130:14: note: declared here
 GSList *     gtk_action_get_proxies            (GtkAction     *action);
              ^
/home/max/hardinfo/shell/shell.c: In function ‘shell_action_set_active’:
/home/max/hardinfo/shell/shell.c:211:5: warning: ‘gtk_action_group_get_action’ is deprecated [-Wdeprecated-declarations]
     action = gtk_action_group_get_action(shell->action_group, action_name);
     ^
In file included from /usr/include/gtk-3.0/gtk/gtk.h:240:0,
                 from /home/max/hardinfo/shell/shell.c:21:
/usr/include/gtk-3.0/gtk/deprecated/gtkactiongroup.h:195:17: note: declared here
 GtkAction      *gtk_action_group_get_action              (GtkActionGroup             *action_group,
                 ^
/home/max/hardinfo/shell/shell.c:213:2: warning: ‘gtk_action_get_proxies’ is deprecated [-Wdeprecated-declarations]
  proxies = gtk_action_get_proxies(action);
  ^
In file included from /usr/include/gtk-3.0/gtk/deprecated/gtkactivatable.h:25:0,
                 from /usr/include/gtk-3.0/gtk/gtk.h:238,
                 from /home/max/hardinfo/shell/shell.c:21:
/usr/include/gtk-3.0/gtk/deprecated/gtkaction.h:130:14: note: declared here
 GSList *     gtk_action_get_proxies            (GtkAction     *action);
              ^
/home/max/hardinfo/shell/shell.c: In function ‘menu_item_set_icon_always_visible’:
/home/max/hardinfo/shell/shell.c:514:5: warning: ‘gtk_ui_manager_get_widget’ is deprecated [-Wdeprecated-declarations]
     menuitem = gtk_ui_manager_get_widget(shell->ui_manager, path);
     ^
In file included from /usr/include/gtk-3.0/gtk/gtk.h:270:0,
                 from /home/max/hardinfo/shell/shell.c:21:
/usr/include/gtk-3.0/gtk/deprecated/gtkuimanager.h:149:16: note: declared here
 GtkWidget     *gtk_ui_manager_get_widget          (GtkUIManager          *manager,
                ^
/home/max/hardinfo/shell/shell.c: In function ‘add_module_to_menu’:
/home/max/hardinfo/shell/shell.c:551:5: warning: ‘gtk_action_group_get_action’ is deprecated [-Wdeprecated-declarations]
     if ((action = gtk_action_group_get_action(shell->action_group, name))) {
     ^
In file included from /usr/include/gtk-3.0/gtk/gtk.h:240:0,
                 from /home/max/hardinfo/shell/shell.c:21:
/usr/include/gtk-3.0/gtk/deprecated/gtkactiongroup.h:195:17: note: declared here
 GtkAction      *gtk_action_group_get_action              (GtkActionGroup             *action_group,
                 ^
/home/max/hardinfo/shell/shell.c:552:9: warning: ‘gtk_action_group_remove_action’ is deprecated [-Wdeprecated-declarations]
         gtk_action_group_remove_action(shell->action_group, action);
         ^
In file included from /usr/include/gtk-3.0/gtk/gtk.h:240:0,
                 from /home/max/hardinfo/shell/shell.c:21:
/usr/include/gtk-3.0/gtk/deprecated/gtkactiongroup.h:207:17: note: declared here
 void            gtk_action_group_remove_action           (GtkActionGroup             *action_group,
                 ^
/home/max/hardinfo/shell/shell.c:555:5: warning: ‘gtk_action_group_get_action’ is deprecated [-Wdeprecated-declarations]
     if ((action = gtk_action_group_get_action(shell->action_group, about_module))) {
     ^
In file included from /usr/include/gtk-3.0/gtk/gtk.h:240:0,
                 from /home/max/hardinfo/shell/shell.c:21:
/usr/include/gtk-3.0/gtk/deprecated/gtkactiongroup.h:195:17: note: declared here
 GtkAction      *gtk_action_group_get_action              (GtkActionGroup             *action_group,
                 ^
/home/max/hardinfo/shell/shell.c:556:9: warning: ‘gtk_action_group_remove_action’ is deprecated [-Wdeprecated-declarations]
         gtk_action_group_remove_action(shell->action_group, action);
         ^
In file included from /usr/include/gtk-3.0/gtk/gtk.h:240:0,
                 from /home/max/hardinfo/shell/shell.c:21:
/usr/include/gtk-3.0/gtk/deprecated/gtkactiongroup.h:207:17: note: declared here
 void            gtk_action_group_remove_action           (GtkActionGroup             *action_group,
                 ^
/home/max/hardinfo/shell/shell.c:559:5: warning: ‘gtk_action_group_add_actions’ is deprecated [-Wdeprecated-declarations]
     gtk_action_group_add_actions(shell->action_group, entries, 2, NULL);
     ^
In file included from /usr/include/gtk-3.0/gtk/gtk.h:240:0,
                 from /home/max/hardinfo/shell/shell.c:21:
/usr/include/gtk-3.0/gtk/deprecated/gtkactiongroup.h:210:17: note: declared here
 void            gtk_action_group_add_actions             (GtkActionGroup             *action_group,
                 ^
/home/max/hardinfo/shell/shell.c:561:5: warning: ‘gtk_ui_manager_new_merge_id’ is deprecated [-Wdeprecated-declarations]
     merge_id = gtk_ui_manager_new_merge_id(shell->ui_manager);
     ^
In file included from /usr/include/gtk-3.0/gtk/gtk.h:270:0,
                 from /home/max/hardinfo/shell/shell.c:21:
/usr/include/gtk-3.0/gtk/deprecated/gtkuimanager.h:186:16: note: declared here
 guint          gtk_ui_manager_new_merge_id        (GtkUIManager          *manager);
                ^
/home/max/hardinfo/shell/shell.c:562:5: warning: ‘gtk_ui_manager_add_ui’ is deprecated [-Wdeprecated-declarations]
     gtk_ui_manager_add_ui(shell->ui_manager,
     ^
In file included from /usr/include/gtk-3.0/gtk/gtk.h:270:0,
                 from /home/max/hardinfo/shell/shell.c:21:
/usr/include/gtk-3.0/gtk/deprecated/gtkuimanager.h:171:16: note: declared here
 void           gtk_ui_manager_add_ui              (GtkUIManager          *manager,
                ^
/home/max/hardinfo/shell/shell.c:568:5: warning: ‘gtk_ui_manager_new_merge_id’ is deprecated [-Wdeprecated-declarations]
     merge_id = gtk_ui_manager_new_merge_id(shell->ui_manager);
     ^
In file included from /usr/include/gtk-3.0/gtk/gtk.h:270:0,
                 from /home/max/hardinfo/shell/shell.c:21:
/usr/include/gtk-3.0/gtk/deprecated/gtkuimanager.h:186:16: note: declared here
 guint          gtk_ui_manager_new_merge_id        (GtkUIManager          *manager);
                ^
/home/max/hardinfo/shell/shell.c:569:5: warning: ‘gtk_ui_manager_add_ui’ is deprecated [-Wdeprecated-declarations]
     gtk_ui_manager_add_ui(shell->ui_manager,
     ^
In file included from /usr/include/gtk-3.0/gtk/gtk.h:270:0,
                 from /home/max/hardinfo/shell/shell.c:21:
/usr/include/gtk-3.0/gtk/deprecated/gtkuimanager.h:171:16: note: declared here
 void           gtk_ui_manager_add_ui              (GtkUIManager          *manager,
                ^
/home/max/hardinfo/shell/shell.c: In function ‘add_module_entry_to_view_menu’:
/home/max/hardinfo/shell/shell.c:598:5: warning: ‘gtk_action_group_get_action’ is deprecated [-Wdeprecated-declarations]
     if ((action = gtk_action_group_get_action(shell->action_group, name))) {
     ^
In file included from /usr/include/gtk-3.0/gtk/gtk.h:240:0,
                 from /home/max/hardinfo/shell/shell.c:21:
/usr/include/gtk-3.0/gtk/deprecated/gtkactiongroup.h:195:17: note: declared here
 GtkAction      *gtk_action_group_get_action              (GtkActionGroup             *action_group,
                 ^
/home/max/hardinfo/shell/shell.c:599:9: warning: ‘gtk_action_group_remove_action’ is deprecated [-Wdeprecated-declarations]
         gtk_action_group_remove_action(shell->action_group, action);
         ^
In file included from /usr/include/gtk-3.0/gtk/gtk.h:240:0,
                 from /home/max/hardinfo/shell/shell.c:21:
/usr/include/gtk-3.0/gtk/deprecated/gtkactiongroup.h:207:17: note: declared here
 void            gtk_action_group_remove_action           (GtkActionGroup             *action_group,
                 ^
/home/max/hardinfo/shell/shell.c:602:5: warning: ‘gtk_action_group_add_actions’ is deprecated [-Wdeprecated-declarations]
     gtk_action_group_add_actions(shell->action_group, &entry, 1, iter);
     ^
In file included from /usr/include/gtk-3.0/gtk/gtk.h:240:0,
                 from /home/max/hardinfo/shell/shell.c:21:
/usr/include/gtk-3.0/gtk/deprecated/gtkactiongroup.h:210:17: note: declared here
 void            gtk_action_group_add_actions             (GtkActionGroup             *action_group,
                 ^
/home/max/hardinfo/shell/shell.c:604:5: warning: ‘gtk_ui_manager_new_merge_id’ is deprecated [-Wdeprecated-declarations]
     merge_id = gtk_ui_manager_new_merge_id(shell->ui_manager);
     ^
In file included from /usr/include/gtk-3.0/gtk/gtk.h:270:0,
                 from /home/max/hardinfo/shell/shell.c:21:
/usr/include/gtk-3.0/gtk/deprecated/gtkuimanager.h:186:16: note: declared here
 guint          gtk_ui_manager_new_merge_id        (GtkUIManager          *manager);
                ^
/home/max/hardinfo/shell/shell.c:606:5: warning: ‘gtk_ui_manager_add_ui’ is deprecated [-Wdeprecated-declarations]
     gtk_ui_manager_add_ui(shell->ui_manager,
     ^
In file included from /usr/include/gtk-3.0/gtk/gtk.h:270:0,
                 from /home/max/hardinfo/shell/shell.c:21:
/usr/include/gtk-3.0/gtk/deprecated/gtkuimanager.h:171:16: note: declared here
 void           gtk_ui_manager_add_ui              (GtkUIManager          *manager,
                ^
```
I thought about removing these strings, but in the end, I've decided just to comment them and write "// Removed warning for GTK3" for easier searching.
First, I wanted to make simple menu with one action "Quit" as written here (http://zetcode.com/gui/gtk2/menusandtoolbars/), but it doesn't appear. I've tried to do everything, but without a result.
So I hope that somebody will fix it.