### PR TITLE
fix for #251 missing <unistd.h> at "hardinfo.h"

### DIFF
--- a/includes/hardinfo.h
+++ b/includes/hardinfo.h
@@ -19,6 +19,7 @@
 #ifndef __HARDINFO_H__
 #define __HARDINFO_H__
 
+#include <unistd.h>
 #include <gtk/gtk.h>
 #include "config.h"
 #include "shell.h"


### PR DESCRIPTION
missing <unistd.h> at "hardinfo.h" produces some errors in many environments