### PR TITLE
added info about runtime depend on usbutils fixed #226

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,11 @@ SETTING UP
 Most things in HardInfo are detected automatically. However, some things
 depends on manual set up. They are:
 
+### Usb listing
+
+Recent distributions does not ship anymore usbutils by default, currently 
+usbutils package must provide the `lsusb` command to right working of the usb information module.
+
 ### Sensors
 
 **lm-sensors**: If your computer is compatible with lm-sensors module, use by example the


### PR DESCRIPTION
usbutils are not included anymore in mayor distribution, found on debian derivates and in some rpm based GPL distros

(fixes #226)