### PR TITLE
vendor.c: add some data fields and cleanup

### DIFF
--- a/hardinfo/hardinfo.c
+++ b/hardinfo/hardinfo.c
@@ -156,6 +156,7 @@ int main(int argc, char **argv)
     }
 
     moreinfo_shutdown();
+    vendor_cleanup();
 
     DEBUG("finished");
     return exit_code;

--- a/includes/vendor.h
+++ b/includes/vendor.h
@@ -24,11 +24,16 @@ struct _Vendor {
   char *match_string;
   int match_case; /* 0 = ignore case, 1 = match case */
   char *name;
+  char *name_short;
   char *url;
+  char *url_support;
 };
 
-void  vendor_init(void);
+void vendor_init(void);
+void vendor_cleanup(void);
+const Vendor *vendor_match(const gchar *id_str, ...); /* end list of strings with NULL */
 const gchar *vendor_get_name(const gchar *id_str);
 const gchar *vendor_get_url(const gchar *id_str);
+void vendor_free(Vendor *v);
 
 #endif	/* __VENDOR_H__ */


### PR DESCRIPTION
* Initialize strings to empty in `read_from_vendor_ids()`
* vendor.ids format reader clears all fields at `name`
* Added `name_short`, and `url_support` fields
* `vendor_cleanup()` function that frees `vendor_list`
* `vendor_match()` returns the whole `Vendor` data structure