### PR TITLE
Fix for the fix

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "deps/uber-graph"]
 	path = deps/uber-graph
-	url = https://gitlab.gnome.org/chergert/uber-graph
+	url = https://gitlab.gnome.org/chergert/uber-graph.git


### PR DESCRIPTION
Removes the warning:
```
1@device:~/hardinfo$ git submodule update --init
Submodule 'deps/uber-graph' (https://gitlab.gnome.org/chergert/uber-graph) registered for path 'deps/uber-graph'
Cloning into '/home/1/hardinfo/deps/uber-graph'...
warning: redirecting to https://gitlab.gnome.org/chergert/uber-graph.git/
Submodule path 'deps/uber-graph': checked out 'd31c8014d8cc9f293dfecfcb4bd6a7bf4d61c0be'
```