### PR TITLE
hardinfo: add cli option to skip benchmarks

### DIFF
--- a/hardinfo/util.c
+++ b/hardinfo/util.c
@@ -388,6 +388,7 @@ void parameters_init(int *argc, char ***argv, ProgramParameters * param)
     static gboolean list_modules = FALSE;
     static gboolean autoload_deps = FALSE;
     static gboolean run_xmlrpc_server = FALSE;
+    static gboolean skip_benchmarks = FALSE;
     static gchar *report_format = NULL;
     static gchar *run_benchmark = NULL;
     static gchar *result_format = NULL;
@@ -450,6 +451,12 @@ void parameters_init(int *argc, char ***argv, ProgramParameters * param)
 	 .arg = G_OPTION_ARG_NONE,
 	 .arg_data = &show_version,
 	 .description = N_("shows program version and quit")},
+	{
+	 .long_name = "skip-benchmarks",
+	 .short_name = 's',
+	 .arg = G_OPTION_ARG_NONE,
+	 .arg_data = &skip_benchmarks,
+	 .description = N_("do not run benchmarks")},
 	{NULL}
     };
     GOptionContext *ctx;
@@ -478,6 +485,7 @@ void parameters_init(int *argc, char ***argv, ProgramParameters * param)
     param->result_format = result_format;
     param->autoload_deps = autoload_deps;
     param->run_xmlrpc_server = run_xmlrpc_server;
+    param->skip_benchmarks = skip_benchmarks;
     param->argv0 = *(argv)[0];
 
     if (report_format && g_str_equal(report_format, "html"))

--- a/includes/hardinfo.h
+++ b/includes/hardinfo.h
@@ -50,6 +50,7 @@ struct _ProgramParameters {
   gboolean list_modules;
   gboolean autoload_deps;
   gboolean run_xmlrpc_server;
+  gboolean skip_benchmarks;
 
   gint     report_format;
 

--- a/modules/benchmark.c
+++ b/modules/benchmark.c
@@ -441,6 +441,8 @@ static void do_benchmark(void (*benchmark_function)(void), int entry)
 {
     int old_priority = 0;
 
+    if (params.skip_benchmarks) return;
+
     if (params.gui_running && !sending_benchmark_results) {
        gchar *argv[] = { params.argv0, "-b", entries[entry].name,
                          "-m", "benchmark.so", "-a", NULL };


### PR DESCRIPTION
If you just need the hardware report, this makes it so much faster.
