### PR TITLE
translation files update

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-08-14 22:23-0500\n"
+"POT-Creation-Date: 2018-06-09 14:09-0500\n"
 "PO-Revision-Date: 2016-06-10 12:11+0200\n"
 "Last-Translator: Alexander Münch <git@thehacker.biz>\n"
 "Language-Team: German\n"
@@ -20,15 +20,200 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 1.8.7.1\n"
 
+#: hardinfo/cpu_util.c:30
+msgid "Little Endian"
+msgstr ""
+
+#: hardinfo/cpu_util.c:32
+msgid "Big Endian"
+msgstr ""
+
+#: hardinfo/cpu_util.c:184 hardinfo/cpu_util.c:195
+msgid "Frequency Scaling"
+msgstr ""
+
+#: hardinfo/cpu_util.c:185
+msgid "Minimum"
+msgstr ""
+
+#: hardinfo/cpu_util.c:185 hardinfo/cpu_util.c:186 hardinfo/cpu_util.c:187
+msgid "kHz"
+msgstr ""
+
+#: hardinfo/cpu_util.c:186
+msgid "Maximum"
+msgstr ""
+
+#: hardinfo/cpu_util.c:187
+msgid "Current"
+msgstr ""
+
+#: hardinfo/cpu_util.c:188
+msgid "Transition Latency"
+msgstr ""
+
+#: hardinfo/cpu_util.c:188
+msgid "ns"
+msgstr ""
+
+#: hardinfo/cpu_util.c:189
+msgid "Governor"
+msgstr ""
+
+#: hardinfo/cpu_util.c:190 hardinfo/cpu_util.c:196 modules/devices/gpu.c:149
+#: modules/devices/pci.c:116
+msgid "Driver"
+msgstr "Treiber"
+
+#: hardinfo/cpu_util.c:202 modules/computer.c:596
+#: modules/devices/arm/processor.c:242 modules/devices/x86/processor.c:284
+#: modules/devices/x86/processor.c:388 modules/devices/x86/processor.c:524
+msgid "(Not Available)"
+msgstr ""
+
+#: hardinfo/cpu_util.c:210 hardinfo/cpu_util.c:212
+msgid "Socket"
+msgstr ""
+
+#: hardinfo/cpu_util.c:215 hardinfo/cpu_util.c:217
+msgid "Core"
+msgstr ""
+
+#: hardinfo/cpu_util.c:220
+msgid "Book"
+msgstr ""
+
+#: hardinfo/cpu_util.c:222
+msgid "Drawer"
+msgstr ""
+
+#: hardinfo/cpu_util.c:228 modules/devices/arm/processor.c:449
+#: modules/devices/x86/processor.c:697
+msgid "Topology"
+msgstr ""
+
+#: hardinfo/cpu_util.c:229
+msgid "ID"
+msgstr ""
+
+#: hardinfo/dmi_util.c:130
+msgid "Invalid chassis type (0)"
+msgstr ""
+
+#: hardinfo/dmi_util.c:131 hardinfo/dmi_util.c:132
+msgid "Unknown chassis type"
+msgstr ""
+
+#: hardinfo/dmi_util.c:133
+msgid "Desktop"
+msgstr ""
+
+#: hardinfo/dmi_util.c:134
+msgid "Low-profile Desktop"
+msgstr ""
+
+#: hardinfo/dmi_util.c:135
+msgid "Pizza Box"
+msgstr ""
+
+#: hardinfo/dmi_util.c:136
+msgid "Mini Tower"
+msgstr ""
+
+#: hardinfo/dmi_util.c:137
+msgid "Tower"
+msgstr ""
+
+#: hardinfo/dmi_util.c:138
+msgid "Portable"
+msgstr ""
+
+#: hardinfo/dmi_util.c:139 modules/computer.c:330 modules/computer.c:339
+#: modules/computer.c:361
+msgid "Laptop"
+msgstr ""
+
+#: hardinfo/dmi_util.c:140
+msgid "Notebook"
+msgstr ""
+
+#: hardinfo/dmi_util.c:141
+msgid "Handheld"
+msgstr ""
+
+#: hardinfo/dmi_util.c:142
+msgid "Docking Station"
+msgstr ""
+
+#: hardinfo/dmi_util.c:143
+msgid "All-in-one"
+msgstr ""
+
+#: hardinfo/dmi_util.c:144
+msgid "Subnotebook"
+msgstr ""
+
+#: hardinfo/dmi_util.c:145
+msgid "Space-saving"
+msgstr ""
+
+#: hardinfo/dmi_util.c:146
+msgid "Lunch Box"
+msgstr ""
+
+#: hardinfo/dmi_util.c:147
+msgid "Main Server Chassis"
+msgstr ""
+
+#: hardinfo/dmi_util.c:148
+msgid "Expansion Chassis"
+msgstr ""
+
+#: hardinfo/dmi_util.c:149
+msgid "Sub Chassis"
+msgstr ""
+
+#: hardinfo/dmi_util.c:150
+msgid "Bus Expansion Chassis"
+msgstr ""
+
+#: hardinfo/dmi_util.c:151
+msgid "Peripheral Chassis"
+msgstr ""
+
+#: hardinfo/dmi_util.c:152
+msgid "RAID Chassis"
+msgstr ""
+
+#: hardinfo/dmi_util.c:153
+msgid "Rack Mount Chassis"
+msgstr ""
+
+#: hardinfo/dmi_util.c:154
+msgid "Sealed-case PC"
+msgstr ""
+
+#: hardinfo/dt_util.c:1011
+msgid "phandle Map"
+msgstr ""
+
+#: hardinfo/dt_util.c:1012
+msgid "Alias Map"
+msgstr ""
+
+#: hardinfo/dt_util.c:1013
+msgid "Symbol Map"
+msgstr ""
+
 #. / %d will be latest year of copyright
-#: hardinfo/hardinfo.c:49
+#: hardinfo/hardinfo.c:50
 #, c-format
 msgid ""
 "Copyright (C) 2003-%d Leandro A. F. Pereira. See COPYING for details.\n"
 "\n"
 msgstr ""
 
-#: hardinfo/hardinfo.c:51
+#: hardinfo/hardinfo.c:52
 #, c-format
 msgid ""
 "Compile-time options:\n"
@@ -39,18 +224,16 @@ msgid ""
 "  Compiled for:      %s\n"
 msgstr ""
 
-#: hardinfo/hardinfo.c:57 hardinfo/hardinfo.c:58 modules/computer.c:605
-#: modules/devices/inputdevices.c:128 modules/devices/pci.c:112
-#: modules/devices/printers.c:138
+#: hardinfo/hardinfo.c:58 hardinfo/hardinfo.c:59 modules/computer.c:644
+#: modules/devices/inputdevices.c:128 modules/devices/printers.c:138
 msgid "Yes"
 msgstr "Ja"
 
-#: hardinfo/hardinfo.c:58 modules/computer.c:605 modules/devices/pci.c:112
-#: modules/devices/printers.c:138
+#: hardinfo/hardinfo.c:59 modules/computer.c:644 modules/devices/printers.c:138
 msgid "No"
 msgstr "Nein"
 
-#: hardinfo/hardinfo.c:69
+#: hardinfo/hardinfo.c:70
 #, c-format
 msgid ""
 "Failed to find runtime data.\n"
@@ -59,56 +242,58 @@ msgid ""
 "• See if %s and %s exists and you have read permission."
 msgstr ""
 
-#: hardinfo/hardinfo.c:76
+#: hardinfo/hardinfo.c:77
 #, c-format
 msgid ""
 "Modules:\n"
 "%-20s %-15s %-12s\n"
 msgstr ""
 
-#: hardinfo/hardinfo.c:77
+#: hardinfo/hardinfo.c:78
 msgid "File Name"
 msgstr ""
 
-#: hardinfo/hardinfo.c:77 modules/computer.c:534 modules/computer.c:562
-#: modules/computer.c:630 modules/computer/languages.c:104
-#: modules/computer/modules.c:146 modules/devices/arm/processor.c:336
+#: hardinfo/hardinfo.c:78 modules/computer.c:528 modules/computer.c:556
+#: modules/computer.c:674 modules/computer/languages.c:104
+#: modules/computer/modules.c:146 modules/devices/arm/processor.c:447
+#: modules/devices/dmi.c:37 modules/devices/dmi.c:46
 #: modules/devices/ia64/processor.c:160 modules/devices/inputdevices.c:116
-#: modules/devices/pci.c:215 modules/devices/sh/processor.c:84
-#: modules/devices/x86/processor.c:455 modules/network.c:326
+#: modules/devices/sh/processor.c:84 modules/devices/x86/processor.c:696
+#: modules/network.c:326
 msgid "Name"
 msgstr "Name"
 
-#: hardinfo/hardinfo.c:77 modules/computer.c:296 modules/computer.c:505
-#: modules/computer.c:507 modules/computer.c:595 modules/computer.c:603
+#: hardinfo/hardinfo.c:78 modules/computer.c:304 modules/computer.c:499
+#: modules/computer.c:501 modules/computer.c:602 modules/devices/dmi.c:40
+#: modules/devices/dmi.c:44 modules/devices/dmi.c:48 modules/devices/dmi.c:54
 #: modules/devices/inputdevices.c:121
 msgid "Version"
 msgstr ""
 
-#: hardinfo/hardinfo.c:124
+#: hardinfo/hardinfo.c:125
 #, c-format
-msgid "Unknown benchmark ``%s'' or libbenchmark.so not loaded"
+msgid "Unknown benchmark ``%s'' or benchmark.so not loaded"
 msgstr ""
 
-#: hardinfo/hardinfo.c:152
+#: hardinfo/hardinfo.c:155
 msgid "Don't know what to do. Exiting."
 msgstr ""
 
-#: hardinfo/util.c:104 modules/computer/uptime.c:53
+#: hardinfo/util.c:104 modules/computer/uptime.c:54
 #, c-format
 msgid "%d day"
 msgid_plural "%d days"
 msgstr[0] "%d Tag"
 msgstr[1] "%d Tage"
 
-#: hardinfo/util.c:105 modules/computer/uptime.c:54
+#: hardinfo/util.c:105 modules/computer/uptime.c:55
 #, c-format
 msgid "%d hour"
 msgid_plural "%d hours"
 msgstr[0] "%d Stunde"
 msgstr[1] "%d Stunden"
 
-#: hardinfo/util.c:106 modules/computer/uptime.c:55
+#: hardinfo/util.c:106 modules/computer/uptime.c:56
 #, c-format
 msgid "%d minute"
 msgid_plural "%d minutes"
@@ -164,89 +349,92 @@ msgstr "Warnung"
 msgid "Fatal Error"
 msgstr "Kritischer Fehler"
 
-#: hardinfo/util.c:401
+#: hardinfo/util.c:403
 msgid "creates a report and prints to standard output"
 msgstr ""
 
-#: hardinfo/util.c:407
+#: hardinfo/util.c:409
 msgid "chooses a report format (text, html)"
 msgstr ""
 
-#: hardinfo/util.c:413
+#: hardinfo/util.c:415
 msgid "run benchmark; requires benchmark.so to be loaded"
 msgstr ""
 
-#: hardinfo/util.c:419
+#: hardinfo/util.c:421
+msgid "benchmark result format ([short], conf, shell)"
+msgstr ""
+
+#: hardinfo/util.c:427
 msgid "lists modules"
 msgstr ""
 
-#: hardinfo/util.c:425
+#: hardinfo/util.c:433
 msgid "specify module to load"
 msgstr ""
 
-#: hardinfo/util.c:431
+#: hardinfo/util.c:439
 msgid "automatically load module dependencies"
 msgstr ""
 
-#: hardinfo/util.c:438
+#: hardinfo/util.c:446
 msgid "run in XML-RPC server mode"
 msgstr ""
 
-#: hardinfo/util.c:445
+#: hardinfo/util.c:453
 msgid "shows program version and quit"
 msgstr ""
 
-#: hardinfo/util.c:450
+#: hardinfo/util.c:459
+msgid "do not run benchmarks"
+msgstr ""
+
+#: hardinfo/util.c:464
 msgid "- System Profiler and Benchmark tool"
 msgstr "- System-Profiler und Benchmark-Werkzeug"
 
-#: hardinfo/util.c:460
+#: hardinfo/util.c:474
 #, c-format
 msgid ""
 "Unrecognized arguments.\n"
 "Try ``%s --help'' for more information.\n"
 msgstr ""
 
-#: hardinfo/util.c:526
+#: hardinfo/util.c:542
 #, c-format
 msgid "Couldn't find a Web browser to open URL %s."
 msgstr "Konnte keinen Web-Browser finden, um die URL %s zu öffnen."
 
-#: hardinfo/util.c:875
+#: hardinfo/util.c:891
 #, c-format
 msgid "Module \"%s\" depends on module \"%s\", load it?"
 msgstr ""
 
-#: hardinfo/util.c:898
+#: hardinfo/util.c:914
 #, c-format
 msgid "Module \"%s\" depends on module \"%s\"."
 msgstr ""
 
-#: hardinfo/util.c:943
+#: hardinfo/util.c:959
 #, c-format
 msgid "No module could be loaded. Check permissions on \"%s\" and try again."
 msgstr ""
 
-#: hardinfo/util.c:947
+#: hardinfo/util.c:963
 msgid ""
 "No module could be loaded. Please use hardinfo -l to list all available "
 "modules and try again with a valid module list."
 msgstr ""
 
-#: hardinfo/util.c:1024
+#: hardinfo/util.c:1040
 #, c-format
 msgid "Scanning: %s..."
 msgstr ""
 
-#: hardinfo/util.c:1034 shell/shell.c:301 shell/shell.c:760 shell/shell.c:1795
-#: modules/benchmark.c:449 modules/benchmark.c:457
+#: hardinfo/util.c:1050 shell/shell.c:301 shell/shell.c:772 shell/shell.c:1850
+#: modules/benchmark.c:549 modules/benchmark.c:557
 msgid "Done."
 msgstr "Fertig."
-
-#: shell/callbacks.c:117
-#, c-format
-msgid "%s Module"
-msgstr ""
 
 #: shell/callbacks.c:128
 #, c-format
@@ -422,35 +610,51 @@ msgstr ""
 msgid "_Toolbar"
 msgstr "_Symbolleiste"
 
-#: shell/report.c:494 shell/report.c:502
+#: shell/report.c:500 shell/report.c:508
 msgid "Save File"
 msgstr "Datei speichern"
 
-#: shell/report.c:629
+#: shell/report.c:503 shell/report.c:935 shell/syncmanager.c:748
+msgid "_Cancel"
+msgstr ""
+
+#: shell/report.c:505
+msgid "_Save"
+msgstr ""
+
+#: shell/report.c:635
 msgid "Cannot create ReportContext. Programming bug?"
 msgstr ""
 
-#: shell/report.c:648
+#: shell/report.c:654
 msgid "Open the report with your web browser?"
 msgstr "Den Bericht in deinem Webbrowser öffnen?"
 
-#: shell/report.c:682
+#: shell/report.c:657
+msgid "_No"
+msgstr ""
+
+#: shell/report.c:658
+msgid "_Open"
+msgstr ""
+
+#: shell/report.c:688
 msgid "Generating report..."
 msgstr "Generiere Bericht…"
 
-#: shell/report.c:692
+#: shell/report.c:698
 msgid "Report saved."
 msgstr "Bericht gespeichert."
 
-#: shell/report.c:694
+#: shell/report.c:700
 msgid "Error while creating the report."
 msgstr "Fehler beim Erzeugen des Berichts."
 
-#: shell/report.c:796
+#: shell/report.c:802
 msgid "Generate Report"
 msgstr "Bericht generieren"
 
-#: shell/report.c:821
+#: shell/report.c:827
 msgid ""
 "<big><b>Generate Report</b></big>\n"
 "Please choose the information that you wish to view in your report:"
@@ -458,19 +662,15 @@ msgstr ""
 "<big><b>Bericht generieren</b></big>\n"
 "Bitte wähle die Informationen, die du in deinen Bereich einbeziehen möchtest:"
 
-#: shell/report.c:893
+#: shell/report.c:899
 msgid "Select _None"
 msgstr "_Nichts auswählen"
 
-#: shell/report.c:904
+#: shell/report.c:910
 msgid "Select _All"
 msgstr "_Alles auswählen"
 
-#: shell/report.c:929 shell/syncmanager.c:748
-msgid "_Cancel"
-msgstr ""
-
-#: shell/report.c:939
+#: shell/report.c:945
 msgid "_Generate"
 msgstr "_Generieren"
 
@@ -483,16 +683,16 @@ msgstr "%s - System-Informationen"
 msgid "System Information"
 msgstr "System-Informationen"
 
-#: shell/shell.c:747
+#: shell/shell.c:759
 msgid "Loading modules..."
 msgstr ""
 
-#: shell/shell.c:1660
+#: shell/shell.c:1715
 #, c-format
 msgid "<b>%s → Summary</b>"
 msgstr "<b>%s → Zusammenfassung</b>"
 
-#: shell/shell.c:1769
+#: shell/shell.c:1824
 msgid "Updating..."
 msgstr "Aktualisiere…"
 
@@ -575,93 +775,217 @@ msgstr "Netzwerk-Updater"
 msgid "_Synchronize"
 msgstr "_Synchronisieren"
 
-#: modules/benchmark.c:52
+#: modules/benchmark/benches.c:74
 msgid "CPU Blowfish"
 msgstr "CPU Blowfish"
 
-#: modules/benchmark.c:53
+#: modules/benchmark/benches.c:75
 msgid "CPU CryptoHash"
 msgstr "CPU Crypto-Hash"
 
-#: modules/benchmark.c:54
+#: modules/benchmark/benches.c:76
 msgid "CPU Fibonacci"
 msgstr "CPU Fibonacci"
 
-#: modules/benchmark.c:55
+#: modules/benchmark/benches.c:77
 msgid "CPU N-Queens"
 msgstr "CPU Damenproblem"
 
-#: modules/benchmark.c:56
+#: modules/benchmark/benches.c:78
 msgid "CPU Zlib"
 msgstr ""
 
-#: modules/benchmark.c:57
+#: modules/benchmark/benches.c:79
 msgid "FPU FFT"
 msgstr "FPU FFT"
 
-#: modules/benchmark.c:58
+#: modules/benchmark/benches.c:80
 msgid "FPU Raytracing"
 msgstr "FPU Raytracing"
 
-#: modules/benchmark.c:60
+#: modules/benchmark/benches.c:82
 msgid "GPU Drawing"
 msgstr "GPU Zeichnen"
 
-#: modules/benchmark.c:239 modules/benchmark.c:255
+#: modules/benchmark/benches.c:91
+msgid "Results in MiB/second. Higher is better."
+msgstr "Ergebnisse in MiB/Sekunde. Höhere Werte sind besser."
+
+#: modules/benchmark/benches.c:95
+msgid "Results in HIMarks. Higher is better."
+msgstr "Ergebnisse in HIMarks. Höhere Werte sind besser."
+
+#: modules/benchmark/benches.c:102
+msgid "Results in seconds. Lower is better."
+msgstr "Ergebnisse in Sekunden. Niedrigere Werte sind besser."
+
+#. /or modify
+#. *    it under the terms of the GNU General Public License as published by
+#. *    the Free Software Foundation, version 2.
+#. *
+#. *    This program is distributed in the hope that it will be useful,
+#. *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#. *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#. *    GNU General Public License for more details.
+#. *
+#. *    You should have received a copy of the GNU General Public License
+#. *    along with this program; if not, write to the Free Software
+#. *    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+#.
+#. / Used for an unknown value. Having it in only one place cleans up the .po line references
+#: modules/benchmark/bench_results.c:22 modules/computer.c:41
+#: modules/computer/display.c:41 modules/computer/os.c:279
+#: modules/devices.c:383 modules/devices/gpu.c:42 modules/devices/gpu.c:58
+#: modules/devices/gpu.c:150 modules/devices/gpu.c:151 modules/devices/pci.c:25
+#: modules/devices/pci.c:117 modules/devices/pci.c:118 modules/devices/usb.c:27
+#: modules/network/net.c:437 includes/cpu_util.h:11
+msgid "(Unknown)"
+msgstr ""
+
+#: modules/benchmark/bench_results.c:47 modules/benchmark/bench_results.c:322
+#: modules/devices/alpha/processor.c:90 modules/devices/arm/processor.c:276
+#: modules/devices/arm/processor.c:289 modules/devices/arm/processor.c:331
+#: modules/devices/arm/processor.c:478 modules/devices.c:310
+#: modules/devices.c:318 modules/devices.c:346
+#: modules/devices/ia64/processor.c:167 modules/devices/ia64/processor.c:196
+#: modules/devices/m68k/processor.c:87 modules/devices/mips/processor.c:77
+#: modules/devices/parisc/processor.c:158
+#: modules/devices/parisc/processor.c:191 modules/devices/ppc/processor.c:160
+#: modules/devices/ppc/processor.c:187 modules/devices/riscv/processor.c:186
+#: modules/devices/riscv/processor.c:214 modules/devices/s390/processor.c:160
+#: modules/devices/sh/processor.c:87 modules/devices/sh/processor.c:88
+#: modules/devices/sh/processor.c:89 modules/devices/x86/processor.c:318
+#: modules/devices/x86/processor.c:331 modules/devices/x86/processor.c:655
+#: modules/devices/x86/processor.c:726
+msgid "MHz"
+msgstr ""
+
+#: modules/benchmark/bench_results.c:374 modules/benchmark/bench_results.c:441
+msgid "kiB"
+msgstr ""
+
+#: modules/benchmark/bench_results.c:389 modules/benchmark/bench_results.c:426
+msgid "Benchmark Result"
+msgstr ""
+
+#: modules/benchmark/bench_results.c:390 modules/benchmark/bench_results.c:428
+msgid "Threads"
+msgstr ""
+
+#: modules/benchmark/bench_results.c:391 modules/benchmark/bench_results.c:431
+msgid "Note"
+msgstr ""
+
+#: modules/benchmark/bench_results.c:392 modules/benchmark/bench_results.c:432
+msgid ""
+"This result is from an old version of HardInfo. Results might not be "
+"comparable to current version. Some details are missing."
+msgstr ""
+
+#: modules/benchmark/bench_results.c:393 modules/benchmark/bench_results.c:433
+#: modules/devices/devicetree/pmac_data.c:81 modules/devices/sh/processor.c:85
+msgid "Machine"
+msgstr ""
+
+#: modules/benchmark/bench_results.c:394 modules/benchmark/bench_results.c:434
+#: modules/devices/devicetree.c:206 modules/devices/dmi.c:45
+msgid "Board"
+msgstr ""
+
+#: modules/benchmark/bench_results.c:395 modules/benchmark/bench_results.c:435
+msgid "CPU Name"
+msgstr ""
+
+#: modules/benchmark/bench_results.c:396 modules/benchmark/bench_results.c:436
+msgid "CPU Description"
+msgstr ""
+
+#: modules/benchmark/bench_results.c:397 modules/benchmark/bench_results.c:437
+#: modules/benchmark.c:390
 msgid "CPU Config"
 msgstr ""
 
-#: modules/benchmark.c:239 modules/benchmark.c:255
+#: modules/benchmark/bench_results.c:398 modules/benchmark/bench_results.c:438
+msgid "Threads Available"
+msgstr ""
+
+#: modules/benchmark/bench_results.c:399 modules/benchmark/bench_results.c:439
+msgid "GPU"
+msgstr ""
+
+#: modules/benchmark/bench_results.c:400 modules/benchmark/bench_results.c:440
+#: modules/computer.c:479
+msgid "OpenGL Renderer"
+msgstr "OpenGL-Renderer"
+
+#: modules/benchmark/bench_results.c:401 modules/benchmark/bench_results.c:441
+#: modules/computer.c:110 modules/computer.c:468 modules/devices.c:99
+msgid "Memory"
+msgstr "Hauptspeicher"
+
+#: modules/benchmark/bench_results.c:427
+msgid "Benchmark"
+msgstr ""
+
+#: modules/benchmark/bench_results.c:429
+msgid "Result"
+msgstr ""
+
+#: modules/benchmark/bench_results.c:430
+msgid "Elapsed Time"
+msgstr ""
+
+#: modules/benchmark/bench_results.c:442
+msgid "Handles"
+msgstr ""
+
+#: modules/benchmark/bench_results.c:443
+msgid "mid"
+msgstr ""
+
+#: modules/benchmark/bench_results.c:444
+msgid "cfg_val"
+msgstr ""
+
+#: modules/benchmark.c:390
 msgid "Results"
 msgstr "Ergebnisse"
 
-#: modules/benchmark.c:239 modules/benchmark.c:255 modules/computer.c:751
+#: modules/benchmark.c:390 modules/computer.c:811
 #: modules/devices/sparc/processor.c:75
 msgid "CPU"
 msgstr ""
 
-#: modules/benchmark.c:381
+#: modules/benchmark.c:460
 #, c-format
 msgid "Benchmarking: <b>%s</b>."
 msgstr "Benchmarke: <b>%s</b>."
 
-#: modules/benchmark.c:395
-msgid "Benchmarking. Please do not move your mouse or press any keys."
-msgstr "Benchmarke. Bitte bewege den Mauszeiger nicht und drücke keine Tasten."
-
-#: modules/benchmark.c:399
+#: modules/benchmark.c:479 modules/benchmark.c:498
 msgid "Cancel"
 msgstr "Abbrechen"
 
-#: modules/benchmark.c:536
-msgid "Results in MiB/second. Higher is better."
-msgstr "Ergebnisse in MiB/Sekunde. Höhere Werte sind besser."
+#: modules/benchmark.c:483 modules/benchmark.c:495
+msgid "Benchmarking. Please do not move your mouse or press any keys."
+msgstr "Benchmarke. Bitte bewege den Mauszeiger nicht und drücke keine Tasten."
 
-#: modules/benchmark.c:540
-msgid "Results in HIMarks. Higher is better."
-msgstr "Ergebnisse in HIMarks. Höhere Werte sind besser."
-
-#: modules/benchmark.c:547
-msgid "Results in seconds. Lower is better."
-msgstr "Ergebnisse in Sekunden. Niedrigere Werte sind besser."
-
-#: modules/benchmark.c:555
+#: modules/benchmark.c:567
 msgid "Benchmarks"
 msgstr "Benchmarks"
 
-#: modules/benchmark.c:573
+#: modules/benchmark.c:585
 msgid "Perform tasks and compare with other systems"
 msgstr "Erledigt Aufgaben und vergleicht die Ergebnisse mit anderen Systemen"
 
-#: modules/benchmark.c:663
+#: modules/benchmark.c:692
 msgid "Send benchmark results"
 msgstr "Übermittle Benchmark-Ergebnisse"
 
-#: modules/benchmark.c:668
+#: modules/benchmark.c:697
 msgid "Receive benchmark results"
 msgstr "Lade Benchmark-Ergebnisse"
 
-#: modules/computer/alsa.c:26 modules/computer.c:489
+#: modules/computer/alsa.c:26 modules/computer.c:483
 msgid "Audio Devices"
 msgstr "Audio-Geräte"
 
@@ -669,501 +993,501 @@ msgstr "Audio-Geräte"
 msgid "Audio Adapter"
 msgstr ""
 
-#: modules/computer/boots.c:33 modules/computer.c:73 modules/computer.c:546
-msgid "Boots"
-msgstr "Systemstarts"
-
-#: modules/computer.c:70
+#: modules/computer.c:76
 msgid "Summary"
 msgstr "Zusammenfassung"
 
-#: modules/computer.c:71 modules/computer.c:476 modules/computer.c:750
+#: modules/computer.c:77 modules/computer.c:471 modules/computer.c:810
 msgid "Operating System"
 msgstr "Betriebssystem"
 
-#: modules/computer.c:72
+#: modules/computer.c:78 modules/devices/gpu.c:151 modules/devices/pci.c:118
 msgid "Kernel Modules"
 msgstr "Kernel-Module"
 
-#: modules/computer.c:74
+#: modules/computer.c:79 modules/computer.c:540
+msgid "Boots"
+msgstr "Systemstarts"
+
+#: modules/computer.c:80
 msgid "Languages"
 msgstr "Sprachen"
 
-#: modules/computer.c:75
+#: modules/computer.c:81
 msgid "Filesystems"
 msgstr "Dateisysteme"
 
-#: modules/computer.c:76 modules/computer.c:481 modules/computer.c:590
+#: modules/computer.c:82 modules/computer.c:476
 msgid "Display"
 msgstr "Anzeige"
 
-#: modules/computer.c:77 modules/computer/environment.c:32
+#: modules/computer.c:83 modules/computer/environment.c:32
 msgid "Environment Variables"
 msgstr "Umgebungsvariablen"
 
-#: modules/computer.c:79
+#: modules/computer.c:85
 msgid "Development"
 msgstr "Entwicklung"
 
-#: modules/computer.c:81 modules/computer.c:617
+#: modules/computer.c:87 modules/computer.c:661
 msgid "Users"
 msgstr "Benutzer"
 
-#: modules/computer.c:82
+#: modules/computer.c:88
 msgid "Groups"
 msgstr "Gruppen"
 
-#: modules/computer.c:104 modules/computer.c:473 modules/devices.c:96
-#: modules/devices/pci.c:149
-msgid "Memory"
-msgstr "Hauptspeicher"
-
-#: modules/computer.c:106
+#: modules/computer.c:112
 #, c-format
 msgid "%dMB (%dMB used)"
 msgstr ""
 
-#: modules/computer.c:108 modules/computer.c:520
+#: modules/computer.c:114 modules/computer.c:514
 msgid "Uptime"
 msgstr ""
 
-#: modules/computer.c:110 modules/computer.c:478
+#: modules/computer.c:116 modules/computer.c:473
 msgid "Date/Time"
 msgstr ""
 
-#: modules/computer.c:115 modules/computer.c:521
+#: modules/computer.c:121 modules/computer.c:515
 msgid "Load Average"
 msgstr ""
 
-#: modules/computer.c:117 modules/computer.c:522
+#: modules/computer.c:123 modules/computer.c:516
 msgid "Available entropy in /dev/random"
 msgstr ""
 
-#: modules/computer.c:203
+#: modules/computer.c:211
 msgid "Scripting Languages"
 msgstr "Script-Sprachen"
 
-#: modules/computer.c:204
+#: modules/computer.c:212
 msgid "Gambas3 (gbr3)"
 msgstr ""
 
-#: modules/computer.c:205
+#: modules/computer.c:213
 msgid "Python"
 msgstr ""
 
-#: modules/computer.c:206
+#: modules/computer.c:214
 msgid "Python2"
 msgstr ""
 
-#: modules/computer.c:207
+#: modules/computer.c:215
 msgid "Python3"
 msgstr ""
 
-#: modules/computer.c:208
+#: modules/computer.c:216
 msgid "Perl"
 msgstr "Perl"
 
-#: modules/computer.c:209
+#: modules/computer.c:217
 msgid "Perl6 (VM)"
 msgstr ""
 
-#: modules/computer.c:210
+#: modules/computer.c:218
 msgid "Perl6"
 msgstr ""
 
-#: modules/computer.c:211
+#: modules/computer.c:219
 msgid "PHP"
 msgstr "PHP"
 
-#: modules/computer.c:212
+#: modules/computer.c:220
 msgid "Ruby"
 msgstr "Ruby"
 
-#: modules/computer.c:213
+#: modules/computer.c:221
 msgid "Bash"
 msgstr "Bash"
 
-#: modules/computer.c:214
+#: modules/computer.c:222
 msgid "Compilers"
 msgstr "Compiler"
 
-#: modules/computer.c:215
+#: modules/computer.c:223
 msgid "C (GCC)"
 msgstr "C (GCC)"
 
-#: modules/computer.c:216
+#: modules/computer.c:224
 msgid "C (Clang)"
 msgstr "C (Clang)"
 
-#: modules/computer.c:217
+#: modules/computer.c:225
 msgid "D (dmd)"
 msgstr "D (dmd)"
 
-#: modules/computer.c:218
+#: modules/computer.c:226
 msgid "Gambas3 (gbc3)"
 msgstr ""
 
-#: modules/computer.c:219
+#: modules/computer.c:227
 msgid "Java"
 msgstr "Java"
 
-#: modules/computer.c:220
+#: modules/computer.c:228
 msgid "CSharp (Mono, old)"
 msgstr "CSharp (Mono, old)"
 
-#: modules/computer.c:221
+#: modules/computer.c:229
 msgid "CSharp (Mono)"
 msgstr "CSharp (Mono)"
 
-#: modules/computer.c:222
+#: modules/computer.c:230
 msgid "Vala"
 msgstr "Vala"
 
-#: modules/computer.c:223
+#: modules/computer.c:231
 msgid "Haskell (GHC)"
 msgstr "Haskell (GHC)"
 
-#: modules/computer.c:224
+#: modules/computer.c:232
 msgid "FreePascal"
 msgstr "FreePascal"
 
-#: modules/computer.c:225
+#: modules/computer.c:233
 msgid "Go"
 msgstr ""
 
-#: modules/computer.c:226
+#: modules/computer.c:234
 msgid "Tools"
 msgstr "Werkzeug-Programme"
 
-#: modules/computer.c:227
+#: modules/computer.c:235
 msgid "make"
 msgstr "make"
 
-#: modules/computer.c:228
+#: modules/computer.c:236
 msgid "GDB"
 msgstr "GDB"
 
-#: modules/computer.c:229
+#: modules/computer.c:237
 msgid "strace"
 msgstr "strace"
 
-#: modules/computer.c:230
+#: modules/computer.c:238
 msgid "valgrind"
 msgstr "valgrind"
 
-#: modules/computer.c:231
+#: modules/computer.c:239
 msgid "QMake"
 msgstr "QMake"
 
-#: modules/computer.c:232
+#: modules/computer.c:240
 msgid "CMake"
 msgstr ""
 
-#: modules/computer.c:233
+#: modules/computer.c:241
 msgid "Gambas3 IDE"
 msgstr ""
 
-#: modules/computer.c:274
+#: modules/computer.c:282
 msgid "Not found"
 msgstr "Nicht gefunden"
 
-#: modules/computer.c:279
+#: modules/computer.c:287
 #, c-format
 msgid "Detecting version: %s"
 msgstr ""
 
-#: modules/computer.c:296
+#: modules/computer.c:304
 msgid "Program"
 msgstr "Programm"
 
-#: modules/computer.c:308
-msgid "Invalid chassis type (0)"
-msgstr ""
-
-#: modules/computer.c:309 modules/computer.c:310
-msgid "Unknown chassis type"
-msgstr ""
-
-#: modules/computer.c:311
-msgid "Desktop"
-msgstr ""
-
-#: modules/computer.c:312
-msgid "Low-profile Desktop"
-msgstr ""
-
-#: modules/computer.c:313
-msgid "Pizza Box"
-msgstr ""
-
-#: modules/computer.c:314
-msgid "Mini Tower"
-msgstr ""
-
-#: modules/computer.c:315
-msgid "Tower"
-msgstr ""
-
-#: modules/computer.c:316
-msgid "Portable"
-msgstr ""
-
-#: modules/computer.c:317 modules/computer.c:341 modules/computer.c:350
-#: modules/computer.c:372
-msgid "Laptop"
-msgstr ""
-
-#: modules/computer.c:318
-msgid "Notebook"
-msgstr ""
-
-#: modules/computer.c:319
-msgid "Handheld"
-msgstr ""
-
-#: modules/computer.c:320
-msgid "Docking Station"
-msgstr ""
-
-#: modules/computer.c:321
-msgid "All-in-one"
-msgstr ""
-
-#: modules/computer.c:322
-msgid "Subnotebook"
-msgstr ""
-
-#: modules/computer.c:323
-msgid "Space-saving"
-msgstr ""
-
 #: modules/computer.c:324
-msgid "Lunch Box"
-msgstr ""
-
-#: modules/computer.c:325
-msgid "Main Server Chassis"
-msgstr ""
-
-#: modules/computer.c:326
-msgid "Expansion Chassis"
-msgstr ""
-
-#: modules/computer.c:327
-msgid "Sub Chassis"
-msgstr ""
-
-#: modules/computer.c:328
-msgid "Bus Expansion Chassis"
-msgstr ""
-
-#: modules/computer.c:329
-msgid "Peripheral Chassis"
-msgstr ""
-
-#: modules/computer.c:330
-msgid "RAID Chassis"
-msgstr ""
-
-#: modules/computer.c:331
-msgid "Rack Mount Chassis"
-msgstr ""
-
-#: modules/computer.c:332
-msgid "Sealed-case PC"
+msgid "Single-board computer"
 msgstr ""
 
 #. /proc/apm
-#. FIXME: use dmidecode if available to get chassis type
-#: modules/computer.c:386
+#: modules/computer.c:373
 msgid "Unknown physical machine type"
 msgstr ""
 
-#: modules/computer.c:470 modules/computer.c:709
+#: modules/computer.c:393 modules/computer.c:394
+msgid "Virtual (VMware)"
+msgstr ""
+
+#: modules/computer.c:396 modules/computer.c:397 modules/computer.c:398
+#: modules/computer.c:399
+msgid "Virtual (QEMU)"
+msgstr ""
+
+#: modules/computer.c:401 modules/computer.c:402
+msgid "Virtual (Unknown)"
+msgstr ""
+
+#: modules/computer.c:404 modules/computer.c:405 modules/computer.c:406
+#: modules/computer.c:427
+msgid "Virtual (VirtualBox)"
+msgstr ""
+
+#: modules/computer.c:408 modules/computer.c:409 modules/computer.c:410
+#: modules/computer.c:421
+msgid "Virtual (Xen)"
+msgstr ""
+
+#: modules/computer.c:412
+msgid "Virtual (hypervisor present)"
+msgstr ""
+
+#: modules/computer.c:465 modules/computer.c:769
 msgid "Computer"
 msgstr "Computer"
 
-#: modules/computer.c:471 modules/devices/alpha/processor.c:87
-#: modules/devices/arm/processor.c:236 modules/devices.c:95
+#: modules/computer.c:466 modules/devices/alpha/processor.c:87
+#: modules/devices/arm/processor.c:327 modules/devices.c:98
 #: modules/devices/ia64/processor.c:159 modules/devices/m68k/processor.c:83
 #: modules/devices/mips/processor.c:74 modules/devices/parisc/processor.c:154
 #: modules/devices/ppc/processor.c:157 modules/devices/riscv/processor.c:181
 #: modules/devices/s390/processor.c:131 modules/devices/sh/processor.c:83
-#: modules/devices/sparc/processor.c:74 modules/devices/x86/processor.c:409
+#: modules/devices/sparc/processor.c:74 modules/devices/x86/processor.c:644
 msgid "Processor"
 msgstr "Prozessor"
 
-#: modules/computer.c:474
+#: modules/computer.c:469
 msgid "Machine Type"
 msgstr "Maschinen-Typ"
 
-#: modules/computer.c:477 modules/computer.c:514
+#: modules/computer.c:472 modules/computer.c:508
 msgid "User Name"
 msgstr "Benutzername"
 
-#: modules/computer.c:482 modules/computer.c:591
+#: modules/computer.c:477
 msgid "Resolution"
 msgstr "Auflösung"
 
-#: modules/computer.c:483 modules/computer.c:592
+#: modules/computer.c:477 modules/computer.c:607
 #, c-format
 msgid "%dx%d pixels"
 msgstr ""
 
-#: modules/computer.c:485
-msgid "OpenGL Renderer"
-msgstr "OpenGL-Renderer"
+#: modules/computer.c:480
+msgid "Session Display Server"
+msgstr ""
 
-#: modules/computer.c:486
-msgid "X11 Vendor"
-msgstr "X11-Hersteller"
-
-#: modules/computer.c:491 modules/devices.c:102
+#: modules/computer.c:485 modules/devices.c:106
 msgid "Input Devices"
 msgstr "Eingabegeräte"
 
-#: modules/computer.c:493 modules/computer.c:752 modules/devices.c:99
-msgid "Printers"
-msgstr "Drucker"
-
-#: modules/computer.c:495 modules/computer.c:752 modules/devices.c:103
-msgid "Storage"
-msgstr "Speicher"
-
-#: modules/computer.c:506
+#: modules/computer.c:500
 msgid "Kernel"
 msgstr ""
 
-#: modules/computer.c:508
+#: modules/computer.c:502
 msgid "C Library"
 msgstr "C-Library"
 
-#: modules/computer.c:509
+#: modules/computer.c:503
 msgid "Distribution"
 msgstr ""
 
-#: modules/computer.c:512
+#: modules/computer.c:506
 msgid "Current Session"
 msgstr "Aktuelle Sitzung"
 
-#: modules/computer.c:513
+#: modules/computer.c:507
 msgid "Computer Name"
 msgstr "Computername"
 
-#: modules/computer.c:515 modules/computer/languages.c:108
+#: modules/computer.c:509 modules/computer/languages.c:108
 msgid "Language"
 msgstr "Sprache"
 
-#: modules/computer.c:516 modules/computer/users.c:50
+#: modules/computer.c:510 modules/computer/users.c:50
 msgid "Home Directory"
 msgstr "Stammverzeichnis"
 
-#: modules/computer.c:519 modules/devices/usb.c:87 modules/devices/usb.c:234
-#: modules/devices/usb.c:351
+#: modules/computer.c:513
 msgid "Misc"
 msgstr "Verschiedenes"
 
-#: modules/computer.c:532
+#: modules/computer.c:526
 msgid "Loaded Modules"
 msgstr "Geladene Module"
 
-#: modules/computer.c:535 modules/computer/modules.c:145
-#: modules/computer/modules.c:147 modules/devices/arm/processor.c:337
-#: modules/devices.c:559 modules/devices/x86/processor.c:456
+#: modules/computer.c:529 modules/computer/modules.c:145
+#: modules/computer/modules.c:147 modules/devices/arm/processor.c:448
+#: modules/devices.c:575
 msgid "Description"
 msgstr "Beschreibung"
 
-#: modules/computer.c:548
+#: modules/computer.c:542
 msgid "Date & Time"
 msgstr "Datum & Uhrzeit"
 
-#: modules/computer.c:549
+#: modules/computer.c:543
 msgid "Kernel Version"
 msgstr "Kernel-Version"
 
-#: modules/computer.c:559
+#: modules/computer.c:553
 msgid "Available Languages"
 msgstr ""
 
-#: modules/computer.c:561
+#: modules/computer.c:555
 msgid "Language Code"
 msgstr "Sprach-Code"
 
-#: modules/computer.c:573
+#: modules/computer.c:567
 msgid "Mounted File Systems"
 msgstr ""
 
-#: modules/computer.c:575 modules/computer/filesystem.c:85
+#: modules/computer.c:569 modules/computer/filesystem.c:85
 msgid "Mount Point"
 msgstr "Mount-Punkt"
 
-#: modules/computer.c:576
+#: modules/computer.c:570
 msgid "Usage"
 msgstr "Verwendung"
 
-#: modules/computer.c:577
+#: modules/computer.c:571 modules/devices/gpu.c:93 modules/devices/gpu.c:101
+#: modules/devices/gpu.c:187 modules/devices/pci.c:70 modules/devices/pci.c:78
+#: modules/devices/pci.c:122 modules/devices/usb.c:72
 msgid "Device"
 msgstr "Gerät"
 
-#: modules/computer.c:594 modules/computer.c:601
+#: modules/computer.c:590
+msgid "Session"
+msgstr ""
+
+#: modules/computer.c:591 modules/devices.c:614 modules/devices/dmi.c:53
+#: modules/devices/inputdevices.c:117
+msgid "Type"
+msgstr ""
+
+#: modules/computer.c:594
+msgid "Wayland"
+msgstr ""
+
+#: modules/computer.c:595 modules/computer.c:600
+msgid "Current Display Name"
+msgstr ""
+
+#: modules/computer.c:599
+msgid "X Server"
+msgstr ""
+
+#: modules/computer.c:601 modules/computer.c:641 modules/devices/dmi.c:39
+#: modules/devices/dmi.c:43 modules/devices/dmi.c:47 modules/devices/dmi.c:52
+#: modules/devices/gpu.c:92 modules/devices/gpu.c:100 modules/devices/gpu.c:186
 #: modules/devices/ia64/processor.c:161 modules/devices/inputdevices.c:119
-#: modules/devices/pci.c:225 modules/devices/usb.c:349
-#: modules/devices/x86/processor.c:416
+#: modules/devices/pci.c:69 modules/devices/pci.c:77 modules/devices/usb.c:64
+#: modules/devices/x86/processor.c:651
 msgid "Vendor"
 msgstr "Hersteller"
 
-#: modules/computer.c:598
-msgid "Monitors"
-msgstr "Bildschirme"
-
-#: modules/computer.c:600
-msgid "OpenGL"
+#: modules/computer.c:603
+msgid "Release Number"
 msgstr ""
 
-#: modules/computer.c:602
+#: modules/computer.c:611
+msgid "Screens"
+msgstr ""
+
+#: modules/computer.c:617
+msgid "Disconnected"
+msgstr ""
+
+#: modules/computer.c:620
+msgid "Connected"
+msgstr ""
+
+#: modules/computer.c:624 modules/computer/os.c:78 modules/computer/os.c:234
+#: modules/computer/os.c:392 modules/devices.c:344 modules/devices.c:396
+#: modules/devices/printers.c:99 modules/devices/printers.c:106
+#: modules/devices/printers.c:116 modules/devices/printers.c:131
+#: modules/devices/printers.c:140 modules/devices/printers.c:243
+msgid "Unknown"
+msgstr ""
+
+#: modules/computer.c:628
+msgid "Unused"
+msgstr ""
+
+#: modules/computer.c:629
+#, c-format
+msgid "%dx%d pixels, offset (%d, %d)"
+msgstr ""
+
+#: modules/computer.c:638
+msgid "Outputs (XRandR)"
+msgstr ""
+
+#: modules/computer.c:640
+msgid "OpenGL (GLX)"
+msgstr ""
+
+#: modules/computer.c:642
 msgid "Renderer"
 msgstr ""
 
-#: modules/computer.c:604
+#: modules/computer.c:643
 msgid "Direct Rendering"
 msgstr "Direct-Rendering"
 
-#: modules/computer.c:608
-msgid "Extensions"
-msgstr "Erweiterungen"
+#: modules/computer.c:645
+msgid "Version (Compatibility)"
+msgstr ""
 
-#: modules/computer.c:628
+#: modules/computer.c:646
+msgid "Shading Language Version (Compatibility)"
+msgstr ""
+
+#: modules/computer.c:647
+msgid "Version (Core)"
+msgstr ""
+
+#: modules/computer.c:648
+msgid "Shading Language Version (Core)"
+msgstr ""
+
+#: modules/computer.c:649
+msgid "Version (ES)"
+msgstr ""
+
+#: modules/computer.c:650
+msgid "Shading Language Version (ES)"
+msgstr ""
+
+#: modules/computer.c:651
+msgid "GLX Version"
+msgstr ""
+
+#: modules/computer.c:672
 msgid "Group"
 msgstr ""
 
-#: modules/computer.c:631 modules/computer/users.c:49
+#: modules/computer.c:675 modules/computer/users.c:49
 msgid "Group ID"
 msgstr "Gruppen-ID"
 
-#: modules/computer.c:751
+#: modules/computer.c:811
 msgid "RAM"
 msgstr ""
 
-#: modules/computer.c:751 modules/devices/devicetree/pmac_data.c:82
+#: modules/computer.c:811 modules/devices/devicetree/pmac_data.c:82
 msgid "Motherboard"
 msgstr ""
 
-#: modules/computer.c:751
+#: modules/computer.c:811
 msgid "Graphics"
 msgstr ""
 
-#: modules/computer.c:752
+#: modules/computer.c:812 modules/devices.c:107
+msgid "Storage"
+msgstr "Speicher"
+
+#: modules/computer.c:812 modules/devices.c:103
+msgid "Printers"
+msgstr "Drucker"
+
+#: modules/computer.c:812
 msgid "Audio"
 msgstr ""
 
-#: modules/computer.c:807
+#: modules/computer.c:857
 msgid "Gathers high-level computer information"
 msgstr "Sammelt high-level Computer-Informationen"
-
-#: modules/computer/display.c:122
-#, c-format
-msgid "Monitor %d=%dx%d pixels\n"
-msgstr "Bildschirm %d=%dx%d Pixel\n"
 
 #: modules/computer/filesystem.c:83
 msgid "Filesystem"
@@ -1213,13 +1537,13 @@ msgstr ""
 msgid "Territory"
 msgstr ""
 
-#: modules/computer/languages.c:110 modules/devices/arm/processor.c:250
-#: modules/devices/ia64/processor.c:166 modules/devices/ppc/processor.c:159
-#: modules/devices/usb.c:236
+#: modules/computer/languages.c:110 modules/devices/arm/processor.c:341
+#: modules/devices/gpu.c:146 modules/devices/ia64/processor.c:166
+#: modules/devices/pci.c:114 modules/devices/ppc/processor.c:159
 msgid "Revision"
 msgstr ""
 
-#: modules/computer/languages.c:111
+#: modules/computer/languages.c:111 modules/devices/dmi.c:42
 msgid "Date"
 msgstr ""
 
@@ -1233,7 +1557,7 @@ msgstr ""
 
 #: modules/computer/modules.c:125 modules/computer/modules.c:126
 #: modules/computer/modules.c:127 modules/computer/modules.c:128
-#: modules/computer/modules.c:129
+#: modules/computer/modules.c:129 modules/devices/dmi.c:115
 msgid "(Not available)"
 msgstr ""
 
@@ -1249,7 +1573,7 @@ msgstr ""
 msgid "Used Memory"
 msgstr ""
 
-#: modules/computer/modules.c:144
+#: modules/computer/modules.c:144 modules/devices/devmemory.c:72
 msgid "KiB"
 msgstr ""
 
@@ -1284,14 +1608,6 @@ msgstr ""
 
 #: modules/computer/os.c:40
 msgid "diet libc"
-msgstr ""
-
-#: modules/computer/os.c:78 modules/computer/os.c:234 modules/computer/os.c:359
-#: modules/devices.c:333 modules/devices.c:387 modules/devices/printers.c:99
-#: modules/devices/printers.c:106 modules/devices/printers.c:116
-#: modules/devices/printers.c:131 modules/devices/printers.c:140
-#: modules/devices/printers.c:243
-msgid "Unknown"
 msgstr ""
 
 #: modules/computer/os.c:112 modules/computer/os.c:115
@@ -1340,11 +1656,6 @@ msgstr ""
 msgid "%d bits (healthy)"
 msgstr ""
 
-#: modules/computer/os.c:279 modules/devices/usb.c:48 modules/devices/usb.c:307
-#: modules/devices/usb.c:310 modules/network/net.c:442 includes/cpu_util.h:11
-msgid "(Unknown)"
-msgstr ""
-
 #: modules/computer/users.c:47
 msgid "User Information"
 msgstr ""
@@ -1357,12 +1668,13 @@ msgstr ""
 msgid "Default Shell"
 msgstr ""
 
-#: modules/devices/alpha/processor.c:88 modules/devices/devicetree.c:141
-#: modules/devices/devicetree.c:176 modules/devices/devicetree/pmac_data.c:80
-#: modules/devices/ia64/processor.c:165 modules/devices/m68k/processor.c:84
-#: modules/devices/mips/processor.c:75 modules/devices/parisc/processor.c:155
-#: modules/devices/ppc/processor.c:158 modules/devices/riscv/processor.c:182
-#: modules/devices/s390/processor.c:132 modules/devices/spd-decode.c:1510
+#: modules/devices/alpha/processor.c:88 modules/devices/devicetree.c:161
+#: modules/devices/devicetree.c:207 modules/devices/devicetree/pmac_data.c:80
+#: modules/devices/gpu.c:124 modules/devices/ia64/processor.c:165
+#: modules/devices/m68k/processor.c:84 modules/devices/mips/processor.c:75
+#: modules/devices/parisc/processor.c:155 modules/devices/ppc/processor.c:158
+#: modules/devices/riscv/processor.c:182 modules/devices/s390/processor.c:132
+#: modules/devices/spd-decode.c:1510
 msgid "Model"
 msgstr ""
 
@@ -1370,44 +1682,28 @@ msgstr ""
 msgid "Platform String"
 msgstr ""
 
-#: modules/devices/alpha/processor.c:90 modules/devices/arm/processor.c:240
+#: modules/devices/alpha/processor.c:90 modules/devices/arm/processor.c:331
 #: modules/devices/ia64/processor.c:167 modules/devices/m68k/processor.c:87
 #: modules/devices/mips/processor.c:77 modules/devices/parisc/processor.c:158
-#: modules/devices/pci.c:108 modules/devices/ppc/processor.c:160
-#: modules/devices/riscv/processor.c:186 modules/devices/sh/processor.c:87
-#: modules/devices/x86/processor.c:420
+#: modules/devices/ppc/processor.c:160 modules/devices/riscv/processor.c:186
+#: modules/devices/sh/processor.c:87 modules/devices/x86/processor.c:655
 msgid "Frequency"
 msgstr "Taktfrequenz"
 
-#: modules/devices/alpha/processor.c:90 modules/devices/arm/processor.c:240
-#: modules/devices/arm/processor.c:365 modules/devices.c:299
-#: modules/devices.c:307 modules/devices.c:335
-#: modules/devices/ia64/processor.c:167 modules/devices/ia64/processor.c:196
-#: modules/devices/m68k/processor.c:87 modules/devices/mips/processor.c:77
-#: modules/devices/parisc/processor.c:158
-#: modules/devices/parisc/processor.c:191 modules/devices/pci.c:108
-#: modules/devices/ppc/processor.c:160 modules/devices/ppc/processor.c:187
-#: modules/devices/riscv/processor.c:186 modules/devices/riscv/processor.c:214
-#: modules/devices/s390/processor.c:160 modules/devices/sh/processor.c:87
-#: modules/devices/sh/processor.c:88 modules/devices/sh/processor.c:89
-#: modules/devices/x86/processor.c:420 modules/devices/x86/processor.c:479
-msgid "MHz"
-msgstr ""
-
-#: modules/devices/alpha/processor.c:91 modules/devices/arm/processor.c:241
+#: modules/devices/alpha/processor.c:91 modules/devices/arm/processor.c:332
 #: modules/devices/ia64/processor.c:168 modules/devices/m68k/processor.c:88
 #: modules/devices/mips/processor.c:78 modules/devices/parisc/processor.c:159
 #: modules/devices/ppc/processor.c:161 modules/devices/s390/processor.c:134
-#: modules/devices/sh/processor.c:90 modules/devices/x86/processor.c:421
+#: modules/devices/sh/processor.c:90 modules/devices/x86/processor.c:656
 msgid "BogoMips"
 msgstr ""
 
-#: modules/devices/alpha/processor.c:92 modules/devices/arm/processor.c:242
+#: modules/devices/alpha/processor.c:92 modules/devices/arm/processor.c:333
 #: modules/devices/ia64/processor.c:169 modules/devices/m68k/processor.c:89
 #: modules/devices/mips/processor.c:79 modules/devices/parisc/processor.c:160
 #: modules/devices/ppc/processor.c:162 modules/devices/riscv/processor.c:187
 #: modules/devices/s390/processor.c:135 modules/devices/sh/processor.c:91
-#: modules/devices/sparc/processor.c:77 modules/devices/x86/processor.c:422
+#: modules/devices/sparc/processor.c:77 modules/devices/x86/processor.c:657
 msgid "Byte Order"
 msgstr "Byte-Reihenfolge"
 
@@ -1586,61 +1882,67 @@ msgid "ARM Processor"
 msgstr "ARM Prozessor"
 
 #: modules/devices/arm/processor.c:200 modules/devices/riscv/processor.c:147
-#: modules/devices/x86/processor.c:371
+#: modules/devices/x86/processor.c:606
 msgid "Empty List"
 msgstr ""
 
-#: modules/devices/arm/processor.c:237
+#: modules/devices/arm/processor.c:226 modules/devices/x86/processor.c:268
+msgid "Clocks"
+msgstr ""
+
+#: modules/devices/arm/processor.c:272 modules/devices/arm/processor.c:285
+#: modules/devices/x86/processor.c:314 modules/devices/x86/processor.c:327
+#, c-format
+msgid "%.2f-%.2f %s=%dx\n"
+msgstr ""
+
+#: modules/devices/arm/processor.c:328
 msgid "Linux Name"
 msgstr ""
 
-#: modules/devices/arm/processor.c:238
+#: modules/devices/arm/processor.c:329
 msgid "Decoded Name"
 msgstr ""
 
-#: modules/devices/arm/processor.c:239 modules/network/net.c:458
+#: modules/devices/arm/processor.c:330 modules/network/net.c:453
 msgid "Mode"
 msgstr ""
 
-#: modules/devices/arm/processor.c:245
+#: modules/devices/arm/processor.c:336
 msgid "ARM"
 msgstr ""
 
-#: modules/devices/arm/processor.c:246
+#: modules/devices/arm/processor.c:337
 msgid "Implementer"
 msgstr ""
 
-#: modules/devices/arm/processor.c:247
+#: modules/devices/arm/processor.c:338
 msgid "Part"
 msgstr ""
 
-#: modules/devices/arm/processor.c:248 modules/devices/ia64/processor.c:162
+#: modules/devices/arm/processor.c:339 modules/devices/ia64/processor.c:162
 #: modules/devices/parisc/processor.c:156 modules/devices/riscv/processor.c:183
 msgid "Architecture"
 msgstr ""
 
-#: modules/devices/arm/processor.c:249
+#: modules/devices/arm/processor.c:340
 msgid "Variant"
 msgstr ""
 
-#: modules/devices/arm/processor.c:251 modules/devices/riscv/processor.c:190
-#: modules/devices/sparc/processor.c:78 modules/devices/x86/processor.c:428
+#: modules/devices/arm/processor.c:342 modules/devices/riscv/processor.c:190
+#: modules/devices/sparc/processor.c:78 modules/devices/x86/processor.c:663
 msgid "Capabilities"
 msgstr "Fähigkeiten"
 
-#: modules/devices/arm/processor.c:335
+#: modules/devices/arm/processor.c:446
 msgid "SOC/Package"
 msgstr ""
 
-#: modules/devices/arm/processor.c:338 modules/devices/cpu_util.c:222
-msgid "Topology"
+#: modules/devices/arm/processor.c:450 modules/devices/x86/processor.c:698
+msgid "Logical CPU Config"
 msgstr ""
 
-#: modules/devices/arm/processor.c:339
-msgid "Clocks"
-msgstr ""
-
-#: modules/devices/arm/processor.c:354
+#: modules/devices/arm/processor.c:467
 msgid "SOC/Package Information"
 msgstr ""
 
@@ -1730,54 +2032,57 @@ msgstr ""
 "[Keine Akkus]\n"
 "Keine Akkus in diesem System gefunden=\n"
 
-#: modules/devices.c:97
+#: modules/devices.c:100
+msgid "Graphics Processors"
+msgstr ""
+
+#: modules/devices.c:101 modules/devices/pci.c:143
 msgid "PCI Devices"
 msgstr "PCI-Geräte"
 
-#: modules/devices.c:98 modules/devices/usb.c:117 modules/devices/usb.c:156
-#: modules/devices/usb.c:415
+#: modules/devices.c:102 modules/devices/usb.c:92
 msgid "USB Devices"
 msgstr "USB-Geräte"
 
-#: modules/devices.c:100
+#: modules/devices.c:104
 msgid "Battery"
 msgstr "Akku"
 
-#: modules/devices.c:101
+#: modules/devices.c:105
 msgid "Sensors"
 msgstr "Sensoren"
 
-#: modules/devices.c:105
+#: modules/devices.c:109
 msgid "DMI"
 msgstr "DMI"
 
-#: modules/devices.c:106
+#: modules/devices.c:110
 msgid "Memory SPD"
 msgstr "Hauptspeicher (SPD)"
 
-#: modules/devices.c:111
+#: modules/devices.c:115
 msgid "Device Tree"
 msgstr ""
 
-#: modules/devices.c:113
+#: modules/devices.c:117
 msgid "Resources"
 msgstr "Ressourcen"
 
-#: modules/devices.c:151
+#: modules/devices.c:162
 #, c-format
 msgid "%d physical processor"
 msgid_plural "%d physical processors"
 msgstr[0] ""
 msgstr[1] ""
 
-#: modules/devices.c:152
+#: modules/devices.c:163
 #, c-format
 msgid "%d core"
 msgid_plural "%d cores"
 msgstr[0] ""
 msgstr[1] ""
 
-#: modules/devices.c:153
+#: modules/devices.c:164
 #, c-format
 msgid "%d thread"
 msgid_plural "%d threads"
@@ -1785,211 +2090,111 @@ msgstr[0] ""
 msgstr[1] ""
 
 #. /NP procs; NC cores; NT threads
-#: modules/devices.c:154
+#: modules/devices.c:165
 #, c-format
 msgid "%s; %s; %s"
 msgstr ""
 
-#: modules/devices.c:372
-msgid " (model unknown)"
-msgstr " (unbekanntes Modell)"
-
-#: modules/devices.c:374
-msgid " (vendor unknown)"
-msgstr " (unbekannter Hersteller)"
-
-#: modules/devices.c:559
+#: modules/devices.c:575
 msgid "Field"
 msgstr ""
 
-#: modules/devices.c:559 modules/devices.c:591
+#: modules/devices.c:575 modules/devices.c:614
 msgid "Value"
 msgstr ""
 
-#: modules/devices.c:591
+#: modules/devices.c:614
 msgid "Sensor"
 msgstr ""
 
-#: modules/devices.c:591 modules/devices/inputdevices.c:117
-msgid "Type"
-msgstr ""
-
-#: modules/devices.c:637
+#: modules/devices.c:661
 msgid "Devices"
 msgstr "Geräte"
 
-#: modules/devices.c:649
+#: modules/devices.c:673
 msgid "Update PCI ID listing"
 msgstr ""
 
-#: modules/devices.c:661
+#: modules/devices.c:685
 msgid "Update CPU feature database"
 msgstr ""
 
-#: modules/devices.c:689
+#: modules/devices.c:713
 msgid "Gathers information about hardware devices"
 msgstr "Sammelt Informationen über die Hardware-Geräte"
 
-#: modules/devices.c:708
+#: modules/devices.c:732
 msgid "Resource information requires superuser privileges"
 msgstr ""
 
-#: modules/devices/cpu_util.c:30
-msgid "Little Endian"
-msgstr ""
-
-#: modules/devices/cpu_util.c:32
-msgid "Big Endian"
-msgstr ""
-
-#: modules/devices/cpu_util.c:178 modules/devices/cpu_util.c:189
-msgid "Frequency Scaling"
-msgstr ""
-
-#: modules/devices/cpu_util.c:179
-msgid "Minimum"
-msgstr ""
-
-#: modules/devices/cpu_util.c:179 modules/devices/cpu_util.c:180
-#: modules/devices/cpu_util.c:181
-msgid "kHz"
-msgstr ""
-
-#: modules/devices/cpu_util.c:180
-msgid "Maximum"
-msgstr ""
-
-#: modules/devices/cpu_util.c:181
-msgid "Current"
-msgstr ""
-
-#: modules/devices/cpu_util.c:182
-msgid "Transition Latency"
-msgstr ""
-
-#: modules/devices/cpu_util.c:182
-msgid "ns"
-msgstr ""
-
-#: modules/devices/cpu_util.c:183
-msgid "Governor"
-msgstr ""
-
-#: modules/devices/cpu_util.c:184 modules/devices/cpu_util.c:190
-msgid "Driver"
-msgstr "Treiber"
-
-#: modules/devices/cpu_util.c:196 modules/devices/x86/processor.c:297
-msgid "(Not Available)"
-msgstr ""
-
-#: modules/devices/cpu_util.c:204 modules/devices/cpu_util.c:206
-msgid "Socket"
-msgstr ""
-
-#: modules/devices/cpu_util.c:209 modules/devices/cpu_util.c:211
-msgid "Core"
-msgstr ""
-
-#: modules/devices/cpu_util.c:214
-msgid "Book"
-msgstr ""
-
-#: modules/devices/cpu_util.c:216
-msgid "Drawer"
-msgstr ""
-
-#: modules/devices/cpu_util.c:223
-msgid "ID"
-msgstr ""
-
-#: modules/devices/devicetree.c:47
+#: modules/devices/devicetree.c:50
 msgid "Properties"
 msgstr ""
 
-#: modules/devices/devicetree.c:48
+#: modules/devices/devicetree.c:51
 msgid "Children"
 msgstr ""
 
-#: modules/devices/devicetree.c:84
+#: modules/devices/devicetree.c:87
 msgid "Node"
 msgstr ""
 
-#: modules/devices/devicetree.c:85
+#: modules/devices/devicetree.c:88
 msgid "Node Path"
 msgstr ""
 
-#: modules/devices/devicetree.c:86
+#: modules/devices/devicetree.c:89
 msgid "Alias"
 msgstr ""
 
-#: modules/devices/devicetree.c:86 modules/devices/devicetree.c:87
+#: modules/devices/devicetree.c:89 modules/devices/devicetree.c:90
 msgid "(None)"
 msgstr ""
 
-#: modules/devices/devicetree.c:87
+#: modules/devices/devicetree.c:90
 msgid "Symbol"
 msgstr ""
 
-#: modules/devices/devicetree.c:132 modules/devices/devicetree/pmac_data.c:79
+#: modules/devices/devicetree.c:143 modules/devices/devicetree/pmac_data.c:79
 msgid "Platform"
 msgstr ""
 
-#: modules/devices/devicetree.c:133 modules/devices/devicetree.c:178
+#: modules/devices/devicetree.c:144 modules/devices/devicetree.c:209
 msgid "Compatible"
 msgstr ""
 
-#: modules/devices/devicetree.c:134
+#: modules/devices/devicetree.c:145
 msgid "GPU-compatible"
 msgstr ""
 
-#: modules/devices/devicetree.c:140
+#: modules/devices/devicetree.c:160
 msgid "Raspberry Pi or Compatible"
 msgstr ""
 
-#: modules/devices/devicetree.c:142 modules/devices/devicetree.c:160
-#: modules/devices/devicetree.c:177 modules/devices/devicetree/rpi_data.c:160
+#: modules/devices/devicetree.c:162 modules/devices/devicetree.c:189
+#: modules/devices/devicetree.c:208 modules/devices/devicetree/rpi_data.c:161
+#: modules/devices/dmi.c:49 modules/devices/dmi.c:55
 msgid "Serial Number"
 msgstr ""
 
-#: modules/devices/devicetree.c:143 modules/devices/devicetree/rpi_data.c:157
+#: modules/devices/devicetree.c:163 modules/devices/devicetree/rpi_data.c:158
 msgid "RCode"
 msgstr ""
 
-#: modules/devices/devicetree.c:143
+#: modules/devices/devicetree.c:163
 msgid "No revision code available; unable to lookup model details."
 msgstr ""
 
-#: modules/devices/devicetree.c:159
+#: modules/devices/devicetree.c:188
 msgid "More"
 msgstr ""
 
-#: modules/devices/devicetree.c:175
-msgid "Board"
-msgstr ""
-
-#: modules/devices/devicetree.c:234
+#: modules/devices/devicetree.c:268
 msgid "Messages"
-msgstr ""
-
-#: modules/devices/devicetree/dt_util.c:1013
-msgid "phandle Map"
-msgstr ""
-
-#: modules/devices/devicetree/dt_util.c:1014
-msgid "Alias Map"
-msgstr ""
-
-#: modules/devices/devicetree/dt_util.c:1015
-msgid "Symbol Map"
 msgstr ""
 
 #: modules/devices/devicetree/pmac_data.c:78
 msgid "Apple Power Macintosh"
-msgstr ""
-
-#: modules/devices/devicetree/pmac_data.c:81 modules/devices/sh/processor.c:85
-msgid "Machine"
 msgstr ""
 
 #: modules/devices/devicetree/pmac_data.c:83
@@ -2008,88 +2213,179 @@ msgstr ""
 msgid "PMAC Generation"
 msgstr ""
 
-#: modules/devices/devicetree/rpi_data.c:152
 #: modules/devices/devicetree/rpi_data.c:153
+#: modules/devices/devicetree/rpi_data.c:154
 msgid "Raspberry Pi"
 msgstr ""
 
-#: modules/devices/devicetree/rpi_data.c:153
+#: modules/devices/devicetree/rpi_data.c:154
 msgid "Board Name"
 msgstr ""
 
-#: modules/devices/devicetree/rpi_data.c:154
+#: modules/devices/devicetree/rpi_data.c:155
 msgid "PCB Revision"
 msgstr ""
 
-#: modules/devices/devicetree/rpi_data.c:155
+#: modules/devices/devicetree/rpi_data.c:156
 msgid "Introduction"
 msgstr ""
 
-#: modules/devices/devicetree/rpi_data.c:156 modules/devices/spd-decode.c:1510
-#: modules/devices/usb.c:84 modules/devices/usb.c:217
+#: modules/devices/devicetree/rpi_data.c:157 modules/devices/spd-decode.c:1510
 msgid "Manufacturer"
 msgstr ""
 
-#: modules/devices/devicetree/rpi_data.c:158
+#: modules/devices/devicetree/rpi_data.c:159
 msgid "SOC (spec)"
 msgstr ""
 
-#: modules/devices/devicetree/rpi_data.c:159
+#: modules/devices/devicetree/rpi_data.c:160
 msgid "Memory (spec)"
 msgstr ""
 
-#: modules/devices/devicetree/rpi_data.c:161
+#: modules/devices/devicetree/rpi_data.c:162
 msgid "Permanent overvolt bit"
 msgstr ""
 
-#: modules/devices/devicetree/rpi_data.c:161
+#: modules/devices/devicetree/rpi_data.c:162
 msgctxt "rpi-ov-bit"
 msgid "Set"
 msgstr ""
 
-#: modules/devices/devicetree/rpi_data.c:161
+#: modules/devices/devicetree/rpi_data.c:162
 msgctxt "rpi-ov-bit"
 msgid "Not set"
 msgstr ""
 
-#: modules/devices/devmemory.c:93
+#: modules/devices/devmemory.c:101
 msgid "Total Memory"
 msgstr ""
 
-#: modules/devices/devmemory.c:94
+#: modules/devices/devmemory.c:102
 msgid "Free Memory"
 msgstr ""
 
-#: modules/devices/devmemory.c:95
+#: modules/devices/devmemory.c:103
 msgid "Cached Swap"
 msgstr ""
 
-#: modules/devices/devmemory.c:96
+#: modules/devices/devmemory.c:104
 msgid "High Memory"
 msgstr ""
 
-#: modules/devices/devmemory.c:97
+#: modules/devices/devmemory.c:105
 msgid "Free High Memory"
 msgstr ""
 
-#: modules/devices/devmemory.c:98
+#: modules/devices/devmemory.c:106
 msgid "Low Memory"
 msgstr ""
 
-#: modules/devices/devmemory.c:99
+#: modules/devices/devmemory.c:107
 msgid "Free Low Memory"
 msgstr ""
 
-#: modules/devices/devmemory.c:100
+#: modules/devices/devmemory.c:108
 msgid "Virtual Memory"
 msgstr ""
 
-#: modules/devices/devmemory.c:101
+#: modules/devices/devmemory.c:109
 msgid "Free Virtual Memory"
 msgstr ""
 
-#: modules/devices/dmi.c:188
+#: modules/devices/dmi.c:36 modules/devices/inputdevices.c:120
+#: modules/devices/usb.c:63
+msgid "Product"
+msgstr ""
+
+#: modules/devices/dmi.c:38 modules/devices/ia64/processor.c:164
+#: modules/devices/sh/processor.c:86
+msgid "Family"
+msgstr ""
+
+#: modules/devices/dmi.c:41
+msgid "BIOS"
+msgstr ""
+
+#: modules/devices/dmi.c:50 modules/devices/dmi.c:56
+msgid "Asset Tag"
+msgstr ""
+
+#: modules/devices/dmi.c:51
+msgid "Chassis"
+msgstr ""
+
+#: modules/devices/dmi.c:116
 msgid "(Not available; Perhaps try running HardInfo as root.)"
+msgstr ""
+
+#: modules/devices/gpu.c:102 modules/devices/pci.c:79
+msgid "SVendor"
+msgstr ""
+
+#: modules/devices/gpu.c:103 modules/devices/pci.c:80
+msgid "SDevice"
+msgstr ""
+
+#: modules/devices/gpu.c:111 modules/devices/pci.c:90
+msgid "PCI Express"
+msgstr ""
+
+#: modules/devices/gpu.c:112 modules/devices/pci.c:92
+msgid "Maximum Link Width"
+msgstr ""
+
+#: modules/devices/gpu.c:113 modules/devices/pci.c:94
+msgid "Maximum Link Speed"
+msgstr ""
+
+#: modules/devices/gpu.c:113 modules/devices/pci.c:93 modules/devices/pci.c:94
+msgid "GT/s"
+msgstr ""
+
+#: modules/devices/gpu.c:123
+msgid "NVIDIA"
+msgstr ""
+
+#: modules/devices/gpu.c:125
+msgid "BIOS Version"
+msgstr ""
+
+#: modules/devices/gpu.c:126
+msgid "UUID"
+msgstr ""
+
+#: modules/devices/gpu.c:141 modules/devices/gpu.c:183
+#: modules/devices/inputdevices.c:115 modules/devices/pci.c:111
+#: modules/devices/usb.c:62
+msgid "Device Information"
+msgstr ""
+
+#: modules/devices/gpu.c:142 modules/devices/gpu.c:184
+msgid "Location"
+msgstr ""
+
+#: modules/devices/gpu.c:143
+msgid "DRM Device"
+msgstr ""
+
+#: modules/devices/gpu.c:144 modules/devices/pci.c:112 modules/devices/usb.c:67
+msgid "Class"
+msgstr ""
+
+#: modules/devices/gpu.c:150 modules/devices/pci.c:117
+msgid "In Use"
+msgstr ""
+
+#: modules/devices/gpu.c:174
+msgid "Unknown integrated GPU"
+msgstr ""
+
+#: modules/devices/gpu.c:185
+msgid "DT Compatibility"
+msgstr ""
+
+#: modules/devices/gpu.c:201
+msgid "GPUs"
 msgstr ""
 
 #: modules/devices/ia64/processor.c:108
@@ -2100,10 +2396,6 @@ msgstr ""
 msgid "Architecture Revision"
 msgstr ""
 
-#: modules/devices/ia64/processor.c:164 modules/devices/sh/processor.c:86
-msgid "Family"
-msgstr ""
-
 #: modules/devices/ia64/processor.c:170
 msgid "CPU regs"
 msgstr ""
@@ -2112,19 +2404,9 @@ msgstr ""
 msgid "Features"
 msgstr "Funktionen"
 
-#: modules/devices/inputdevices.c:115 modules/devices/pci.c:214
-#: modules/devices/usb.c:82 modules/devices/usb.c:215 modules/devices/usb.c:347
-msgid "Device Information"
-msgstr ""
-
-#: modules/devices/inputdevices.c:118 modules/devices/usb.c:92
-#: modules/devices/usb.c:240 modules/devices/usb.c:356
+#: modules/devices/inputdevices.c:118 modules/devices/pci.c:121
+#: modules/devices/usb.c:71
 msgid "Bus"
-msgstr ""
-
-#: modules/devices/inputdevices.c:120 modules/devices/usb.c:83
-#: modules/devices/usb.c:216 modules/devices/usb.c:348
-msgid "Product"
 msgstr ""
 
 #: modules/devices/inputdevices.c:124
@@ -2167,61 +2449,31 @@ msgstr ""
 msgid "SVersion"
 msgstr ""
 
-#: modules/devices/parisc/processor.c:163 modules/devices/x86/processor.c:425
+#: modules/devices/parisc/processor.c:163 modules/devices/x86/processor.c:660
 msgid "Cache"
 msgstr ""
 
-#: modules/devices/pci.c:106
-msgid "IRQ"
+#: modules/devices/pci.c:91
+msgid "Link Width"
 msgstr ""
 
-#: modules/devices/pci.c:110
-msgid "Latency"
+#: modules/devices/pci.c:93
+msgid "Link Speed"
 msgstr ""
 
-#: modules/devices/pci.c:112
-msgid "Bus Master"
+#: modules/devices/pci.c:119 modules/devices/usb.c:70
+msgid "Connection"
 msgstr ""
 
-#: modules/devices/pci.c:118
-msgid "Kernel modules"
-msgstr ""
-
-#: modules/devices/pci.c:124
-#, c-format
-msgid "%s=%s (%s)\n"
-msgstr ""
-
-#: modules/devices/pci.c:126
-msgid "OEM Vendor"
-msgstr ""
-
-#: modules/devices/pci.c:153
-msgid "prefetchable"
-msgstr ""
-
-#: modules/devices/pci.c:154
-msgid "non-prefetchable"
-msgstr ""
-
-#: modules/devices/pci.c:163
-msgid "I/O ports at"
-msgstr ""
-
-#: modules/devices/pci.c:216 modules/devices/usb.c:89 modules/devices/usb.c:237
-#: modules/devices/usb.c:353
-msgid "Class"
-msgstr ""
-
-#: modules/devices/pci.c:217
+#: modules/devices/pci.c:120
 msgid "Domain"
 msgstr ""
 
-#: modules/devices/pci.c:218
-msgid "Bus, device, function"
+#: modules/devices/pci.c:123
+msgid "Function"
 msgstr ""
 
-#: modules/devices/pci.c:243
+#: modules/devices/pci.c:161
 msgid "No PCI devices found"
 msgstr ""
 
@@ -2451,7 +2703,7 @@ msgstr ""
 msgid "Bank"
 msgstr ""
 
-#: modules/devices/storage.c:46
+#: modules/devices/storage.c:43
 msgid ""
 "\n"
 "[SCSI Disks]\n"
@@ -2459,7 +2711,7 @@ msgstr ""
 "\n"
 "[SCSI-Geräte]\n"
 
-#: modules/devices/storage.c:110 modules/devices/storage.c:313
+#: modules/devices/storage.c:114 modules/devices/storage.c:320
 #, c-format
 msgid ""
 "[Device Information]\n"
@@ -2468,17 +2720,17 @@ msgstr ""
 "[Geräte-Informationen]\n"
 "Modell=%s\n"
 
-#: modules/devices/storage.c:115 modules/devices/storage.c:319
+#: modules/devices/storage.c:119 modules/devices/storage.c:326
 #, c-format
 msgid "Vendor=%s (%s)\n"
 msgstr "Hersteller=%s (%s)\n"
 
-#: modules/devices/storage.c:120 modules/devices/storage.c:321
+#: modules/devices/storage.c:124 modules/devices/storage.c:328
 #, c-format
 msgid "Vendor=%s\n"
 msgstr "Hersteller=%s\n"
 
-#: modules/devices/storage.c:125
+#: modules/devices/storage.c:129
 #, c-format
 msgid ""
 "Type=%s\n"
@@ -2490,7 +2742,7 @@ msgid ""
 "LUN=%d\n"
 msgstr ""
 
-#: modules/devices/storage.c:167
+#: modules/devices/storage.c:174
 msgid ""
 "\n"
 "[IDE Disks]\n"
@@ -2498,12 +2750,12 @@ msgstr ""
 "\n"
 "[IDE-Geräte]\n"
 
-#: modules/devices/storage.c:250
+#: modules/devices/storage.c:257
 #, c-format
 msgid "Driver=%s\n"
 msgstr "Treiber=%s\n"
 
-#: modules/devices/storage.c:324
+#: modules/devices/storage.c:331
 #, c-format
 msgid ""
 "Device Name=hd%c\n"
@@ -2511,7 +2763,7 @@ msgid ""
 "Cache=%dkb\n"
 msgstr ""
 
-#: modules/devices/storage.c:334
+#: modules/devices/storage.c:341
 #, c-format
 msgid ""
 "[Geometry]\n"
@@ -2522,7 +2774,7 @@ msgstr ""
 "Physikalisch=%s\n"
 "Logisch=%s\n"
 
-#: modules/devices/storage.c:344
+#: modules/devices/storage.c:351
 #, c-format
 msgid ""
 "[Capabilities]\n"
@@ -2531,7 +2783,7 @@ msgstr ""
 "[Fähigkeiten]\n"
 "%s"
 
-#: modules/devices/storage.c:351
+#: modules/devices/storage.c:358
 #, c-format
 msgid ""
 "[Speeds]\n"
@@ -2540,51 +2792,28 @@ msgstr ""
 "[Geschwindigkeiten]\n"
 "%s"
 
-#: modules/devices/usb.c:44 modules/devices/usb.c:326
-msgid "mA"
-msgstr ""
-
-#. /%.2f is version
-#: modules/devices/usb.c:53 modules/devices/usb.c:190
-#, c-format
-msgid "USB %.2f Hub"
-msgstr ""
-
-#: modules/devices/usb.c:55 modules/devices/usb.c:192
-#, c-format
-msgid "Unknown USB %.2f Device (class %d)"
-msgstr ""
-
-#: modules/devices/usb.c:85 modules/devices/usb.c:232
-msgid "Speed"
-msgstr ""
-
-#: modules/devices/usb.c:85 modules/devices/usb.c:232
-msgid "Mbit/s"
-msgstr ""
-
-#: modules/devices/usb.c:86 modules/devices/usb.c:233 modules/devices/usb.c:350
+#: modules/devices/usb.c:65
 msgid "Max Current"
 msgstr ""
 
-#: modules/devices/usb.c:88 modules/devices/usb.c:235 modules/devices/usb.c:352
+#: modules/devices/usb.c:65
+msgid "mA"
+msgstr ""
+
+#: modules/devices/usb.c:66
 msgid "USB Version"
 msgstr ""
 
-#: modules/devices/usb.c:90 modules/devices/usb.c:238 modules/devices/usb.c:354
-msgid "Vendor ID"
+#: modules/devices/usb.c:68
+msgid "Sub-class"
 msgstr ""
 
-#: modules/devices/usb.c:91 modules/devices/usb.c:239 modules/devices/usb.c:355
-msgid "Product ID"
+#: modules/devices/usb.c:69
+msgid "Device Version"
 msgstr ""
 
-#: modules/devices/usb.c:231
-msgid "Port"
-msgstr ""
-
-#: modules/devices/usb.c:241
-msgid "Level"
+#: modules/devices/usb.c:103
+msgid "No USB devices found."
 msgstr ""
 
 #: modules/devices/x86/processor.c:149
@@ -2614,40 +2843,57 @@ msgctxt "cache-type"
 msgid "Unified"
 msgstr ""
 
-#: modules/devices/x86/processor.c:410
+#: modules/devices/x86/processor.c:367
+msgid "Caches"
+msgstr ""
+
+#: modules/devices/x86/processor.c:418 modules/devices/x86/processor.c:435
+#, c-format
+msgid "Level %d (%s)#%d=%dx %dKB (%dKB), %d-way set-associative, %d sets\n"
+msgstr ""
+
+#: modules/devices/x86/processor.c:645
 msgid "Model Name"
 msgstr ""
 
-#: modules/devices/x86/processor.c:411
+#: modules/devices/x86/processor.c:646
 msgid "Family, model, stepping"
 msgstr "Familie, Modell, Stufung"
 
-#: modules/devices/x86/processor.c:417
+#: modules/devices/x86/processor.c:652
 msgid "Microcode Version"
 msgstr ""
 
-#: modules/devices/x86/processor.c:418
+#: modules/devices/x86/processor.c:653
 msgid "Configuration"
 msgstr "Konfiguration"
 
-#: modules/devices/x86/processor.c:419
+#: modules/devices/x86/processor.c:654
 msgid "Cache Size"
 msgstr "Cache-Größe"
 
-#: modules/devices/x86/processor.c:419
+#: modules/devices/x86/processor.c:654
 msgid "kb"
 msgstr ""
 
-#: modules/devices/x86/processor.c:426
+#: modules/devices/x86/processor.c:661
 msgid "Power Management"
 msgstr ""
 
-#: modules/devices/x86/processor.c:427
+#: modules/devices/x86/processor.c:662
 msgid "Bug Workarounds"
 msgstr ""
 
-#: modules/devices/x86/processor.c:454 modules/devices/x86/processor.c:468
+#: modules/devices/x86/processor.c:695 modules/devices/x86/processor.c:715
 msgid "Package Information"
+msgstr ""
+
+#: modules/devices/x86/processor.c:742
+msgid "Socket:Core"
+msgstr ""
+
+#: modules/devices/x86/processor.c:742
+msgid "Thread"
 msgstr ""
 
 #. /flag:fpu
@@ -3961,75 +4207,100 @@ msgctxt "x86-flag"
 msgid "IPI required to wake up remote CPU"
 msgstr ""
 
+#. /bug:cpu_insecure & bug:cpu_meltdown
+#: modules/devices/x86/x86_data.c:281 modules/devices/x86/x86_data.c:282
+msgctxt "x86-flag"
+msgid ""
+"CPU is affected by meltdown attack and needs kernel page table isolation"
+msgstr ""
+
+#. /bug:spectre_v1
+#: modules/devices/x86/x86_data.c:283
+msgctxt "x86-flag"
+msgid "CPU is affected by Spectre variant 1 attack with conditional branches"
+msgstr ""
+
+#. /bug:spectre_v2
+#: modules/devices/x86/x86_data.c:284
+msgctxt "x86-flag"
+msgid "CPU is affected by Spectre variant 2 attack with indirect branches"
+msgstr ""
+
+#. /bug:spec_store_bypass
+#: modules/devices/x86/x86_data.c:285
+msgctxt "x86-flag"
+msgid "CPU is affected by speculative store bypass attack"
+msgstr ""
+
 #. /x86/kernel/cpu/powerflags.h
 #. /flag:pm:ts
-#: modules/devices/x86/x86_data.c:283
+#: modules/devices/x86/x86_data.c:288
 msgctxt "x86-flag"
 msgid "temperature sensor"
 msgstr ""
 
 #. /flag:pm:fid
-#: modules/devices/x86/x86_data.c:284
+#: modules/devices/x86/x86_data.c:289
 msgctxt "x86-flag"
 msgid "frequency id control"
 msgstr ""
 
 #. /flag:pm:vid
-#: modules/devices/x86/x86_data.c:285
+#: modules/devices/x86/x86_data.c:290
 msgctxt "x86-flag"
 msgid "voltage id control"
 msgstr ""
 
 #. /flag:pm:ttp
-#: modules/devices/x86/x86_data.c:286
+#: modules/devices/x86/x86_data.c:291
 msgctxt "x86-flag"
 msgid "thermal trip"
 msgstr ""
 
 #. /flag:pm:tm
-#: modules/devices/x86/x86_data.c:287
+#: modules/devices/x86/x86_data.c:292
 msgctxt "x86-flag"
 msgid "hardware thermal control"
 msgstr ""
 
 #. /flag:pm:stc
-#: modules/devices/x86/x86_data.c:288
+#: modules/devices/x86/x86_data.c:293
 msgctxt "x86-flag"
 msgid "software thermal control"
 msgstr ""
 
 #. /flag:pm:100mhzsteps
-#: modules/devices/x86/x86_data.c:289
+#: modules/devices/x86/x86_data.c:294
 msgctxt "x86-flag"
 msgid "100 MHz multiplier control"
 msgstr ""
 
 #. /flag:pm:hwpstate
-#: modules/devices/x86/x86_data.c:290
+#: modules/devices/x86/x86_data.c:295
 msgctxt "x86-flag"
 msgid "hardware P-state control"
 msgstr ""
 
 #. /flag:pm:cpb
-#: modules/devices/x86/x86_data.c:291
+#: modules/devices/x86/x86_data.c:296
 msgctxt "x86-flag"
 msgid "core performance boost"
 msgstr ""
 
 #. /flag:pm:eff_freq_ro
-#: modules/devices/x86/x86_data.c:292
+#: modules/devices/x86/x86_data.c:297
 msgctxt "x86-flag"
 msgid "Readonly aperf/mperf"
 msgstr ""
 
 #. /flag:pm:proc_feedback
-#: modules/devices/x86/x86_data.c:293
+#: modules/devices/x86/x86_data.c:298
 msgctxt "x86-flag"
 msgid "processor feedback interface"
 msgstr ""
 
 #. /flag:pm:acc_power
-#: modules/devices/x86/x86_data.c:294
+#: modules/devices/x86/x86_data.c:299
 msgctxt "x86-flag"
 msgid "accumulated power mechanism"
 msgstr ""
@@ -4063,7 +4334,7 @@ msgid "Shared Directories"
 msgstr "Freigegebene Verzeichnisse"
 
 #: modules/network.c:304 modules/network.c:326 modules/network.c:357
-#: modules/network/net.c:477
+#: modules/network/net.c:472
 msgid "IP Address"
 msgstr "IP-Adresse"
 
@@ -4127,7 +4398,7 @@ msgstr "Ziel/Vorgaberoute"
 msgid "Flags"
 msgstr ""
 
-#: modules/network.c:374 modules/network/net.c:478
+#: modules/network.c:374 modules/network/net.c:473
 msgid "Mask"
 msgstr "Netz-Maske"
 
@@ -4297,100 +4568,118 @@ msgctxt "net-if-type"
 msgid "(Unknown)"
 msgstr ""
 
-#: modules/network/net.c:348 modules/network/net.c:358
+#: modules/network/net.c:343 modules/network/net.c:353
 msgid "Network Interfaces"
 msgstr ""
 
-#: modules/network/net.c:348
+#: modules/network/net.c:343
 msgid "None Found"
 msgstr ""
 
-#: modules/network/net.c:400 modules/network/net.c:422
-#: modules/network/net.c:423
+#: modules/network/net.c:395 modules/network/net.c:417
+#: modules/network/net.c:418
 msgid "MiB"
 msgstr ""
 
-#: modules/network/net.c:414
+#: modules/network/net.c:409
 msgid "Network Adapter Properties"
 msgstr ""
 
-#: modules/network/net.c:415
+#: modules/network/net.c:410
 msgid "Interface Type"
 msgstr ""
 
-#: modules/network/net.c:416
+#: modules/network/net.c:411
 msgid "Hardware Address (MAC)"
 msgstr ""
 
-#: modules/network/net.c:420
+#: modules/network/net.c:415
 msgid "MTU"
 msgstr ""
 
-#: modules/network/net.c:421
+#: modules/network/net.c:416
 msgid "Transfer Details"
 msgstr ""
 
-#: modules/network/net.c:422
+#: modules/network/net.c:417
 msgid "Bytes Received"
 msgstr ""
 
-#: modules/network/net.c:423
+#: modules/network/net.c:418
 msgid "Bytes Sent"
 msgstr ""
 
-#: modules/network/net.c:440 modules/network/net.c:462
-#: modules/network/net.c:463
+#: modules/network/net.c:435 modules/network/net.c:457
+#: modules/network/net.c:458
 msgid "dBm"
 msgstr ""
 
-#: modules/network/net.c:440
+#: modules/network/net.c:435
 msgid "mW"
 msgstr ""
 
-#: modules/network/net.c:454
+#: modules/network/net.c:449
 msgid "Wireless Properties"
 msgstr ""
 
-#: modules/network/net.c:455
+#: modules/network/net.c:450
 msgid "Network Name (SSID)"
 msgstr ""
 
-#: modules/network/net.c:456
+#: modules/network/net.c:451
 msgid "Bit Rate"
 msgstr ""
 
-#: modules/network/net.c:456
+#: modules/network/net.c:451
 msgid "Mb/s"
 msgstr ""
 
-#: modules/network/net.c:457
+#: modules/network/net.c:452
 msgid "Transmission Power"
 msgstr ""
 
-#: modules/network/net.c:459
+#: modules/network/net.c:454
 msgid "Status"
 msgstr ""
 
-#: modules/network/net.c:460
+#: modules/network/net.c:455
 msgid "Link Quality"
 msgstr ""
 
-#: modules/network/net.c:461
+#: modules/network/net.c:456
 msgid "Signal / Noise"
 msgstr ""
 
-#: modules/network/net.c:476
+#: modules/network/net.c:471
 msgid "Internet Protocol (IPv4)"
 msgstr ""
 
-#: modules/network/net.c:477 modules/network/net.c:478
-#: modules/network/net.c:480
+#: modules/network/net.c:472 modules/network/net.c:473
+#: modules/network/net.c:475
 msgid "(Not set)"
 msgstr ""
 
-#: modules/network/net.c:479
+#: modules/network/net.c:474
 msgid "Broadcast Address"
 msgstr ""
+
+#~ msgid "X11 Vendor"
+#~ msgstr "X11-Hersteller"
+
+#~ msgid "Monitors"
+#~ msgstr "Bildschirme"
+
+#~ msgid "Extensions"
+#~ msgstr "Erweiterungen"
+
+#~ msgid "Monitor %d=%dx%d pixels\n"
+#~ msgstr "Bildschirm %d=%dx%d Pixel\n"
+
+#~ msgid " (model unknown)"
+#~ msgstr " (unbekanntes Modell)"
+
+#~ msgid " (vendor unknown)"
+#~ msgstr " (unbekannter Hersteller)"
 
 #~ msgid "CPU Clock"
 #~ msgstr "CPU-Takt"

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: hardinfo\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-08-14 22:23-0500\n"
+"POT-Creation-Date: 2018-06-09 14:09-0500\n"
 "PO-Revision-Date: 2017-08-04 00:00-0430\n"
 "Last-Translator: PICCORO Lenz McKAY <mckaygerhard@gmail.com>\n"
 "Language-Team: Fernando López <soportelihuen@linti.unlp.edu.ar>\n"
@@ -18,8 +18,193 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Poedit-Language: Spanish\n"
 
+#: hardinfo/cpu_util.c:30
+msgid "Little Endian"
+msgstr "Little Endian"
+
+#: hardinfo/cpu_util.c:32
+msgid "Big Endian"
+msgstr "Big Endian"
+
+#: hardinfo/cpu_util.c:184 hardinfo/cpu_util.c:195
+msgid "Frequency Scaling"
+msgstr "Escalador de frecuencia"
+
+#: hardinfo/cpu_util.c:185
+msgid "Minimum"
+msgstr "Minimo"
+
+#: hardinfo/cpu_util.c:185 hardinfo/cpu_util.c:186 hardinfo/cpu_util.c:187
+msgid "kHz"
+msgstr "Khz"
+
+#: hardinfo/cpu_util.c:186
+msgid "Maximum"
+msgstr "Maximo"
+
+#: hardinfo/cpu_util.c:187
+msgid "Current"
+msgstr "Actual"
+
+#: hardinfo/cpu_util.c:188
+msgid "Transition Latency"
+msgstr "Latencia de transicion"
+
+#: hardinfo/cpu_util.c:188
+msgid "ns"
+msgstr "ns"
+
+#: hardinfo/cpu_util.c:189
+msgid "Governor"
+msgstr "Gobernador"
+
+#: hardinfo/cpu_util.c:190 hardinfo/cpu_util.c:196 modules/devices/gpu.c:149
+#: modules/devices/pci.c:116
+msgid "Driver"
+msgstr "Manejador"
+
+#: hardinfo/cpu_util.c:202 modules/computer.c:596
+#: modules/devices/arm/processor.c:242 modules/devices/x86/processor.c:284
+#: modules/devices/x86/processor.c:388 modules/devices/x86/processor.c:524
+msgid "(Not Available)"
+msgstr "(no disponible)"
+
+#: hardinfo/cpu_util.c:210 hardinfo/cpu_util.c:212
+msgid "Socket"
+msgstr "Soket"
+
+#: hardinfo/cpu_util.c:215 hardinfo/cpu_util.c:217
+msgid "Core"
+msgstr "Core"
+
+#: hardinfo/cpu_util.c:220
+msgid "Book"
+msgstr "Asentamientos"
+
+#: hardinfo/cpu_util.c:222
+msgid "Drawer"
+msgstr "Dibujado"
+
+#: hardinfo/cpu_util.c:228 modules/devices/arm/processor.c:449
+#: modules/devices/x86/processor.c:697
+msgid "Topology"
+msgstr "Topologia"
+
+#: hardinfo/cpu_util.c:229
+msgid "ID"
+msgstr "ID"
+
+#: hardinfo/dmi_util.c:130
+msgid "Invalid chassis type (0)"
+msgstr "Clasificación maquina invalida (0)"
+
+#: hardinfo/dmi_util.c:131 hardinfo/dmi_util.c:132
+msgid "Unknown chassis type"
+msgstr "Clasificación mauqina desconocida"
+
+#: hardinfo/dmi_util.c:133
+msgid "Desktop"
+msgstr "PC Escritorio"
+
+#: hardinfo/dmi_util.c:134
+msgid "Low-profile Desktop"
+msgstr "PC economico"
+
+#: hardinfo/dmi_util.c:135
+msgid "Pizza Box"
+msgstr "PC caja pizza"
+
+#: hardinfo/dmi_util.c:136
+msgid "Mini Tower"
+msgstr "Torre mediana"
+
+#: hardinfo/dmi_util.c:137
+msgid "Tower"
+msgstr "Torreta"
+
+#: hardinfo/dmi_util.c:138
+msgid "Portable"
+msgstr "Portable"
+
+#: hardinfo/dmi_util.c:139 modules/computer.c:330 modules/computer.c:339
+#: modules/computer.c:361
+msgid "Laptop"
+msgstr "Portatil"
+
+#: hardinfo/dmi_util.c:140
+msgid "Notebook"
+msgstr "Mini portatil"
+
+#: hardinfo/dmi_util.c:141
+msgid "Handheld"
+msgstr "Mini bolsillo"
+
+#: hardinfo/dmi_util.c:142
+msgid "Docking Station"
+msgstr "Estacion fija"
+
+#: hardinfo/dmi_util.c:143
+msgid "All-in-one"
+msgstr "All in one"
+
+#: hardinfo/dmi_util.c:144
+msgid "Subnotebook"
+msgstr "Subportátil"
+
+#: hardinfo/dmi_util.c:145
+msgid "Space-saving"
+msgstr "PC Espacio-pequeño"
+
+#: hardinfo/dmi_util.c:146
+msgid "Lunch Box"
+msgstr "PC caja"
+
+#: hardinfo/dmi_util.c:147
+msgid "Main Server Chassis"
+msgstr "Servidor principal"
+
+#: hardinfo/dmi_util.c:148
+msgid "Expansion Chassis"
+msgstr "Servidor expansion"
+
+#: hardinfo/dmi_util.c:149
+msgid "Sub Chassis"
+msgstr "Sub servidor"
+
+#: hardinfo/dmi_util.c:150
+msgid "Bus Expansion Chassis"
+msgstr "Expansion de bus acoplable"
+
+#: hardinfo/dmi_util.c:151
+msgid "Peripheral Chassis"
+msgstr "Periferico acoplable"
+
+#: hardinfo/dmi_util.c:152
+msgid "RAID Chassis"
+msgstr "RAID acoplable"
+
+#: hardinfo/dmi_util.c:153
+msgid "Rack Mount Chassis"
+msgstr "Rack de montaje acoplable"
+
+#: hardinfo/dmi_util.c:154
+msgid "Sealed-case PC"
+msgstr "PC sellada"
+
+#: hardinfo/dt_util.c:1011
+msgid "phandle Map"
+msgstr "Mapa manejado"
+
+#: hardinfo/dt_util.c:1012
+msgid "Alias Map"
+msgstr "Mapa alternativo"
+
+#: hardinfo/dt_util.c:1013
+msgid "Symbol Map"
+msgstr "Mapa de simbolos"
+
 #. / %d will be latest year of copyright
-#: hardinfo/hardinfo.c:49
+#: hardinfo/hardinfo.c:50
 #, c-format
 msgid ""
 "Copyright (C) 2003-%d Leandro A. F. Pereira. See COPYING for details.\n"
@@ -28,7 +213,7 @@ msgstr ""
 "Copyright (C) 2003-%d Leandro A. F. Pereira. Vea COPYING para más detalles.\n"
 "\n"
 
-#: hardinfo/hardinfo.c:51
+#: hardinfo/hardinfo.c:52
 #, c-format
 msgid ""
 "Compile-time options:\n"
@@ -45,18 +230,16 @@ msgstr ""
 "  Prefijo de bibliotecas: %s\n"
 "  Compilado en:           %s\n"
 
-#: hardinfo/hardinfo.c:57 hardinfo/hardinfo.c:58 modules/computer.c:605
-#: modules/devices/inputdevices.c:128 modules/devices/pci.c:112
-#: modules/devices/printers.c:138
+#: hardinfo/hardinfo.c:58 hardinfo/hardinfo.c:59 modules/computer.c:644
+#: modules/devices/inputdevices.c:128 modules/devices/printers.c:138
 msgid "Yes"
 msgstr "Sí"
 
-#: hardinfo/hardinfo.c:58 modules/computer.c:605 modules/devices/pci.c:112
-#: modules/devices/printers.c:138
+#: hardinfo/hardinfo.c:59 modules/computer.c:644 modules/devices/printers.c:138
 msgid "No"
 msgstr "_No"
 
-#: hardinfo/hardinfo.c:69
+#: hardinfo/hardinfo.c:70
 #, c-format
 msgid ""
 "Failed to find runtime data.\n"
@@ -69,7 +252,7 @@ msgstr ""
 "• ¿HardInfo está correctamente instalado?\n"
 "• Vea si %s y %s existen y tenga accesos para lectura."
 
-#: hardinfo/hardinfo.c:76
+#: hardinfo/hardinfo.c:77
 #, c-format
 msgid ""
 "Modules:\n"
@@ -78,49 +261,51 @@ msgstr ""
 "Módulos:\n"
 "%-20s %-15s %-12s\n"
 
-#: hardinfo/hardinfo.c:77
+#: hardinfo/hardinfo.c:78
 msgid "File Name"
 msgstr "Nombre de archivo"
 
-#: hardinfo/hardinfo.c:77 modules/computer.c:534 modules/computer.c:562
-#: modules/computer.c:630 modules/computer/languages.c:104
-#: modules/computer/modules.c:146 modules/devices/arm/processor.c:336
+#: hardinfo/hardinfo.c:78 modules/computer.c:528 modules/computer.c:556
+#: modules/computer.c:674 modules/computer/languages.c:104
+#: modules/computer/modules.c:146 modules/devices/arm/processor.c:447
+#: modules/devices/dmi.c:37 modules/devices/dmi.c:46
 #: modules/devices/ia64/processor.c:160 modules/devices/inputdevices.c:116
-#: modules/devices/pci.c:215 modules/devices/sh/processor.c:84
-#: modules/devices/x86/processor.c:455 modules/network.c:326
+#: modules/devices/sh/processor.c:84 modules/devices/x86/processor.c:696
+#: modules/network.c:326
 msgid "Name"
 msgstr "Nombre"
 
-#: hardinfo/hardinfo.c:77 modules/computer.c:296 modules/computer.c:505
-#: modules/computer.c:507 modules/computer.c:595 modules/computer.c:603
+#: hardinfo/hardinfo.c:78 modules/computer.c:304 modules/computer.c:499
+#: modules/computer.c:501 modules/computer.c:602 modules/devices/dmi.c:40
+#: modules/devices/dmi.c:44 modules/devices/dmi.c:48 modules/devices/dmi.c:54
 #: modules/devices/inputdevices.c:121
 msgid "Version"
 msgstr "Versión"
 
-#: hardinfo/hardinfo.c:124
+#: hardinfo/hardinfo.c:125
 #, c-format
-msgid "Unknown benchmark ``%s'' or libbenchmark.so not loaded"
-msgstr "Benchmark desconocido ``%s'' o no se cargó libbenchmark.so"
+msgid "Unknown benchmark ``%s'' or benchmark.so not loaded"
+msgstr ""
 
-#: hardinfo/hardinfo.c:152
+#: hardinfo/hardinfo.c:155
 msgid "Don't know what to do. Exiting."
 msgstr "No se puede determinar que hacer. Saliendo."
 
-#: hardinfo/util.c:104 modules/computer/uptime.c:53
+#: hardinfo/util.c:104 modules/computer/uptime.c:54
 #, c-format
 msgid "%d day"
 msgid_plural "%d days"
 msgstr[0] "%d día"
 msgstr[1] "%d días"
 
-#: hardinfo/util.c:105 modules/computer/uptime.c:54
+#: hardinfo/util.c:105 modules/computer/uptime.c:55
 #, c-format
 msgid "%d hour"
 msgid_plural "%d hours"
 msgstr[0] "%d hora"
 msgstr[1] "%d horas"
 
-#: hardinfo/util.c:106 modules/computer/uptime.c:55
+#: hardinfo/util.c:106 modules/computer/uptime.c:56
 #, c-format
 msgid "%d minute"
 msgid_plural "%d minutes"
@@ -176,43 +361,51 @@ msgstr "Advertencia"
 msgid "Fatal Error"
 msgstr "Error fatal"
 
-#: hardinfo/util.c:401
+#: hardinfo/util.c:403
 msgid "creates a report and prints to standard output"
 msgstr "crea un reporte y lo imprime en la salida estándar"
 
-#: hardinfo/util.c:407
+#: hardinfo/util.c:409
 msgid "chooses a report format (text, html)"
 msgstr "elige un formato para el reporte (texto, html)"
 
-#: hardinfo/util.c:413
+#: hardinfo/util.c:415
 msgid "run benchmark; requires benchmark.so to be loaded"
 msgstr "correr benchmark; requiere benchmark.so para ser cargado"
 
-#: hardinfo/util.c:419
+#: hardinfo/util.c:421
+msgid "benchmark result format ([short], conf, shell)"
+msgstr ""
+
+#: hardinfo/util.c:427
 msgid "lists modules"
 msgstr "lista los módulos"
 
-#: hardinfo/util.c:425
+#: hardinfo/util.c:433
 msgid "specify module to load"
 msgstr "especificar módulo a cargar"
 
-#: hardinfo/util.c:431
+#: hardinfo/util.c:439
 msgid "automatically load module dependencies"
 msgstr "cargar automáticamente las dependencias de los módulos"
 
-#: hardinfo/util.c:438
+#: hardinfo/util.c:446
 msgid "run in XML-RPC server mode"
 msgstr "correr en modo servidor XML-RPC"
 
-#: hardinfo/util.c:445
+#: hardinfo/util.c:453
 msgid "shows program version and quit"
 msgstr "muestra la versión del programa y sale"
 
-#: hardinfo/util.c:450
+#: hardinfo/util.c:459
+msgid "do not run benchmarks"
+msgstr ""
+
+#: hardinfo/util.c:464
 msgid "- System Profiler and Benchmark tool"
 msgstr "- Analizador de sistema y herramienta de benchmark"
 
-#: hardinfo/util.c:460
+#: hardinfo/util.c:474
 #, c-format
 msgid ""
 "Unrecognized arguments.\n"
@@ -221,29 +414,29 @@ msgstr ""
 "Argumentos no reconocidos.\n"
 "Intente ``%s --help'' para más información.\n"
 
-#: hardinfo/util.c:526
+#: hardinfo/util.c:542
 #, c-format
 msgid "Couldn't find a Web browser to open URL %s."
 msgstr "No se pudo encontrar un navegador Web para abrir la URL %s."
 
-#: hardinfo/util.c:875
+#: hardinfo/util.c:891
 #, c-format
 msgid "Module \"%s\" depends on module \"%s\", load it?"
 msgstr "El módulo \"%s\" depende del módulo \"%s\", ¿desea cargarlo?"
 
-#: hardinfo/util.c:898
+#: hardinfo/util.c:914
 #, c-format
 msgid "Module \"%s\" depends on module \"%s\"."
 msgstr "El módulo \"%s\" depende del módulo \"%s\"."
 
-#: hardinfo/util.c:943
+#: hardinfo/util.c:959
 #, c-format
 msgid "No module could be loaded. Check permissions on \"%s\" and try again."
 msgstr ""
 "No se puede cargar ningún módulo. Verifique los permisos en \"%s\" y pruebe "
 "de nuevo."
 
-#: hardinfo/util.c:947
+#: hardinfo/util.c:963
 msgid ""
 "No module could be loaded. Please use hardinfo -l to list all available "
 "modules and try again with a valid module list."
@@ -252,20 +445,15 @@ msgstr ""
 "todoslos módulos disponibles e intente de nuevo con una lista válida de "
 "módulos."
 
-#: hardinfo/util.c:1024
+#: hardinfo/util.c:1040
 #, c-format
 msgid "Scanning: %s..."
 msgstr "Escaneando: %s..."
 
-#: hardinfo/util.c:1034 shell/shell.c:301 shell/shell.c:760 shell/shell.c:1795
-#: modules/benchmark.c:449 modules/benchmark.c:457
+#: hardinfo/util.c:1050 shell/shell.c:301 shell/shell.c:772 shell/shell.c:1850
+#: modules/benchmark.c:549 modules/benchmark.c:557
 msgid "Done."
 msgstr "Hecho."
-
-#: shell/callbacks.c:117
-#, c-format
-msgid "%s Module"
-msgstr "%s módulo"
 
 #: shell/callbacks.c:128
 #, c-format
@@ -443,35 +631,51 @@ msgstr "Cambia la visibilidad del panel lateral"
 msgid "_Toolbar"
 msgstr "_Barra de herramientas"
 
-#: shell/report.c:494 shell/report.c:502
+#: shell/report.c:500 shell/report.c:508
 msgid "Save File"
 msgstr "Guardar archivo"
 
-#: shell/report.c:629
+#: shell/report.c:503 shell/report.c:935 shell/syncmanager.c:748
+msgid "_Cancel"
+msgstr "_Cancelar"
+
+#: shell/report.c:505
+msgid "_Save"
+msgstr ""
+
+#: shell/report.c:635
 msgid "Cannot create ReportContext. Programming bug?"
 msgstr "No se puede crear ReportContext. ¿Error del programa?"
 
-#: shell/report.c:648
+#: shell/report.c:654
 msgid "Open the report with your web browser?"
 msgstr "¿Abrir el reporte en el navegador web?"
 
-#: shell/report.c:682
+#: shell/report.c:657
+msgid "_No"
+msgstr ""
+
+#: shell/report.c:658
+msgid "_Open"
+msgstr ""
+
+#: shell/report.c:688
 msgid "Generating report..."
 msgstr "Generando reporte..."
 
-#: shell/report.c:692
+#: shell/report.c:698
 msgid "Report saved."
 msgstr "Reporte guardado."
 
-#: shell/report.c:694
+#: shell/report.c:700
 msgid "Error while creating the report."
 msgstr "Error creando el reporte."
 
-#: shell/report.c:796
+#: shell/report.c:802
 msgid "Generate Report"
 msgstr "Generar reporte"
 
-#: shell/report.c:821
+#: shell/report.c:827
 msgid ""
 "<big><b>Generate Report</b></big>\n"
 "Please choose the information that you wish to view in your report:"
@@ -479,19 +683,15 @@ msgstr ""
 "<big><b>Generar reporte</b></big>\n"
 "Por favor elija la información que desea ver en el reporte:"
 
-#: shell/report.c:893
+#: shell/report.c:899
 msgid "Select _None"
 msgstr "_Deseleccionar todo"
 
-#: shell/report.c:904
+#: shell/report.c:910
 msgid "Select _All"
 msgstr "_Seleccionar todo"
 
-#: shell/report.c:929 shell/syncmanager.c:748
-msgid "_Cancel"
-msgstr "_Cancelar"
-
-#: shell/report.c:939
+#: shell/report.c:945
 msgid "_Generate"
 msgstr "_Generar"
 
@@ -504,16 +704,16 @@ msgstr "%s - Información del sistema"
 msgid "System Information"
 msgstr "Información del sistema"
 
-#: shell/shell.c:747
+#: shell/shell.c:759
 msgid "Loading modules..."
 msgstr "Cargando módulos..."
 
-#: shell/shell.c:1660
+#: shell/shell.c:1715
 #, c-format
 msgid "<b>%s → Summary</b>"
 msgstr "<b>%s → Resumen</b>"
 
-#: shell/shell.c:1769
+#: shell/shell.c:1824
 msgid "Updating..."
 msgstr "Actualizando..."
 
@@ -606,93 +806,217 @@ msgstr "Actualizador por red"
 msgid "_Synchronize"
 msgstr "_Sincronizar"
 
-#: modules/benchmark.c:52
+#: modules/benchmark/benches.c:74
 msgid "CPU Blowfish"
 msgstr ""
 
-#: modules/benchmark.c:53
+#: modules/benchmark/benches.c:75
 msgid "CPU CryptoHash"
 msgstr ""
 
-#: modules/benchmark.c:54
+#: modules/benchmark/benches.c:76
 msgid "CPU Fibonacci"
 msgstr ""
 
-#: modules/benchmark.c:55
+#: modules/benchmark/benches.c:77
 msgid "CPU N-Queens"
 msgstr "CPU N-Reinas"
 
-#: modules/benchmark.c:56
+#: modules/benchmark/benches.c:78
 msgid "CPU Zlib"
 msgstr "CPU Zlib"
 
-#: modules/benchmark.c:57
+#: modules/benchmark/benches.c:79
 msgid "FPU FFT"
 msgstr "FPU FFT"
 
-#: modules/benchmark.c:58
+#: modules/benchmark/benches.c:80
 msgid "FPU Raytracing"
 msgstr "FPU trazado de rayos"
 
-#: modules/benchmark.c:60
+#: modules/benchmark/benches.c:82
 msgid "GPU Drawing"
 msgstr "GPU dibujado"
 
-#: modules/benchmark.c:239 modules/benchmark.c:255
+#: modules/benchmark/benches.c:91
+msgid "Results in MiB/second. Higher is better."
+msgstr "Resultados en MiB/segundo. Más alto es mejor."
+
+#: modules/benchmark/benches.c:95
+msgid "Results in HIMarks. Higher is better."
+msgstr "Resultados en HIMarks. Más alto es mejor."
+
+#: modules/benchmark/benches.c:102
+msgid "Results in seconds. Lower is better."
+msgstr "Resultados en segundos. Más bajo es mejor."
+
+#. /or modify
+#. *    it under the terms of the GNU General Public License as published by
+#. *    the Free Software Foundation, version 2.
+#. *
+#. *    This program is distributed in the hope that it will be useful,
+#. *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#. *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#. *    GNU General Public License for more details.
+#. *
+#. *    You should have received a copy of the GNU General Public License
+#. *    along with this program; if not, write to the Free Software
+#. *    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+#.
+#. / Used for an unknown value. Having it in only one place cleans up the .po line references
+#: modules/benchmark/bench_results.c:22 modules/computer.c:41
+#: modules/computer/display.c:41 modules/computer/os.c:279
+#: modules/devices.c:383 modules/devices/gpu.c:42 modules/devices/gpu.c:58
+#: modules/devices/gpu.c:150 modules/devices/gpu.c:151 modules/devices/pci.c:25
+#: modules/devices/pci.c:117 modules/devices/pci.c:118 modules/devices/usb.c:27
+#: modules/network/net.c:437 includes/cpu_util.h:11
+msgid "(Unknown)"
+msgstr "(desconocido)"
+
+#: modules/benchmark/bench_results.c:47 modules/benchmark/bench_results.c:322
+#: modules/devices/alpha/processor.c:90 modules/devices/arm/processor.c:276
+#: modules/devices/arm/processor.c:289 modules/devices/arm/processor.c:331
+#: modules/devices/arm/processor.c:478 modules/devices.c:310
+#: modules/devices.c:318 modules/devices.c:346
+#: modules/devices/ia64/processor.c:167 modules/devices/ia64/processor.c:196
+#: modules/devices/m68k/processor.c:87 modules/devices/mips/processor.c:77
+#: modules/devices/parisc/processor.c:158
+#: modules/devices/parisc/processor.c:191 modules/devices/ppc/processor.c:160
+#: modules/devices/ppc/processor.c:187 modules/devices/riscv/processor.c:186
+#: modules/devices/riscv/processor.c:214 modules/devices/s390/processor.c:160
+#: modules/devices/sh/processor.c:87 modules/devices/sh/processor.c:88
+#: modules/devices/sh/processor.c:89 modules/devices/x86/processor.c:318
+#: modules/devices/x86/processor.c:331 modules/devices/x86/processor.c:655
+#: modules/devices/x86/processor.c:726
+msgid "MHz"
+msgstr "MHz"
+
+#: modules/benchmark/bench_results.c:374 modules/benchmark/bench_results.c:441
+msgid "kiB"
+msgstr ""
+
+#: modules/benchmark/bench_results.c:389 modules/benchmark/bench_results.c:426
+msgid "Benchmark Result"
+msgstr ""
+
+#: modules/benchmark/bench_results.c:390 modules/benchmark/bench_results.c:428
+msgid "Threads"
+msgstr ""
+
+#: modules/benchmark/bench_results.c:391 modules/benchmark/bench_results.c:431
+msgid "Note"
+msgstr ""
+
+#: modules/benchmark/bench_results.c:392 modules/benchmark/bench_results.c:432
+msgid ""
+"This result is from an old version of HardInfo. Results might not be "
+"comparable to current version. Some details are missing."
+msgstr ""
+
+#: modules/benchmark/bench_results.c:393 modules/benchmark/bench_results.c:433
+#: modules/devices/devicetree/pmac_data.c:81 modules/devices/sh/processor.c:85
+msgid "Machine"
+msgstr "Maquina"
+
+#: modules/benchmark/bench_results.c:394 modules/benchmark/bench_results.c:434
+#: modules/devices/devicetree.c:206 modules/devices/dmi.c:45
+msgid "Board"
+msgstr "Tarjeta"
+
+#: modules/benchmark/bench_results.c:395 modules/benchmark/bench_results.c:435
+msgid "CPU Name"
+msgstr ""
+
+#: modules/benchmark/bench_results.c:396 modules/benchmark/bench_results.c:436
+msgid "CPU Description"
+msgstr ""
+
+#: modules/benchmark/bench_results.c:397 modules/benchmark/bench_results.c:437
+#: modules/benchmark.c:390
 msgid "CPU Config"
 msgstr "CPU Caracteristicas"
 
-#: modules/benchmark.c:239 modules/benchmark.c:255
+#: modules/benchmark/bench_results.c:398 modules/benchmark/bench_results.c:438
+msgid "Threads Available"
+msgstr ""
+
+#: modules/benchmark/bench_results.c:399 modules/benchmark/bench_results.c:439
+msgid "GPU"
+msgstr ""
+
+#: modules/benchmark/bench_results.c:400 modules/benchmark/bench_results.c:440
+#: modules/computer.c:479
+msgid "OpenGL Renderer"
+msgstr "Renderizador OpenGL"
+
+#: modules/benchmark/bench_results.c:401 modules/benchmark/bench_results.c:441
+#: modules/computer.c:110 modules/computer.c:468 modules/devices.c:99
+msgid "Memory"
+msgstr "Memoria"
+
+#: modules/benchmark/bench_results.c:427
+msgid "Benchmark"
+msgstr ""
+
+#: modules/benchmark/bench_results.c:429
+msgid "Result"
+msgstr ""
+
+#: modules/benchmark/bench_results.c:430
+msgid "Elapsed Time"
+msgstr ""
+
+#: modules/benchmark/bench_results.c:442
+msgid "Handles"
+msgstr ""
+
+#: modules/benchmark/bench_results.c:443
+msgid "mid"
+msgstr ""
+
+#: modules/benchmark/bench_results.c:444
+msgid "cfg_val"
+msgstr ""
+
+#: modules/benchmark.c:390
 msgid "Results"
 msgstr "Resultados"
 
-#: modules/benchmark.c:239 modules/benchmark.c:255 modules/computer.c:751
+#: modules/benchmark.c:390 modules/computer.c:811
 #: modules/devices/sparc/processor.c:75
 msgid "CPU"
 msgstr "CPU"
 
-#: modules/benchmark.c:381
+#: modules/benchmark.c:460
 #, c-format
 msgid "Benchmarking: <b>%s</b>."
 msgstr "Ejecutando benchmark: <b>%s</b>."
 
-#: modules/benchmark.c:395
-msgid "Benchmarking. Please do not move your mouse or press any keys."
-msgstr "Ejecutando benchmarks. Por favor no mueva el mouse ni use el teclado."
-
-#: modules/benchmark.c:399
+#: modules/benchmark.c:479 modules/benchmark.c:498
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: modules/benchmark.c:536
-msgid "Results in MiB/second. Higher is better."
-msgstr "Resultados en MiB/segundo. Más alto es mejor."
+#: modules/benchmark.c:483 modules/benchmark.c:495
+msgid "Benchmarking. Please do not move your mouse or press any keys."
+msgstr "Ejecutando benchmarks. Por favor no mueva el mouse ni use el teclado."
 
-#: modules/benchmark.c:540
-msgid "Results in HIMarks. Higher is better."
-msgstr "Resultados en HIMarks. Más alto es mejor."
-
-#: modules/benchmark.c:547
-msgid "Results in seconds. Lower is better."
-msgstr "Resultados en segundos. Más bajo es mejor."
-
-#: modules/benchmark.c:555
+#: modules/benchmark.c:567
 msgid "Benchmarks"
 msgstr "Benchmarks"
 
-#: modules/benchmark.c:573
+#: modules/benchmark.c:585
 msgid "Perform tasks and compare with other systems"
 msgstr "Realizar tareas y comparar con otros sistemas"
 
-#: modules/benchmark.c:663
+#: modules/benchmark.c:692
 msgid "Send benchmark results"
 msgstr "Enviar resultados de los benchmark"
 
-#: modules/benchmark.c:668
+#: modules/benchmark.c:697
 msgid "Receive benchmark results"
 msgstr "Recibir resultados de los benchmark"
 
-#: modules/computer/alsa.c:26 modules/computer.c:489
+#: modules/computer/alsa.c:26 modules/computer.c:483
 msgid "Audio Devices"
 msgstr "Dispositivos de audio"
 
@@ -700,501 +1024,501 @@ msgstr "Dispositivos de audio"
 msgid "Audio Adapter"
 msgstr "Adaptador de audio"
 
-#: modules/computer/boots.c:33 modules/computer.c:73 modules/computer.c:546
-msgid "Boots"
-msgstr "Arranques"
-
-#: modules/computer.c:70
+#: modules/computer.c:76
 msgid "Summary"
 msgstr "Resumen"
 
-#: modules/computer.c:71 modules/computer.c:476 modules/computer.c:750
+#: modules/computer.c:77 modules/computer.c:471 modules/computer.c:810
 msgid "Operating System"
 msgstr "Sistema operativo"
 
-#: modules/computer.c:72
+#: modules/computer.c:78 modules/devices/gpu.c:151 modules/devices/pci.c:118
 msgid "Kernel Modules"
 msgstr "Módulos del kernel"
 
-#: modules/computer.c:74
+#: modules/computer.c:79 modules/computer.c:540
+msgid "Boots"
+msgstr "Arranques"
+
+#: modules/computer.c:80
 msgid "Languages"
 msgstr "Idiomas"
 
-#: modules/computer.c:75
+#: modules/computer.c:81
 msgid "Filesystems"
 msgstr "Sistemas de archivos"
 
-#: modules/computer.c:76 modules/computer.c:481 modules/computer.c:590
+#: modules/computer.c:82 modules/computer.c:476
 msgid "Display"
 msgstr "Pantalla"
 
-#: modules/computer.c:77 modules/computer/environment.c:32
+#: modules/computer.c:83 modules/computer/environment.c:32
 msgid "Environment Variables"
 msgstr "Variables de entorno"
 
-#: modules/computer.c:79
+#: modules/computer.c:85
 msgid "Development"
 msgstr "Desarrollo"
 
-#: modules/computer.c:81 modules/computer.c:617
+#: modules/computer.c:87 modules/computer.c:661
 msgid "Users"
 msgstr "Usuarios"
 
-#: modules/computer.c:82
+#: modules/computer.c:88
 msgid "Groups"
 msgstr "Grupos"
 
-#: modules/computer.c:104 modules/computer.c:473 modules/devices.c:96
-#: modules/devices/pci.c:149
-msgid "Memory"
-msgstr "Memoria"
-
-#: modules/computer.c:106
+#: modules/computer.c:112
 #, c-format
 msgid "%dMB (%dMB used)"
 msgstr "%dMB (%dMB usados)"
 
-#: modules/computer.c:108 modules/computer.c:520
+#: modules/computer.c:114 modules/computer.c:514
 msgid "Uptime"
 msgstr "Activo"
 
-#: modules/computer.c:110 modules/computer.c:478
+#: modules/computer.c:116 modules/computer.c:473
 msgid "Date/Time"
 msgstr "Fecha/Hora"
 
-#: modules/computer.c:115 modules/computer.c:521
+#: modules/computer.c:121 modules/computer.c:515
 msgid "Load Average"
 msgstr "Promedio de carga"
 
-#: modules/computer.c:117 modules/computer.c:522
+#: modules/computer.c:123 modules/computer.c:516
 msgid "Available entropy in /dev/random"
 msgstr "Entropía disponible en /dev/random"
 
-#: modules/computer.c:203
+#: modules/computer.c:211
 msgid "Scripting Languages"
 msgstr "Lenguajes de scripting"
 
-#: modules/computer.c:204
+#: modules/computer.c:212
 msgid "Gambas3 (gbr3)"
 msgstr ""
 
-#: modules/computer.c:205
+#: modules/computer.c:213
 msgid "Python"
 msgstr ""
 
-#: modules/computer.c:206
+#: modules/computer.c:214
 msgid "Python2"
 msgstr ""
 
-#: modules/computer.c:207
+#: modules/computer.c:215
 msgid "Python3"
 msgstr ""
 
-#: modules/computer.c:208
+#: modules/computer.c:216
 msgid "Perl"
 msgstr ""
 
-#: modules/computer.c:209
+#: modules/computer.c:217
 msgid "Perl6 (VM)"
 msgstr ""
 
-#: modules/computer.c:210
+#: modules/computer.c:218
 msgid "Perl6"
 msgstr ""
 
-#: modules/computer.c:211
+#: modules/computer.c:219
 msgid "PHP"
 msgstr ""
 
-#: modules/computer.c:212
+#: modules/computer.c:220
 msgid "Ruby"
 msgstr ""
 
-#: modules/computer.c:213
+#: modules/computer.c:221
 msgid "Bash"
 msgstr ""
 
-#: modules/computer.c:214
+#: modules/computer.c:222
 msgid "Compilers"
 msgstr "Compiladores"
 
-#: modules/computer.c:215
+#: modules/computer.c:223
 msgid "C (GCC)"
 msgstr ""
 
-#: modules/computer.c:216
+#: modules/computer.c:224
 msgid "C (Clang)"
 msgstr ""
 
-#: modules/computer.c:217
+#: modules/computer.c:225
 msgid "D (dmd)"
 msgstr ""
 
-#: modules/computer.c:218
+#: modules/computer.c:226
 msgid "Gambas3 (gbc3)"
 msgstr ""
 
-#: modules/computer.c:219
+#: modules/computer.c:227
 msgid "Java"
 msgstr ""
 
-#: modules/computer.c:220
+#: modules/computer.c:228
 msgid "CSharp (Mono, old)"
 msgstr "CSharp (Mono, antiguo)"
 
-#: modules/computer.c:221
+#: modules/computer.c:229
 msgid "CSharp (Mono)"
 msgstr ""
 
-#: modules/computer.c:222
+#: modules/computer.c:230
 msgid "Vala"
 msgstr ""
 
-#: modules/computer.c:223
+#: modules/computer.c:231
 msgid "Haskell (GHC)"
 msgstr ""
 
-#: modules/computer.c:224
+#: modules/computer.c:232
 msgid "FreePascal"
 msgstr ""
 
-#: modules/computer.c:225
+#: modules/computer.c:233
 msgid "Go"
 msgstr ""
 
-#: modules/computer.c:226
+#: modules/computer.c:234
 msgid "Tools"
 msgstr "Herramientas"
 
-#: modules/computer.c:227
+#: modules/computer.c:235
 msgid "make"
 msgstr ""
 
-#: modules/computer.c:228
+#: modules/computer.c:236
 msgid "GDB"
 msgstr ""
 
-#: modules/computer.c:229
+#: modules/computer.c:237
 msgid "strace"
 msgstr ""
 
-#: modules/computer.c:230
+#: modules/computer.c:238
 msgid "valgrind"
 msgstr ""
 
-#: modules/computer.c:231
+#: modules/computer.c:239
 msgid "QMake"
 msgstr ""
 
-#: modules/computer.c:232
+#: modules/computer.c:240
 msgid "CMake"
 msgstr ""
 
-#: modules/computer.c:233
+#: modules/computer.c:241
 msgid "Gambas3 IDE"
 msgstr ""
 
-#: modules/computer.c:274
+#: modules/computer.c:282
 msgid "Not found"
 msgstr "No encontrado"
 
-#: modules/computer.c:279
+#: modules/computer.c:287
 #, c-format
 msgid "Detecting version: %s"
 msgstr "Detectando versión: %s"
 
-#: modules/computer.c:296
+#: modules/computer.c:304
 msgid "Program"
 msgstr "Programa"
 
-#: modules/computer.c:308
-msgid "Invalid chassis type (0)"
-msgstr "Clasificación maquina invalida (0)"
-
-#: modules/computer.c:309 modules/computer.c:310
-msgid "Unknown chassis type"
-msgstr "Clasificación mauqina desconocida"
-
-#: modules/computer.c:311
-msgid "Desktop"
-msgstr "PC Escritorio"
-
-#: modules/computer.c:312
-msgid "Low-profile Desktop"
-msgstr "PC economico"
-
-#: modules/computer.c:313
-msgid "Pizza Box"
-msgstr "PC caja pizza"
-
-#: modules/computer.c:314
-msgid "Mini Tower"
-msgstr "Torre mediana"
-
-#: modules/computer.c:315
-msgid "Tower"
-msgstr "Torreta"
-
-#: modules/computer.c:316
-msgid "Portable"
-msgstr "Portable"
-
-#: modules/computer.c:317 modules/computer.c:341 modules/computer.c:350
-#: modules/computer.c:372
-msgid "Laptop"
-msgstr "Portatil"
-
-#: modules/computer.c:318
-msgid "Notebook"
-msgstr "Mini portatil"
-
-#: modules/computer.c:319
-msgid "Handheld"
-msgstr "Mini bolsillo"
-
-#: modules/computer.c:320
-msgid "Docking Station"
-msgstr "Estacion fija"
-
-#: modules/computer.c:321
-msgid "All-in-one"
-msgstr "All in one"
-
-#: modules/computer.c:322
-msgid "Subnotebook"
-msgstr "Subportátil"
-
-#: modules/computer.c:323
-msgid "Space-saving"
-msgstr "PC Espacio-pequeño"
-
 #: modules/computer.c:324
-msgid "Lunch Box"
-msgstr "PC caja"
-
-#: modules/computer.c:325
-msgid "Main Server Chassis"
-msgstr "Servidor principal"
-
-#: modules/computer.c:326
-msgid "Expansion Chassis"
-msgstr "Servidor expansion"
-
-#: modules/computer.c:327
-msgid "Sub Chassis"
-msgstr "Sub servidor"
-
-#: modules/computer.c:328
-msgid "Bus Expansion Chassis"
-msgstr "Expansion de bus acoplable"
-
-#: modules/computer.c:329
-msgid "Peripheral Chassis"
-msgstr "Periferico acoplable"
-
-#: modules/computer.c:330
-msgid "RAID Chassis"
-msgstr "RAID acoplable"
-
-#: modules/computer.c:331
-msgid "Rack Mount Chassis"
-msgstr "Rack de montaje acoplable"
-
-#: modules/computer.c:332
-msgid "Sealed-case PC"
-msgstr "PC sellada"
+msgid "Single-board computer"
+msgstr ""
 
 #. /proc/apm
-#. FIXME: use dmidecode if available to get chassis type
-#: modules/computer.c:386
+#: modules/computer.c:373
 msgid "Unknown physical machine type"
 msgstr "Equipo fisico no catalogado"
 
-#: modules/computer.c:470 modules/computer.c:709
+#: modules/computer.c:393 modules/computer.c:394
+msgid "Virtual (VMware)"
+msgstr ""
+
+#: modules/computer.c:396 modules/computer.c:397 modules/computer.c:398
+#: modules/computer.c:399
+msgid "Virtual (QEMU)"
+msgstr ""
+
+#: modules/computer.c:401 modules/computer.c:402
+msgid "Virtual (Unknown)"
+msgstr ""
+
+#: modules/computer.c:404 modules/computer.c:405 modules/computer.c:406
+#: modules/computer.c:427
+msgid "Virtual (VirtualBox)"
+msgstr ""
+
+#: modules/computer.c:408 modules/computer.c:409 modules/computer.c:410
+#: modules/computer.c:421
+msgid "Virtual (Xen)"
+msgstr ""
+
+#: modules/computer.c:412
+msgid "Virtual (hypervisor present)"
+msgstr ""
+
+#: modules/computer.c:465 modules/computer.c:769
 msgid "Computer"
 msgstr "Equipo"
 
-#: modules/computer.c:471 modules/devices/alpha/processor.c:87
-#: modules/devices/arm/processor.c:236 modules/devices.c:95
+#: modules/computer.c:466 modules/devices/alpha/processor.c:87
+#: modules/devices/arm/processor.c:327 modules/devices.c:98
 #: modules/devices/ia64/processor.c:159 modules/devices/m68k/processor.c:83
 #: modules/devices/mips/processor.c:74 modules/devices/parisc/processor.c:154
 #: modules/devices/ppc/processor.c:157 modules/devices/riscv/processor.c:181
 #: modules/devices/s390/processor.c:131 modules/devices/sh/processor.c:83
-#: modules/devices/sparc/processor.c:74 modules/devices/x86/processor.c:409
+#: modules/devices/sparc/processor.c:74 modules/devices/x86/processor.c:644
 msgid "Processor"
 msgstr "Procesador"
 
-#: modules/computer.c:474
+#: modules/computer.c:469
 msgid "Machine Type"
 msgstr "Tipo de equipo"
 
-#: modules/computer.c:477 modules/computer.c:514
+#: modules/computer.c:472 modules/computer.c:508
 msgid "User Name"
 msgstr "Nombre de usuario"
 
-#: modules/computer.c:482 modules/computer.c:591
+#: modules/computer.c:477
 msgid "Resolution"
 msgstr "Resolución"
 
-#: modules/computer.c:483 modules/computer.c:592
+#: modules/computer.c:477 modules/computer.c:607
 #, c-format
 msgid "%dx%d pixels"
 msgstr "%dx%d pixeles"
 
-#: modules/computer.c:485
-msgid "OpenGL Renderer"
-msgstr "Renderizador OpenGL"
+#: modules/computer.c:480
+msgid "Session Display Server"
+msgstr ""
 
-#: modules/computer.c:486
-msgid "X11 Vendor"
-msgstr "Proveedor X11"
-
-#: modules/computer.c:491 modules/devices.c:102
+#: modules/computer.c:485 modules/devices.c:106
 msgid "Input Devices"
 msgstr "Dispositivos de entrada"
 
-#: modules/computer.c:493 modules/computer.c:752 modules/devices.c:99
-msgid "Printers"
-msgstr "Impresoras"
-
-#: modules/computer.c:495 modules/computer.c:752 modules/devices.c:103
-msgid "Storage"
-msgstr "Almacenamiento"
-
-#: modules/computer.c:506
+#: modules/computer.c:500
 msgid "Kernel"
 msgstr "Núcleo"
 
-#: modules/computer.c:508
+#: modules/computer.c:502
 msgid "C Library"
 msgstr "Biblioteca C"
 
-#: modules/computer.c:509
+#: modules/computer.c:503
 msgid "Distribution"
 msgstr "Distribución"
 
-#: modules/computer.c:512
+#: modules/computer.c:506
 msgid "Current Session"
 msgstr "Sesión actual"
 
-#: modules/computer.c:513
+#: modules/computer.c:507
 msgid "Computer Name"
 msgstr "Nombre del equipo"
 
-#: modules/computer.c:515 modules/computer/languages.c:108
+#: modules/computer.c:509 modules/computer/languages.c:108
 msgid "Language"
 msgstr "Idioma"
 
-#: modules/computer.c:516 modules/computer/users.c:50
+#: modules/computer.c:510 modules/computer/users.c:50
 msgid "Home Directory"
 msgstr "Directorio personal"
 
-#: modules/computer.c:519 modules/devices/usb.c:87 modules/devices/usb.c:234
-#: modules/devices/usb.c:351
+#: modules/computer.c:513
 msgid "Misc"
 msgstr "Otras"
 
-#: modules/computer.c:532
+#: modules/computer.c:526
 msgid "Loaded Modules"
 msgstr "Módulos cargados"
 
-#: modules/computer.c:535 modules/computer/modules.c:145
-#: modules/computer/modules.c:147 modules/devices/arm/processor.c:337
-#: modules/devices.c:559 modules/devices/x86/processor.c:456
+#: modules/computer.c:529 modules/computer/modules.c:145
+#: modules/computer/modules.c:147 modules/devices/arm/processor.c:448
+#: modules/devices.c:575
 msgid "Description"
 msgstr "Descripción"
 
-#: modules/computer.c:548
+#: modules/computer.c:542
 msgid "Date & Time"
 msgstr "Fecha y hora"
 
-#: modules/computer.c:549
+#: modules/computer.c:543
 msgid "Kernel Version"
 msgstr "Versión del núcleo"
 
-#: modules/computer.c:559
+#: modules/computer.c:553
 msgid "Available Languages"
 msgstr "Idiomas disponibles"
 
-#: modules/computer.c:561
+#: modules/computer.c:555
 msgid "Language Code"
 msgstr "Código del idioma"
 
-#: modules/computer.c:573
+#: modules/computer.c:567
 msgid "Mounted File Systems"
 msgstr "Sistemas de archivos montados"
 
-#: modules/computer.c:575 modules/computer/filesystem.c:85
+#: modules/computer.c:569 modules/computer/filesystem.c:85
 msgid "Mount Point"
 msgstr "Punto de montaje"
 
-#: modules/computer.c:576
+#: modules/computer.c:570
 msgid "Usage"
 msgstr "Uso"
 
-#: modules/computer.c:577
+#: modules/computer.c:571 modules/devices/gpu.c:93 modules/devices/gpu.c:101
+#: modules/devices/gpu.c:187 modules/devices/pci.c:70 modules/devices/pci.c:78
+#: modules/devices/pci.c:122 modules/devices/usb.c:72
 msgid "Device"
 msgstr "Dispositivo"
 
-#: modules/computer.c:594 modules/computer.c:601
+#: modules/computer.c:590
+msgid "Session"
+msgstr ""
+
+#: modules/computer.c:591 modules/devices.c:614 modules/devices/dmi.c:53
+#: modules/devices/inputdevices.c:117
+msgid "Type"
+msgstr "Tipo"
+
+#: modules/computer.c:594
+msgid "Wayland"
+msgstr ""
+
+#: modules/computer.c:595 modules/computer.c:600
+msgid "Current Display Name"
+msgstr ""
+
+#: modules/computer.c:599
+msgid "X Server"
+msgstr ""
+
+#: modules/computer.c:601 modules/computer.c:641 modules/devices/dmi.c:39
+#: modules/devices/dmi.c:43 modules/devices/dmi.c:47 modules/devices/dmi.c:52
+#: modules/devices/gpu.c:92 modules/devices/gpu.c:100 modules/devices/gpu.c:186
 #: modules/devices/ia64/processor.c:161 modules/devices/inputdevices.c:119
-#: modules/devices/pci.c:225 modules/devices/usb.c:349
-#: modules/devices/x86/processor.c:416
+#: modules/devices/pci.c:69 modules/devices/pci.c:77 modules/devices/usb.c:64
+#: modules/devices/x86/processor.c:651
 msgid "Vendor"
 msgstr "Proveedor"
 
-#: modules/computer.c:598
-msgid "Monitors"
-msgstr "Monitores"
+#: modules/computer.c:603
+msgid "Release Number"
+msgstr ""
 
-#: modules/computer.c:600
-msgid "OpenGL"
-msgstr "OpenGL (3D)"
+#: modules/computer.c:611
+msgid "Screens"
+msgstr ""
 
-#: modules/computer.c:602
+#: modules/computer.c:617
+msgid "Disconnected"
+msgstr ""
+
+#: modules/computer.c:620
+msgid "Connected"
+msgstr ""
+
+#: modules/computer.c:624 modules/computer/os.c:78 modules/computer/os.c:234
+#: modules/computer/os.c:392 modules/devices.c:344 modules/devices.c:396
+#: modules/devices/printers.c:99 modules/devices/printers.c:106
+#: modules/devices/printers.c:116 modules/devices/printers.c:131
+#: modules/devices/printers.c:140 modules/devices/printers.c:243
+msgid "Unknown"
+msgstr "Desconocido"
+
+#: modules/computer.c:628
+msgid "Unused"
+msgstr ""
+
+#: modules/computer.c:629
+#, c-format
+msgid "%dx%d pixels, offset (%d, %d)"
+msgstr ""
+
+#: modules/computer.c:638
+msgid "Outputs (XRandR)"
+msgstr ""
+
+#: modules/computer.c:640
+msgid "OpenGL (GLX)"
+msgstr ""
+
+#: modules/computer.c:642
 msgid "Renderer"
 msgstr "Renderizador"
 
-#: modules/computer.c:604
+#: modules/computer.c:643
 msgid "Direct Rendering"
 msgstr "Renderizado Directo"
 
-#: modules/computer.c:608
-msgid "Extensions"
-msgstr "Extensiones"
+#: modules/computer.c:645
+msgid "Version (Compatibility)"
+msgstr ""
 
-#: modules/computer.c:628
+#: modules/computer.c:646
+msgid "Shading Language Version (Compatibility)"
+msgstr ""
+
+#: modules/computer.c:647
+msgid "Version (Core)"
+msgstr ""
+
+#: modules/computer.c:648
+msgid "Shading Language Version (Core)"
+msgstr ""
+
+#: modules/computer.c:649
+msgid "Version (ES)"
+msgstr ""
+
+#: modules/computer.c:650
+msgid "Shading Language Version (ES)"
+msgstr ""
+
+#: modules/computer.c:651
+msgid "GLX Version"
+msgstr ""
+
+#: modules/computer.c:672
 msgid "Group"
 msgstr "Grupo"
 
-#: modules/computer.c:631 modules/computer/users.c:49
+#: modules/computer.c:675 modules/computer/users.c:49
 msgid "Group ID"
 msgstr "ID del grupo"
 
-#: modules/computer.c:751
+#: modules/computer.c:811
 msgid "RAM"
 msgstr "RAM"
 
-#: modules/computer.c:751 modules/devices/devicetree/pmac_data.c:82
+#: modules/computer.c:811 modules/devices/devicetree/pmac_data.c:82
 msgid "Motherboard"
 msgstr "Tarjeta madre"
 
-#: modules/computer.c:751
+#: modules/computer.c:811
 msgid "Graphics"
 msgstr "Graficos"
 
-#: modules/computer.c:752
+#: modules/computer.c:812 modules/devices.c:107
+msgid "Storage"
+msgstr "Almacenamiento"
+
+#: modules/computer.c:812 modules/devices.c:103
+msgid "Printers"
+msgstr "Impresoras"
+
+#: modules/computer.c:812
 msgid "Audio"
 msgstr "Audio"
 
-#: modules/computer.c:807
+#: modules/computer.c:857
 msgid "Gathers high-level computer information"
 msgstr "Obtiene información del equipo de alto nivel"
-
-#: modules/computer/display.c:122
-#, c-format
-msgid "Monitor %d=%dx%d pixels\n"
-msgstr "Monitor %d=%dx%d pixels\n"
 
 #: modules/computer/filesystem.c:83
 msgid "Filesystem"
@@ -1244,13 +1568,13 @@ msgstr "Correo-e"
 msgid "Territory"
 msgstr "Territorio"
 
-#: modules/computer/languages.c:110 modules/devices/arm/processor.c:250
-#: modules/devices/ia64/processor.c:166 modules/devices/ppc/processor.c:159
-#: modules/devices/usb.c:236
+#: modules/computer/languages.c:110 modules/devices/arm/processor.c:341
+#: modules/devices/gpu.c:146 modules/devices/ia64/processor.c:166
+#: modules/devices/pci.c:114 modules/devices/ppc/processor.c:159
 msgid "Revision"
 msgstr "Revision"
 
-#: modules/computer/languages.c:111
+#: modules/computer/languages.c:111 modules/devices/dmi.c:42
 msgid "Date"
 msgstr "Fecha"
 
@@ -1264,7 +1588,7 @@ msgstr "No se pudo obtener estadisticas"
 
 #: modules/computer/modules.c:125 modules/computer/modules.c:126
 #: modules/computer/modules.c:127 modules/computer/modules.c:128
-#: modules/computer/modules.c:129
+#: modules/computer/modules.c:129 modules/devices/dmi.c:115
 msgid "(Not available)"
 msgstr "(No disponible)"
 
@@ -1280,7 +1604,7 @@ msgstr "Ruta"
 msgid "Used Memory"
 msgstr "Memoria usada"
 
-#: modules/computer/modules.c:144
+#: modules/computer/modules.c:144 modules/devices/devmemory.c:72
 msgid "KiB"
 msgstr ""
 
@@ -1316,14 +1640,6 @@ msgstr "Libreria uClibc/uClibc-ng"
 #: modules/computer/os.c:40
 msgid "diet libc"
 msgstr "Libreria diet libc"
-
-#: modules/computer/os.c:78 modules/computer/os.c:234 modules/computer/os.c:359
-#: modules/devices.c:333 modules/devices.c:387 modules/devices/printers.c:99
-#: modules/devices/printers.c:106 modules/devices/printers.c:116
-#: modules/devices/printers.c:131 modules/devices/printers.c:140
-#: modules/devices/printers.c:243
-msgid "Unknown"
-msgstr "Desconocido"
 
 #: modules/computer/os.c:112 modules/computer/os.c:115
 msgid "GNOME Shell "
@@ -1371,11 +1687,6 @@ msgstr "%d bits (promedio)"
 msgid "%d bits (healthy)"
 msgstr "%d bits (saludable)"
 
-#: modules/computer/os.c:279 modules/devices/usb.c:48 modules/devices/usb.c:307
-#: modules/devices/usb.c:310 modules/network/net.c:442 includes/cpu_util.h:11
-msgid "(Unknown)"
-msgstr "(desconocido)"
-
 #: modules/computer/users.c:47
 msgid "User Information"
 msgstr "Información de usuario"
@@ -1388,12 +1699,13 @@ msgstr "ID usuario"
 msgid "Default Shell"
 msgstr "Shell principal"
 
-#: modules/devices/alpha/processor.c:88 modules/devices/devicetree.c:141
-#: modules/devices/devicetree.c:176 modules/devices/devicetree/pmac_data.c:80
-#: modules/devices/ia64/processor.c:165 modules/devices/m68k/processor.c:84
-#: modules/devices/mips/processor.c:75 modules/devices/parisc/processor.c:155
-#: modules/devices/ppc/processor.c:158 modules/devices/riscv/processor.c:182
-#: modules/devices/s390/processor.c:132 modules/devices/spd-decode.c:1510
+#: modules/devices/alpha/processor.c:88 modules/devices/devicetree.c:161
+#: modules/devices/devicetree.c:207 modules/devices/devicetree/pmac_data.c:80
+#: modules/devices/gpu.c:124 modules/devices/ia64/processor.c:165
+#: modules/devices/m68k/processor.c:84 modules/devices/mips/processor.c:75
+#: modules/devices/parisc/processor.c:155 modules/devices/ppc/processor.c:158
+#: modules/devices/riscv/processor.c:182 modules/devices/s390/processor.c:132
+#: modules/devices/spd-decode.c:1510
 msgid "Model"
 msgstr "Modelo"
 
@@ -1401,44 +1713,28 @@ msgstr "Modelo"
 msgid "Platform String"
 msgstr "Plataforma"
 
-#: modules/devices/alpha/processor.c:90 modules/devices/arm/processor.c:240
+#: modules/devices/alpha/processor.c:90 modules/devices/arm/processor.c:331
 #: modules/devices/ia64/processor.c:167 modules/devices/m68k/processor.c:87
 #: modules/devices/mips/processor.c:77 modules/devices/parisc/processor.c:158
-#: modules/devices/pci.c:108 modules/devices/ppc/processor.c:160
-#: modules/devices/riscv/processor.c:186 modules/devices/sh/processor.c:87
-#: modules/devices/x86/processor.c:420
+#: modules/devices/ppc/processor.c:160 modules/devices/riscv/processor.c:186
+#: modules/devices/sh/processor.c:87 modules/devices/x86/processor.c:655
 msgid "Frequency"
 msgstr "Frecuencia"
 
-#: modules/devices/alpha/processor.c:90 modules/devices/arm/processor.c:240
-#: modules/devices/arm/processor.c:365 modules/devices.c:299
-#: modules/devices.c:307 modules/devices.c:335
-#: modules/devices/ia64/processor.c:167 modules/devices/ia64/processor.c:196
-#: modules/devices/m68k/processor.c:87 modules/devices/mips/processor.c:77
-#: modules/devices/parisc/processor.c:158
-#: modules/devices/parisc/processor.c:191 modules/devices/pci.c:108
-#: modules/devices/ppc/processor.c:160 modules/devices/ppc/processor.c:187
-#: modules/devices/riscv/processor.c:186 modules/devices/riscv/processor.c:214
-#: modules/devices/s390/processor.c:160 modules/devices/sh/processor.c:87
-#: modules/devices/sh/processor.c:88 modules/devices/sh/processor.c:89
-#: modules/devices/x86/processor.c:420 modules/devices/x86/processor.c:479
-msgid "MHz"
-msgstr "MHz"
-
-#: modules/devices/alpha/processor.c:91 modules/devices/arm/processor.c:241
+#: modules/devices/alpha/processor.c:91 modules/devices/arm/processor.c:332
 #: modules/devices/ia64/processor.c:168 modules/devices/m68k/processor.c:88
 #: modules/devices/mips/processor.c:78 modules/devices/parisc/processor.c:159
 #: modules/devices/ppc/processor.c:161 modules/devices/s390/processor.c:134
-#: modules/devices/sh/processor.c:90 modules/devices/x86/processor.c:421
+#: modules/devices/sh/processor.c:90 modules/devices/x86/processor.c:656
 msgid "BogoMips"
 msgstr "BogoMips"
 
-#: modules/devices/alpha/processor.c:92 modules/devices/arm/processor.c:242
+#: modules/devices/alpha/processor.c:92 modules/devices/arm/processor.c:333
 #: modules/devices/ia64/processor.c:169 modules/devices/m68k/processor.c:89
 #: modules/devices/mips/processor.c:79 modules/devices/parisc/processor.c:160
 #: modules/devices/ppc/processor.c:162 modules/devices/riscv/processor.c:187
 #: modules/devices/s390/processor.c:135 modules/devices/sh/processor.c:91
-#: modules/devices/sparc/processor.c:77 modules/devices/x86/processor.c:422
+#: modules/devices/sparc/processor.c:77 modules/devices/x86/processor.c:657
 msgid "Byte Order"
 msgstr "Orden Byte"
 
@@ -1619,61 +1915,67 @@ msgid "ARM Processor"
 msgstr "Procesador ARM"
 
 #: modules/devices/arm/processor.c:200 modules/devices/riscv/processor.c:147
-#: modules/devices/x86/processor.c:371
+#: modules/devices/x86/processor.c:606
 msgid "Empty List"
 msgstr "Lista vacia"
 
-#: modules/devices/arm/processor.c:237
+#: modules/devices/arm/processor.c:226 modules/devices/x86/processor.c:268
+msgid "Clocks"
+msgstr "Ciclos"
+
+#: modules/devices/arm/processor.c:272 modules/devices/arm/processor.c:285
+#: modules/devices/x86/processor.c:314 modules/devices/x86/processor.c:327
+#, c-format
+msgid "%.2f-%.2f %s=%dx\n"
+msgstr ""
+
+#: modules/devices/arm/processor.c:328
 msgid "Linux Name"
 msgstr "Nombre Linux"
 
-#: modules/devices/arm/processor.c:238
+#: modules/devices/arm/processor.c:329
 msgid "Decoded Name"
 msgstr "Nombre decodificado"
 
-#: modules/devices/arm/processor.c:239 modules/network/net.c:458
+#: modules/devices/arm/processor.c:330 modules/network/net.c:453
 msgid "Mode"
 msgstr "Modo"
 
-#: modules/devices/arm/processor.c:245
+#: modules/devices/arm/processor.c:336
 msgid "ARM"
 msgstr "ARM"
 
-#: modules/devices/arm/processor.c:246
+#: modules/devices/arm/processor.c:337
 msgid "Implementer"
 msgstr "Implementador"
 
-#: modules/devices/arm/processor.c:247
+#: modules/devices/arm/processor.c:338
 msgid "Part"
 msgstr "Parte"
 
-#: modules/devices/arm/processor.c:248 modules/devices/ia64/processor.c:162
+#: modules/devices/arm/processor.c:339 modules/devices/ia64/processor.c:162
 #: modules/devices/parisc/processor.c:156 modules/devices/riscv/processor.c:183
 msgid "Architecture"
 msgstr "Arquitectura"
 
-#: modules/devices/arm/processor.c:249
+#: modules/devices/arm/processor.c:340
 msgid "Variant"
 msgstr "Variante"
 
-#: modules/devices/arm/processor.c:251 modules/devices/riscv/processor.c:190
-#: modules/devices/sparc/processor.c:78 modules/devices/x86/processor.c:428
+#: modules/devices/arm/processor.c:342 modules/devices/riscv/processor.c:190
+#: modules/devices/sparc/processor.c:78 modules/devices/x86/processor.c:663
 msgid "Capabilities"
 msgstr "Capacidades"
 
-#: modules/devices/arm/processor.c:335
+#: modules/devices/arm/processor.c:446
 msgid "SOC/Package"
 msgstr "SOC/Paquete"
 
-#: modules/devices/arm/processor.c:338 modules/devices/cpu_util.c:222
-msgid "Topology"
-msgstr "Topologia"
+#: modules/devices/arm/processor.c:450 modules/devices/x86/processor.c:698
+msgid "Logical CPU Config"
+msgstr ""
 
-#: modules/devices/arm/processor.c:339
-msgid "Clocks"
-msgstr "Ciclos"
-
-#: modules/devices/arm/processor.c:354
+#: modules/devices/arm/processor.c:467
 msgid "SOC/Package Information"
 msgstr "Información SOC/Paquete"
 
@@ -1763,54 +2065,57 @@ msgstr ""
 "[Sin baterías]\n"
 "No se encontraron baterías en este sistema=\n"
 
-#: modules/devices.c:97
+#: modules/devices.c:100
+msgid "Graphics Processors"
+msgstr ""
+
+#: modules/devices.c:101 modules/devices/pci.c:143
 msgid "PCI Devices"
 msgstr "Dispositivos PCI"
 
-#: modules/devices.c:98 modules/devices/usb.c:117 modules/devices/usb.c:156
-#: modules/devices/usb.c:415
+#: modules/devices.c:102 modules/devices/usb.c:92
 msgid "USB Devices"
 msgstr "Dispositivos USB"
 
-#: modules/devices.c:100
+#: modules/devices.c:104
 msgid "Battery"
 msgstr "Batería"
 
-#: modules/devices.c:101
+#: modules/devices.c:105
 msgid "Sensors"
 msgstr "Sensores"
 
-#: modules/devices.c:105
+#: modules/devices.c:109
 msgid "DMI"
 msgstr "DMI"
 
-#: modules/devices.c:106
+#: modules/devices.c:110
 msgid "Memory SPD"
 msgstr "Memoria SPD"
 
-#: modules/devices.c:111
+#: modules/devices.c:115
 msgid "Device Tree"
 msgstr "Arbol de dispositivos"
 
-#: modules/devices.c:113
+#: modules/devices.c:117
 msgid "Resources"
 msgstr "Recursos"
 
-#: modules/devices.c:151
+#: modules/devices.c:162
 #, c-format
 msgid "%d physical processor"
 msgid_plural "%d physical processors"
 msgstr[0] "%d procesador real"
 msgstr[1] "%d procesadores reales"
 
-#: modules/devices.c:152
+#: modules/devices.c:163
 #, c-format
 msgid "%d core"
 msgid_plural "%d cores"
 msgstr[0] "%d nucleo"
 msgstr[1] "%d nucleos"
 
-#: modules/devices.c:153
+#: modules/devices.c:164
 #, c-format
 msgid "%d thread"
 msgid_plural "%d threads"
@@ -1818,212 +2123,112 @@ msgstr[0] "%d hilo"
 msgstr[1] "%d hilos"
 
 #. /NP procs; NC cores; NT threads
-#: modules/devices.c:154
+#: modules/devices.c:165
 #, c-format
 msgid "%s; %s; %s"
 msgstr ""
 
-#: modules/devices.c:372
-msgid " (model unknown)"
-msgstr " (modelo desconocido)"
-
-#: modules/devices.c:374
-msgid " (vendor unknown)"
-msgstr " (proveedor desconocido)"
-
-#: modules/devices.c:559
+#: modules/devices.c:575
 msgid "Field"
 msgstr "Campo"
 
-#: modules/devices.c:559 modules/devices.c:591
+#: modules/devices.c:575 modules/devices.c:614
 msgid "Value"
 msgstr "Valor"
 
-#: modules/devices.c:591
+#: modules/devices.c:614
 msgid "Sensor"
 msgstr "Sensor"
 
-#: modules/devices.c:591 modules/devices/inputdevices.c:117
-msgid "Type"
-msgstr "Tipo"
-
-#: modules/devices.c:637
+#: modules/devices.c:661
 msgid "Devices"
 msgstr "Dispositivos"
 
-#: modules/devices.c:649
+#: modules/devices.c:673
 msgid "Update PCI ID listing"
 msgstr "Actualizar listado de ids PCI"
 
-#: modules/devices.c:661
+#: modules/devices.c:685
 msgid "Update CPU feature database"
 msgstr "Actualizar base de datos de características de CPU"
 
-#: modules/devices.c:689
+#: modules/devices.c:713
 msgid "Gathers information about hardware devices"
 msgstr "Obtiene información acerca de los dispositivos de hardware"
 
-#: modules/devices.c:708
+#: modules/devices.c:732
 msgid "Resource information requires superuser privileges"
 msgstr "Información de recursos require privilegios de superusuario"
 
-#: modules/devices/cpu_util.c:30
-msgid "Little Endian"
-msgstr "Little Endian"
-
-#: modules/devices/cpu_util.c:32
-msgid "Big Endian"
-msgstr "Big Endian"
-
-#: modules/devices/cpu_util.c:178 modules/devices/cpu_util.c:189
-msgid "Frequency Scaling"
-msgstr "Escalador de frecuencia"
-
-#: modules/devices/cpu_util.c:179
-msgid "Minimum"
-msgstr "Minimo"
-
-#: modules/devices/cpu_util.c:179 modules/devices/cpu_util.c:180
-#: modules/devices/cpu_util.c:181
-msgid "kHz"
-msgstr "Khz"
-
-#: modules/devices/cpu_util.c:180
-msgid "Maximum"
-msgstr "Maximo"
-
-#: modules/devices/cpu_util.c:181
-msgid "Current"
-msgstr "Actual"
-
-#: modules/devices/cpu_util.c:182
-msgid "Transition Latency"
-msgstr "Latencia de transicion"
-
-#: modules/devices/cpu_util.c:182
-msgid "ns"
-msgstr "ns"
-
-#: modules/devices/cpu_util.c:183
-msgid "Governor"
-msgstr "Gobernador"
-
-#: modules/devices/cpu_util.c:184 modules/devices/cpu_util.c:190
-msgid "Driver"
-msgstr "Manejador"
-
-#: modules/devices/cpu_util.c:196 modules/devices/x86/processor.c:297
-msgid "(Not Available)"
-msgstr "(no disponible)"
-
-#: modules/devices/cpu_util.c:204 modules/devices/cpu_util.c:206
-msgid "Socket"
-msgstr "Soket"
-
-#: modules/devices/cpu_util.c:209 modules/devices/cpu_util.c:211
-msgid "Core"
-msgstr "Core"
-
-#: modules/devices/cpu_util.c:214
-msgid "Book"
-msgstr "Asentamientos"
-
-#: modules/devices/cpu_util.c:216
-msgid "Drawer"
-msgstr "Dibujado"
-
-#: modules/devices/cpu_util.c:223
-msgid "ID"
-msgstr "ID"
-
-#: modules/devices/devicetree.c:47
+#: modules/devices/devicetree.c:50
 msgid "Properties"
 msgstr "Propiedades"
 
-#: modules/devices/devicetree.c:48
+#: modules/devices/devicetree.c:51
 msgid "Children"
 msgstr "Hijos"
 
-#: modules/devices/devicetree.c:84
+#: modules/devices/devicetree.c:87
 msgid "Node"
 msgstr "Nodo"
 
-#: modules/devices/devicetree.c:85
+#: modules/devices/devicetree.c:88
 msgid "Node Path"
 msgstr "Ruta nodo"
 
-#: modules/devices/devicetree.c:86
+#: modules/devices/devicetree.c:89
 msgid "Alias"
 msgstr "Alterno"
 
-#: modules/devices/devicetree.c:86 modules/devices/devicetree.c:87
+#: modules/devices/devicetree.c:89 modules/devices/devicetree.c:90
 msgid "(None)"
 msgstr "(ninguno)"
 
-#: modules/devices/devicetree.c:87
+#: modules/devices/devicetree.c:90
 msgid "Symbol"
 msgstr "Simbolo"
 
-#: modules/devices/devicetree.c:132 modules/devices/devicetree/pmac_data.c:79
+#: modules/devices/devicetree.c:143 modules/devices/devicetree/pmac_data.c:79
 msgid "Platform"
 msgstr "Plataforma"
 
-#: modules/devices/devicetree.c:133 modules/devices/devicetree.c:178
+#: modules/devices/devicetree.c:144 modules/devices/devicetree.c:209
 msgid "Compatible"
 msgstr "Compatible"
 
-#: modules/devices/devicetree.c:134
+#: modules/devices/devicetree.c:145
 msgid "GPU-compatible"
 msgstr "GPU-compatble"
 
-#: modules/devices/devicetree.c:140
+#: modules/devices/devicetree.c:160
 msgid "Raspberry Pi or Compatible"
 msgstr "Raspberry Pi o similar"
 
-#: modules/devices/devicetree.c:142 modules/devices/devicetree.c:160
-#: modules/devices/devicetree.c:177 modules/devices/devicetree/rpi_data.c:160
+#: modules/devices/devicetree.c:162 modules/devices/devicetree.c:189
+#: modules/devices/devicetree.c:208 modules/devices/devicetree/rpi_data.c:161
+#: modules/devices/dmi.c:49 modules/devices/dmi.c:55
 msgid "Serial Number"
 msgstr "Numero serial"
 
-#: modules/devices/devicetree.c:143 modules/devices/devicetree/rpi_data.c:157
+#: modules/devices/devicetree.c:163 modules/devices/devicetree/rpi_data.c:158
 msgid "RCode"
 msgstr "Codigo R"
 
-#: modules/devices/devicetree.c:143
+#: modules/devices/devicetree.c:163
 msgid "No revision code available; unable to lookup model details."
 msgstr "No hay codigo de revision disponible, imposible obtener detalles"
 
-#: modules/devices/devicetree.c:159
+#: modules/devices/devicetree.c:188
 msgid "More"
 msgstr "Mas"
 
-#: modules/devices/devicetree.c:175
-msgid "Board"
-msgstr "Tarjeta"
-
-#: modules/devices/devicetree.c:234
+#: modules/devices/devicetree.c:268
 msgid "Messages"
 msgstr "Mensajes"
-
-#: modules/devices/devicetree/dt_util.c:1013
-msgid "phandle Map"
-msgstr "Mapa manejado"
-
-#: modules/devices/devicetree/dt_util.c:1014
-msgid "Alias Map"
-msgstr "Mapa alternativo"
-
-#: modules/devices/devicetree/dt_util.c:1015
-msgid "Symbol Map"
-msgstr "Mapa de simbolos"
 
 #: modules/devices/devicetree/pmac_data.c:78
 msgid "Apple Power Macintosh"
 msgstr "Power Macintosh de Apple"
-
-#: modules/devices/devicetree/pmac_data.c:81 modules/devices/sh/processor.c:85
-msgid "Machine"
-msgstr "Maquina"
 
 #: modules/devices/devicetree/pmac_data.c:83
 msgid "Detected as"
@@ -2041,88 +2246,179 @@ msgstr "Cache L2"
 msgid "PMAC Generation"
 msgstr "PMAC generacion"
 
-#: modules/devices/devicetree/rpi_data.c:152
 #: modules/devices/devicetree/rpi_data.c:153
+#: modules/devices/devicetree/rpi_data.c:154
 msgid "Raspberry Pi"
 msgstr "Raspberry Pi"
 
-#: modules/devices/devicetree/rpi_data.c:153
+#: modules/devices/devicetree/rpi_data.c:154
 msgid "Board Name"
 msgstr "Nombre Tarjeta"
 
-#: modules/devices/devicetree/rpi_data.c:154
+#: modules/devices/devicetree/rpi_data.c:155
 msgid "PCB Revision"
 msgstr "Revision PCB"
 
-#: modules/devices/devicetree/rpi_data.c:155
+#: modules/devices/devicetree/rpi_data.c:156
 msgid "Introduction"
 msgstr "Introducido"
 
-#: modules/devices/devicetree/rpi_data.c:156 modules/devices/spd-decode.c:1510
-#: modules/devices/usb.c:84 modules/devices/usb.c:217
+#: modules/devices/devicetree/rpi_data.c:157 modules/devices/spd-decode.c:1510
 msgid "Manufacturer"
 msgstr "Manufacturado"
 
-#: modules/devices/devicetree/rpi_data.c:158
+#: modules/devices/devicetree/rpi_data.c:159
 msgid "SOC (spec)"
 msgstr "SOC (specif)"
 
-#: modules/devices/devicetree/rpi_data.c:159
+#: modules/devices/devicetree/rpi_data.c:160
 msgid "Memory (spec)"
 msgstr "Memoria (specif)"
 
-#: modules/devices/devicetree/rpi_data.c:161
+#: modules/devices/devicetree/rpi_data.c:162
 msgid "Permanent overvolt bit"
 msgstr "Bit de sobrevoltage permanente"
 
-#: modules/devices/devicetree/rpi_data.c:161
+#: modules/devices/devicetree/rpi_data.c:162
 msgctxt "rpi-ov-bit"
 msgid "Set"
 msgstr "Asignado"
 
-#: modules/devices/devicetree/rpi_data.c:161
+#: modules/devices/devicetree/rpi_data.c:162
 msgctxt "rpi-ov-bit"
 msgid "Not set"
 msgstr "Sin ajustar"
 
-#: modules/devices/devmemory.c:93
+#: modules/devices/devmemory.c:101
 msgid "Total Memory"
 msgstr "Memoria total"
 
-#: modules/devices/devmemory.c:94
+#: modules/devices/devmemory.c:102
 msgid "Free Memory"
 msgstr "Memoria Libre"
 
-#: modules/devices/devmemory.c:95
+#: modules/devices/devmemory.c:103
 msgid "Cached Swap"
 msgstr "Intercambio"
 
-#: modules/devices/devmemory.c:96
+#: modules/devices/devmemory.c:104
 msgid "High Memory"
 msgstr "Memoria alta"
 
-#: modules/devices/devmemory.c:97
+#: modules/devices/devmemory.c:105
 msgid "Free High Memory"
 msgstr "Memoria alta libre"
 
-#: modules/devices/devmemory.c:98
+#: modules/devices/devmemory.c:106
 msgid "Low Memory"
 msgstr "Memoria base"
 
-#: modules/devices/devmemory.c:99
+#: modules/devices/devmemory.c:107
 msgid "Free Low Memory"
 msgstr "Memoria base libre"
 
-#: modules/devices/devmemory.c:100
+#: modules/devices/devmemory.c:108
 msgid "Virtual Memory"
 msgstr "Memoria virtual"
 
-#: modules/devices/devmemory.c:101
+#: modules/devices/devmemory.c:109
 msgid "Free Virtual Memory"
 msgstr "Memoria virtual libre"
 
-#: modules/devices/dmi.c:188
+#: modules/devices/dmi.c:36 modules/devices/inputdevices.c:120
+#: modules/devices/usb.c:63
+msgid "Product"
+msgstr "Producto"
+
+#: modules/devices/dmi.c:38 modules/devices/ia64/processor.c:164
+#: modules/devices/sh/processor.c:86
+msgid "Family"
+msgstr "Familia"
+
+#: modules/devices/dmi.c:41
+msgid "BIOS"
+msgstr ""
+
+#: modules/devices/dmi.c:50 modules/devices/dmi.c:56
+msgid "Asset Tag"
+msgstr ""
+
+#: modules/devices/dmi.c:51
+msgid "Chassis"
+msgstr ""
+
+#: modules/devices/dmi.c:116
 msgid "(Not available; Perhaps try running HardInfo as root.)"
+msgstr ""
+
+#: modules/devices/gpu.c:102 modules/devices/pci.c:79
+msgid "SVendor"
+msgstr ""
+
+#: modules/devices/gpu.c:103 modules/devices/pci.c:80
+msgid "SDevice"
+msgstr ""
+
+#: modules/devices/gpu.c:111 modules/devices/pci.c:90
+msgid "PCI Express"
+msgstr ""
+
+#: modules/devices/gpu.c:112 modules/devices/pci.c:92
+msgid "Maximum Link Width"
+msgstr ""
+
+#: modules/devices/gpu.c:113 modules/devices/pci.c:94
+msgid "Maximum Link Speed"
+msgstr ""
+
+#: modules/devices/gpu.c:113 modules/devices/pci.c:93 modules/devices/pci.c:94
+msgid "GT/s"
+msgstr ""
+
+#: modules/devices/gpu.c:123
+msgid "NVIDIA"
+msgstr ""
+
+#: modules/devices/gpu.c:125
+msgid "BIOS Version"
+msgstr ""
+
+#: modules/devices/gpu.c:126
+msgid "UUID"
+msgstr ""
+
+#: modules/devices/gpu.c:141 modules/devices/gpu.c:183
+#: modules/devices/inputdevices.c:115 modules/devices/pci.c:111
+#: modules/devices/usb.c:62
+msgid "Device Information"
+msgstr "Información de dispositivo"
+
+#: modules/devices/gpu.c:142 modules/devices/gpu.c:184
+msgid "Location"
+msgstr ""
+
+#: modules/devices/gpu.c:143
+msgid "DRM Device"
+msgstr ""
+
+#: modules/devices/gpu.c:144 modules/devices/pci.c:112 modules/devices/usb.c:67
+msgid "Class"
+msgstr "clase"
+
+#: modules/devices/gpu.c:150 modules/devices/pci.c:117
+msgid "In Use"
+msgstr ""
+
+#: modules/devices/gpu.c:174
+msgid "Unknown integrated GPU"
+msgstr ""
+
+#: modules/devices/gpu.c:185
+msgid "DT Compatibility"
+msgstr ""
+
+#: modules/devices/gpu.c:201
+msgid "GPUs"
 msgstr ""
 
 #: modules/devices/ia64/processor.c:108
@@ -2133,10 +2429,6 @@ msgstr "Procesador IA64"
 msgid "Architecture Revision"
 msgstr "Revision arquitectura"
 
-#: modules/devices/ia64/processor.c:164 modules/devices/sh/processor.c:86
-msgid "Family"
-msgstr "Familia"
-
 #: modules/devices/ia64/processor.c:170
 msgid "CPU regs"
 msgstr "Registros"
@@ -2145,20 +2437,10 @@ msgstr "Registros"
 msgid "Features"
 msgstr "Capacidades"
 
-#: modules/devices/inputdevices.c:115 modules/devices/pci.c:214
-#: modules/devices/usb.c:82 modules/devices/usb.c:215 modules/devices/usb.c:347
-msgid "Device Information"
-msgstr "Información de dispositivo"
-
-#: modules/devices/inputdevices.c:118 modules/devices/usb.c:92
-#: modules/devices/usb.c:240 modules/devices/usb.c:356
+#: modules/devices/inputdevices.c:118 modules/devices/pci.c:121
+#: modules/devices/usb.c:71
 msgid "Bus"
 msgstr "Bus"
-
-#: modules/devices/inputdevices.c:120 modules/devices/usb.c:83
-#: modules/devices/usb.c:216 modules/devices/usb.c:348
-msgid "Product"
-msgstr "Producto"
 
 #: modules/devices/inputdevices.c:124
 msgid "Connected to"
@@ -2200,61 +2482,31 @@ msgstr "HVersion"
 msgid "SVersion"
 msgstr "SVersion"
 
-#: modules/devices/parisc/processor.c:163 modules/devices/x86/processor.c:425
+#: modules/devices/parisc/processor.c:163 modules/devices/x86/processor.c:660
 msgid "Cache"
 msgstr "Cache"
 
-#: modules/devices/pci.c:106
-msgid "IRQ"
+#: modules/devices/pci.c:91
+msgid "Link Width"
 msgstr ""
 
-#: modules/devices/pci.c:110
-msgid "Latency"
-msgstr "Latencia"
-
-#: modules/devices/pci.c:112
-msgid "Bus Master"
-msgstr "Bus Maestro"
-
-#: modules/devices/pci.c:118
-msgid "Kernel modules"
-msgstr "Modulos"
-
-#: modules/devices/pci.c:124
-#, c-format
-msgid "%s=%s (%s)\n"
+#: modules/devices/pci.c:93
+msgid "Link Speed"
 msgstr ""
 
-#: modules/devices/pci.c:126
-msgid "OEM Vendor"
-msgstr "Vendedor OEM"
-
-#: modules/devices/pci.c:153
-msgid "prefetchable"
+#: modules/devices/pci.c:119 modules/devices/usb.c:70
+msgid "Connection"
 msgstr ""
 
-#: modules/devices/pci.c:154
-msgid "non-prefetchable"
-msgstr ""
-
-#: modules/devices/pci.c:163
-msgid "I/O ports at"
-msgstr "Puertos I/O en"
-
-#: modules/devices/pci.c:216 modules/devices/usb.c:89 modules/devices/usb.c:237
-#: modules/devices/usb.c:353
-msgid "Class"
-msgstr "clase"
-
-#: modules/devices/pci.c:217
+#: modules/devices/pci.c:120
 msgid "Domain"
 msgstr "Dominio"
 
-#: modules/devices/pci.c:218
-msgid "Bus, device, function"
-msgstr "Bus, dispositivo, funcion"
+#: modules/devices/pci.c:123
+msgid "Function"
+msgstr ""
 
-#: modules/devices/pci.c:243
+#: modules/devices/pci.c:161
 msgid "No PCI devices found"
 msgstr "No se encontro dispositivos PCI"
 
@@ -2490,7 +2742,7 @@ msgstr "SPD"
 msgid "Bank"
 msgstr "Ranura"
 
-#: modules/devices/storage.c:46
+#: modules/devices/storage.c:43
 msgid ""
 "\n"
 "[SCSI Disks]\n"
@@ -2498,7 +2750,7 @@ msgstr ""
 "\n"
 "[Discos SCSI]\n"
 
-#: modules/devices/storage.c:110 modules/devices/storage.c:313
+#: modules/devices/storage.c:114 modules/devices/storage.c:320
 #, c-format
 msgid ""
 "[Device Information]\n"
@@ -2507,17 +2759,17 @@ msgstr ""
 "[Información de dispositivo]\n"
 "Modelo=%s\n"
 
-#: modules/devices/storage.c:115 modules/devices/storage.c:319
+#: modules/devices/storage.c:119 modules/devices/storage.c:326
 #, c-format
 msgid "Vendor=%s (%s)\n"
 msgstr "Proveedor=%s (%s)\n"
 
-#: modules/devices/storage.c:120 modules/devices/storage.c:321
+#: modules/devices/storage.c:124 modules/devices/storage.c:328
 #, c-format
 msgid "Vendor=%s\n"
 msgstr "Proveedor=%s\n"
 
-#: modules/devices/storage.c:125
+#: modules/devices/storage.c:129
 #, c-format
 msgid ""
 "Type=%s\n"
@@ -2536,7 +2788,7 @@ msgstr ""
 "ID=%d\n"
 "LUN=%d\n"
 
-#: modules/devices/storage.c:167
+#: modules/devices/storage.c:174
 msgid ""
 "\n"
 "[IDE Disks]\n"
@@ -2544,12 +2796,12 @@ msgstr ""
 "\n"
 "[Discos IDE]\n"
 
-#: modules/devices/storage.c:250
+#: modules/devices/storage.c:257
 #, c-format
 msgid "Driver=%s\n"
 msgstr "Driver=%s\n"
 
-#: modules/devices/storage.c:324
+#: modules/devices/storage.c:331
 #, c-format
 msgid ""
 "Device Name=hd%c\n"
@@ -2560,7 +2812,7 @@ msgstr ""
 "Medio=%s\n"
 "Cache=%dkb\n"
 
-#: modules/devices/storage.c:334
+#: modules/devices/storage.c:341
 #, c-format
 msgid ""
 "[Geometry]\n"
@@ -2571,7 +2823,7 @@ msgstr ""
 "Física=%s\n"
 "Lógica=%s\n"
 
-#: modules/devices/storage.c:344
+#: modules/devices/storage.c:351
 #, c-format
 msgid ""
 "[Capabilities]\n"
@@ -2580,7 +2832,7 @@ msgstr ""
 "[Capacidades]\n"
 "%s"
 
-#: modules/devices/storage.c:351
+#: modules/devices/storage.c:358
 #, c-format
 msgid ""
 "[Speeds]\n"
@@ -2589,52 +2841,29 @@ msgstr ""
 "[Velocidades]\n"
 "%s"
 
-#: modules/devices/usb.c:44 modules/devices/usb.c:326
-msgid "mA"
-msgstr ""
-
-#. /%.2f is version
-#: modules/devices/usb.c:53 modules/devices/usb.c:190
-#, c-format
-msgid "USB %.2f Hub"
-msgstr ""
-
-#: modules/devices/usb.c:55 modules/devices/usb.c:192
-#, c-format
-msgid "Unknown USB %.2f Device (class %d)"
-msgstr "USB desconocido %.2f (class %d)"
-
-#: modules/devices/usb.c:85 modules/devices/usb.c:232
-msgid "Speed"
-msgstr "Velocidad"
-
-#: modules/devices/usb.c:85 modules/devices/usb.c:232
-msgid "Mbit/s"
-msgstr ""
-
-#: modules/devices/usb.c:86 modules/devices/usb.c:233 modules/devices/usb.c:350
+#: modules/devices/usb.c:65
 msgid "Max Current"
 msgstr "Max Actual"
 
-#: modules/devices/usb.c:88 modules/devices/usb.c:235 modules/devices/usb.c:352
+#: modules/devices/usb.c:65
+msgid "mA"
+msgstr ""
+
+#: modules/devices/usb.c:66
 msgid "USB Version"
 msgstr "USB Versión"
 
-#: modules/devices/usb.c:90 modules/devices/usb.c:238 modules/devices/usb.c:354
-msgid "Vendor ID"
-msgstr "ID Vendedor"
+#: modules/devices/usb.c:68
+msgid "Sub-class"
+msgstr ""
 
-#: modules/devices/usb.c:91 modules/devices/usb.c:239 modules/devices/usb.c:355
-msgid "Product ID"
-msgstr "ID Producto"
+#: modules/devices/usb.c:69
+msgid "Device Version"
+msgstr ""
 
-#: modules/devices/usb.c:231
-msgid "Port"
-msgstr "Puerto"
-
-#: modules/devices/usb.c:241
-msgid "Level"
-msgstr "Nivel"
+#: modules/devices/usb.c:103
+msgid "No USB devices found."
+msgstr ""
 
 #: modules/devices/x86/processor.c:149
 msgid "Cache information not available=\n"
@@ -2663,41 +2892,58 @@ msgctxt "cache-type"
 msgid "Unified"
 msgstr "Unificado"
 
-#: modules/devices/x86/processor.c:410
+#: modules/devices/x86/processor.c:367
+msgid "Caches"
+msgstr ""
+
+#: modules/devices/x86/processor.c:418 modules/devices/x86/processor.c:435
+#, c-format
+msgid "Level %d (%s)#%d=%dx %dKB (%dKB), %d-way set-associative, %d sets\n"
+msgstr ""
+
+#: modules/devices/x86/processor.c:645
 msgid "Model Name"
 msgstr "Nombre Modelo"
 
-#: modules/devices/x86/processor.c:411
+#: modules/devices/x86/processor.c:646
 msgid "Family, model, stepping"
 msgstr "Familia, modelo, escalado"
 
-#: modules/devices/x86/processor.c:417
+#: modules/devices/x86/processor.c:652
 msgid "Microcode Version"
 msgstr ""
 
-#: modules/devices/x86/processor.c:418
+#: modules/devices/x86/processor.c:653
 msgid "Configuration"
 msgstr "Configuracion"
 
-#: modules/devices/x86/processor.c:419
+#: modules/devices/x86/processor.c:654
 msgid "Cache Size"
 msgstr "Tamaño cache"
 
-#: modules/devices/x86/processor.c:419
+#: modules/devices/x86/processor.c:654
 msgid "kb"
 msgstr "kb"
 
-#: modules/devices/x86/processor.c:426
+#: modules/devices/x86/processor.c:661
 msgid "Power Management"
 msgstr "Manejador energia"
 
-#: modules/devices/x86/processor.c:427
+#: modules/devices/x86/processor.c:662
 msgid "Bug Workarounds"
 msgstr "Manejo de errores"
 
-#: modules/devices/x86/processor.c:454 modules/devices/x86/processor.c:468
+#: modules/devices/x86/processor.c:695 modules/devices/x86/processor.c:715
 msgid "Package Information"
 msgstr "Información paquete"
+
+#: modules/devices/x86/processor.c:742
+msgid "Socket:Core"
+msgstr ""
+
+#: modules/devices/x86/processor.c:742
+msgid "Thread"
+msgstr ""
 
 #. /flag:fpu
 #: modules/devices/x86/x86_data.c:43
@@ -4029,75 +4275,100 @@ msgctxt "x86-flag"
 msgid "IPI required to wake up remote CPU"
 msgstr ""
 
+#. /bug:cpu_insecure & bug:cpu_meltdown
+#: modules/devices/x86/x86_data.c:281 modules/devices/x86/x86_data.c:282
+msgctxt "x86-flag"
+msgid ""
+"CPU is affected by meltdown attack and needs kernel page table isolation"
+msgstr ""
+
+#. /bug:spectre_v1
+#: modules/devices/x86/x86_data.c:283
+msgctxt "x86-flag"
+msgid "CPU is affected by Spectre variant 1 attack with conditional branches"
+msgstr ""
+
+#. /bug:spectre_v2
+#: modules/devices/x86/x86_data.c:284
+msgctxt "x86-flag"
+msgid "CPU is affected by Spectre variant 2 attack with indirect branches"
+msgstr ""
+
+#. /bug:spec_store_bypass
+#: modules/devices/x86/x86_data.c:285
+msgctxt "x86-flag"
+msgid "CPU is affected by speculative store bypass attack"
+msgstr ""
+
 #. /x86/kernel/cpu/powerflags.h
 #. /flag:pm:ts
-#: modules/devices/x86/x86_data.c:283
+#: modules/devices/x86/x86_data.c:288
 msgctxt "x86-flag"
 msgid "temperature sensor"
 msgstr "sensor de temparatura"
 
 #. /flag:pm:fid
-#: modules/devices/x86/x86_data.c:284
+#: modules/devices/x86/x86_data.c:289
 msgctxt "x86-flag"
 msgid "frequency id control"
 msgstr "id de control frecuencia"
 
 #. /flag:pm:vid
-#: modules/devices/x86/x86_data.c:285
+#: modules/devices/x86/x86_data.c:290
 msgctxt "x86-flag"
 msgid "voltage id control"
 msgstr "id control voltage"
 
 #. /flag:pm:ttp
-#: modules/devices/x86/x86_data.c:286
+#: modules/devices/x86/x86_data.c:291
 msgctxt "x86-flag"
 msgid "thermal trip"
 msgstr "limite termico"
 
 #. /flag:pm:tm
-#: modules/devices/x86/x86_data.c:287
+#: modules/devices/x86/x86_data.c:292
 msgctxt "x86-flag"
 msgid "hardware thermal control"
 msgstr "control terminco por hardware"
 
 #. /flag:pm:stc
-#: modules/devices/x86/x86_data.c:288
+#: modules/devices/x86/x86_data.c:293
 msgctxt "x86-flag"
 msgid "software thermal control"
 msgstr "control terminco por software"
 
 #. /flag:pm:100mhzsteps
-#: modules/devices/x86/x86_data.c:289
+#: modules/devices/x86/x86_data.c:294
 msgctxt "x86-flag"
 msgid "100 MHz multiplier control"
 msgstr "control multiplicador 100MHz"
 
 #. /flag:pm:hwpstate
-#: modules/devices/x86/x86_data.c:290
+#: modules/devices/x86/x86_data.c:295
 msgctxt "x86-flag"
 msgid "hardware P-state control"
 msgstr "control hardware de P-state"
 
 #. /flag:pm:cpb
-#: modules/devices/x86/x86_data.c:291
+#: modules/devices/x86/x86_data.c:296
 msgctxt "x86-flag"
 msgid "core performance boost"
 msgstr "Impulso de rendimiento básico"
 
 #. /flag:pm:eff_freq_ro
-#: modules/devices/x86/x86_data.c:292
+#: modules/devices/x86/x86_data.c:297
 msgctxt "x86-flag"
 msgid "Readonly aperf/mperf"
 msgstr ""
 
 #. /flag:pm:proc_feedback
-#: modules/devices/x86/x86_data.c:293
+#: modules/devices/x86/x86_data.c:298
 msgctxt "x86-flag"
 msgid "processor feedback interface"
 msgstr "interfez de retroalimentacion de procesador"
 
 #. /flag:pm:acc_power
-#: modules/devices/x86/x86_data.c:294
+#: modules/devices/x86/x86_data.c:299
 msgctxt "x86-flag"
 msgid "accumulated power mechanism"
 msgstr "mecanismo de energia acumulada"
@@ -4131,7 +4402,7 @@ msgid "Shared Directories"
 msgstr "Directorios compartidos"
 
 #: modules/network.c:304 modules/network.c:326 modules/network.c:357
-#: modules/network/net.c:477
+#: modules/network/net.c:472
 msgid "IP Address"
 msgstr "Dirección IP"
 
@@ -4195,7 +4466,7 @@ msgstr "Destino/Puerta de enlace"
 msgid "Flags"
 msgstr "Marcas"
 
-#: modules/network.c:374 modules/network/net.c:478
+#: modules/network.c:374 modules/network/net.c:473
 msgid "Mask"
 msgstr "Máscara"
 
@@ -4365,100 +4636,163 @@ msgctxt "net-if-type"
 msgid "(Unknown)"
 msgstr "(desconocida)"
 
-#: modules/network/net.c:348 modules/network/net.c:358
+#: modules/network/net.c:343 modules/network/net.c:353
 msgid "Network Interfaces"
 msgstr "Interfaces de Red"
 
-#: modules/network/net.c:348
+#: modules/network/net.c:343
 msgid "None Found"
 msgstr "Ninguna encontrada"
 
-#: modules/network/net.c:400 modules/network/net.c:422
-#: modules/network/net.c:423
+#: modules/network/net.c:395 modules/network/net.c:417
+#: modules/network/net.c:418
 msgid "MiB"
 msgstr "MiB"
 
-#: modules/network/net.c:414
+#: modules/network/net.c:409
 msgid "Network Adapter Properties"
 msgstr "Propiedades de adaptador"
 
-#: modules/network/net.c:415
+#: modules/network/net.c:410
 msgid "Interface Type"
 msgstr "Tipo interfaz"
 
-#: modules/network/net.c:416
+#: modules/network/net.c:411
 msgid "Hardware Address (MAC)"
 msgstr "Direccion fisica"
 
-#: modules/network/net.c:420
+#: modules/network/net.c:415
 msgid "MTU"
 msgstr "MTU"
 
-#: modules/network/net.c:421
+#: modules/network/net.c:416
 msgid "Transfer Details"
 msgstr "Detalles de transferencias"
 
-#: modules/network/net.c:422
+#: modules/network/net.c:417
 msgid "Bytes Received"
 msgstr "Bytes Recividos"
 
-#: modules/network/net.c:423
+#: modules/network/net.c:418
 msgid "Bytes Sent"
 msgstr "Bytes Enviados"
 
-#: modules/network/net.c:440 modules/network/net.c:462
-#: modules/network/net.c:463
+#: modules/network/net.c:435 modules/network/net.c:457
+#: modules/network/net.c:458
 msgid "dBm"
 msgstr "dBm"
 
-#: modules/network/net.c:440
+#: modules/network/net.c:435
 msgid "mW"
 msgstr "mW"
 
-#: modules/network/net.c:454
+#: modules/network/net.c:449
 msgid "Wireless Properties"
 msgstr "Propiedades de Inalambrica"
 
-#: modules/network/net.c:455
+#: modules/network/net.c:450
 msgid "Network Name (SSID)"
 msgstr "Nombre de red (SSID)"
 
-#: modules/network/net.c:456
+#: modules/network/net.c:451
 msgid "Bit Rate"
 msgstr "Velocidad de bits"
 
-#: modules/network/net.c:456
+#: modules/network/net.c:451
 msgid "Mb/s"
 msgstr "Mb/s"
 
-#: modules/network/net.c:457
+#: modules/network/net.c:452
 msgid "Transmission Power"
 msgstr "Intensidad transmision"
 
-#: modules/network/net.c:459
+#: modules/network/net.c:454
 msgid "Status"
 msgstr "Estado"
 
-#: modules/network/net.c:460
+#: modules/network/net.c:455
 msgid "Link Quality"
 msgstr "Calidad enlace"
 
-#: modules/network/net.c:461
+#: modules/network/net.c:456
 msgid "Signal / Noise"
 msgstr "Señal / Ruido"
 
-#: modules/network/net.c:476
+#: modules/network/net.c:471
 msgid "Internet Protocol (IPv4)"
 msgstr "Protocolo Internet (IPv4)"
 
-#: modules/network/net.c:477 modules/network/net.c:478
-#: modules/network/net.c:480
+#: modules/network/net.c:472 modules/network/net.c:473
+#: modules/network/net.c:475
 msgid "(Not set)"
 msgstr "(sin asignar)"
 
-#: modules/network/net.c:479
+#: modules/network/net.c:474
 msgid "Broadcast Address"
 msgstr "Dirección de Difusión"
+
+#~ msgid "Unknown benchmark ``%s'' or libbenchmark.so not loaded"
+#~ msgstr "Benchmark desconocido ``%s'' o no se cargó libbenchmark.so"
+
+#~ msgid "%s Module"
+#~ msgstr "%s módulo"
+
+#~ msgid "X11 Vendor"
+#~ msgstr "Proveedor X11"
+
+#~ msgid "Monitors"
+#~ msgstr "Monitores"
+
+#~ msgid "OpenGL"
+#~ msgstr "OpenGL (3D)"
+
+#~ msgid "Extensions"
+#~ msgstr "Extensiones"
+
+#~ msgid "Monitor %d=%dx%d pixels\n"
+#~ msgstr "Monitor %d=%dx%d pixels\n"
+
+#~ msgid " (model unknown)"
+#~ msgstr " (modelo desconocido)"
+
+#~ msgid " (vendor unknown)"
+#~ msgstr " (proveedor desconocido)"
+
+#~ msgid "Latency"
+#~ msgstr "Latencia"
+
+#~ msgid "Bus Master"
+#~ msgstr "Bus Maestro"
+
+#~ msgid "Kernel modules"
+#~ msgstr "Modulos"
+
+#~ msgid "OEM Vendor"
+#~ msgstr "Vendedor OEM"
+
+#~ msgid "I/O ports at"
+#~ msgstr "Puertos I/O en"
+
+#~ msgid "Bus, device, function"
+#~ msgstr "Bus, dispositivo, funcion"
+
+#~ msgid "Unknown USB %.2f Device (class %d)"
+#~ msgstr "USB desconocido %.2f (class %d)"
+
+#~ msgid "Speed"
+#~ msgstr "Velocidad"
+
+#~ msgid "Vendor ID"
+#~ msgstr "ID Vendedor"
+
+#~ msgid "Product ID"
+#~ msgstr "ID Producto"
+
+#~ msgid "Port"
+#~ msgstr "Puerto"
+
+#~ msgid "Level"
+#~ msgstr "Nivel"
 
 #~ msgid "pixels"
 #~ msgstr "pixeles"

--- a/po/fr.po
+++ b/po/fr.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: hardinfo\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-08-14 22:23-0500\n"
+"POT-Creation-Date: 2018-06-09 14:09-0500\n"
 "PO-Revision-Date: 2014-09-03\n"
 "Last-Translator: yolateng0 @olala22000\n"
 "Language-Team: LeFlood\n"
@@ -18,8 +18,193 @@ msgstr ""
 "Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
 "X-Generator: Poedit 1.5.4\n"
 
+#: hardinfo/cpu_util.c:30
+msgid "Little Endian"
+msgstr ""
+
+#: hardinfo/cpu_util.c:32
+msgid "Big Endian"
+msgstr ""
+
+#: hardinfo/cpu_util.c:184 hardinfo/cpu_util.c:195
+msgid "Frequency Scaling"
+msgstr ""
+
+#: hardinfo/cpu_util.c:185
+msgid "Minimum"
+msgstr ""
+
+#: hardinfo/cpu_util.c:185 hardinfo/cpu_util.c:186 hardinfo/cpu_util.c:187
+msgid "kHz"
+msgstr ""
+
+#: hardinfo/cpu_util.c:186
+msgid "Maximum"
+msgstr ""
+
+#: hardinfo/cpu_util.c:187
+msgid "Current"
+msgstr ""
+
+#: hardinfo/cpu_util.c:188
+msgid "Transition Latency"
+msgstr ""
+
+#: hardinfo/cpu_util.c:188
+msgid "ns"
+msgstr ""
+
+#: hardinfo/cpu_util.c:189
+msgid "Governor"
+msgstr ""
+
+#: hardinfo/cpu_util.c:190 hardinfo/cpu_util.c:196 modules/devices/gpu.c:149
+#: modules/devices/pci.c:116
+msgid "Driver"
+msgstr ""
+
+#: hardinfo/cpu_util.c:202 modules/computer.c:596
+#: modules/devices/arm/processor.c:242 modules/devices/x86/processor.c:284
+#: modules/devices/x86/processor.c:388 modules/devices/x86/processor.c:524
+msgid "(Not Available)"
+msgstr ""
+
+#: hardinfo/cpu_util.c:210 hardinfo/cpu_util.c:212
+msgid "Socket"
+msgstr ""
+
+#: hardinfo/cpu_util.c:215 hardinfo/cpu_util.c:217
+msgid "Core"
+msgstr ""
+
+#: hardinfo/cpu_util.c:220
+msgid "Book"
+msgstr ""
+
+#: hardinfo/cpu_util.c:222
+msgid "Drawer"
+msgstr ""
+
+#: hardinfo/cpu_util.c:228 modules/devices/arm/processor.c:449
+#: modules/devices/x86/processor.c:697
+msgid "Topology"
+msgstr ""
+
+#: hardinfo/cpu_util.c:229
+msgid "ID"
+msgstr ""
+
+#: hardinfo/dmi_util.c:130
+msgid "Invalid chassis type (0)"
+msgstr ""
+
+#: hardinfo/dmi_util.c:131 hardinfo/dmi_util.c:132
+msgid "Unknown chassis type"
+msgstr ""
+
+#: hardinfo/dmi_util.c:133
+msgid "Desktop"
+msgstr ""
+
+#: hardinfo/dmi_util.c:134
+msgid "Low-profile Desktop"
+msgstr ""
+
+#: hardinfo/dmi_util.c:135
+msgid "Pizza Box"
+msgstr ""
+
+#: hardinfo/dmi_util.c:136
+msgid "Mini Tower"
+msgstr ""
+
+#: hardinfo/dmi_util.c:137
+msgid "Tower"
+msgstr ""
+
+#: hardinfo/dmi_util.c:138
+msgid "Portable"
+msgstr ""
+
+#: hardinfo/dmi_util.c:139 modules/computer.c:330 modules/computer.c:339
+#: modules/computer.c:361
+msgid "Laptop"
+msgstr ""
+
+#: hardinfo/dmi_util.c:140
+msgid "Notebook"
+msgstr ""
+
+#: hardinfo/dmi_util.c:141
+msgid "Handheld"
+msgstr ""
+
+#: hardinfo/dmi_util.c:142
+msgid "Docking Station"
+msgstr ""
+
+#: hardinfo/dmi_util.c:143
+msgid "All-in-one"
+msgstr ""
+
+#: hardinfo/dmi_util.c:144
+msgid "Subnotebook"
+msgstr ""
+
+#: hardinfo/dmi_util.c:145
+msgid "Space-saving"
+msgstr ""
+
+#: hardinfo/dmi_util.c:146
+msgid "Lunch Box"
+msgstr ""
+
+#: hardinfo/dmi_util.c:147
+msgid "Main Server Chassis"
+msgstr ""
+
+#: hardinfo/dmi_util.c:148
+msgid "Expansion Chassis"
+msgstr ""
+
+#: hardinfo/dmi_util.c:149
+msgid "Sub Chassis"
+msgstr ""
+
+#: hardinfo/dmi_util.c:150
+msgid "Bus Expansion Chassis"
+msgstr ""
+
+#: hardinfo/dmi_util.c:151
+msgid "Peripheral Chassis"
+msgstr ""
+
+#: hardinfo/dmi_util.c:152
+msgid "RAID Chassis"
+msgstr ""
+
+#: hardinfo/dmi_util.c:153
+msgid "Rack Mount Chassis"
+msgstr ""
+
+#: hardinfo/dmi_util.c:154
+msgid "Sealed-case PC"
+msgstr ""
+
+#: hardinfo/dt_util.c:1011
+msgid "phandle Map"
+msgstr ""
+
+#: hardinfo/dt_util.c:1012
+msgid "Alias Map"
+msgstr ""
+
+#: hardinfo/dt_util.c:1013
+msgid "Symbol Map"
+msgstr ""
+
 #. / %d will be latest year of copyright
-#: hardinfo/hardinfo.c:49
+#: hardinfo/hardinfo.c:50
 #, c-format
 msgid ""
 "Copyright (C) 2003-%d Leandro A. F. Pereira. See COPYING for details.\n"
@@ -28,7 +213,7 @@ msgstr ""
 "Copyright (C) 2003-%d Leandro A. F. Pereira. voir COPYING pour les details.\n"
 "\n"
 
-#: hardinfo/hardinfo.c:51
+#: hardinfo/hardinfo.c:52
 #, c-format
 msgid ""
 "Compile-time options:\n"
@@ -45,18 +230,16 @@ msgstr ""
 " Library prefix:    %s\n"
 " Compilation:       %s\n"
 
-#: hardinfo/hardinfo.c:57 hardinfo/hardinfo.c:58 modules/computer.c:605
-#: modules/devices/inputdevices.c:128 modules/devices/pci.c:112
-#: modules/devices/printers.c:138
+#: hardinfo/hardinfo.c:58 hardinfo/hardinfo.c:59 modules/computer.c:644
+#: modules/devices/inputdevices.c:128 modules/devices/printers.c:138
 msgid "Yes"
 msgstr "Oui"
 
-#: hardinfo/hardinfo.c:58 modules/computer.c:605 modules/devices/pci.c:112
-#: modules/devices/printers.c:138
+#: hardinfo/hardinfo.c:59 modules/computer.c:644 modules/devices/printers.c:138
 msgid "No"
 msgstr "Non"
 
-#: hardinfo/hardinfo.c:69
+#: hardinfo/hardinfo.c:70
 #, c-format
 msgid ""
 "Failed to find runtime data.\n"
@@ -69,56 +252,58 @@ msgstr ""
 "• Est ce que HardInfo est correctement installé?\n"
 "• Voir si %s et %s existes et que vous avez bien les privilèges."
 
-#: hardinfo/hardinfo.c:76
+#: hardinfo/hardinfo.c:77
 #, c-format
 msgid ""
 "Modules:\n"
 "%-20s %-15s %-12s\n"
 msgstr ""
 
-#: hardinfo/hardinfo.c:77
+#: hardinfo/hardinfo.c:78
 msgid "File Name"
 msgstr "Nom du fichier"
 
-#: hardinfo/hardinfo.c:77 modules/computer.c:534 modules/computer.c:562
-#: modules/computer.c:630 modules/computer/languages.c:104
-#: modules/computer/modules.c:146 modules/devices/arm/processor.c:336
+#: hardinfo/hardinfo.c:78 modules/computer.c:528 modules/computer.c:556
+#: modules/computer.c:674 modules/computer/languages.c:104
+#: modules/computer/modules.c:146 modules/devices/arm/processor.c:447
+#: modules/devices/dmi.c:37 modules/devices/dmi.c:46
 #: modules/devices/ia64/processor.c:160 modules/devices/inputdevices.c:116
-#: modules/devices/pci.c:215 modules/devices/sh/processor.c:84
-#: modules/devices/x86/processor.c:455 modules/network.c:326
+#: modules/devices/sh/processor.c:84 modules/devices/x86/processor.c:696
+#: modules/network.c:326
 msgid "Name"
 msgstr "Nom"
 
-#: hardinfo/hardinfo.c:77 modules/computer.c:296 modules/computer.c:505
-#: modules/computer.c:507 modules/computer.c:595 modules/computer.c:603
+#: hardinfo/hardinfo.c:78 modules/computer.c:304 modules/computer.c:499
+#: modules/computer.c:501 modules/computer.c:602 modules/devices/dmi.c:40
+#: modules/devices/dmi.c:44 modules/devices/dmi.c:48 modules/devices/dmi.c:54
 #: modules/devices/inputdevices.c:121
 msgid "Version"
 msgstr "Version"
 
-#: hardinfo/hardinfo.c:124
+#: hardinfo/hardinfo.c:125
 #, c-format
-msgid "Unknown benchmark ``%s'' or libbenchmark.so not loaded"
-msgstr "Benchmark inconnu ``%s'' ou libbenchmark.so non chargé"
+msgid "Unknown benchmark ``%s'' or benchmark.so not loaded"
+msgstr ""
 
-#: hardinfo/hardinfo.c:152
+#: hardinfo/hardinfo.c:155
 msgid "Don't know what to do. Exiting."
 msgstr "Que faire. Sortie."
 
-#: hardinfo/util.c:104 modules/computer/uptime.c:53
+#: hardinfo/util.c:104 modules/computer/uptime.c:54
 #, c-format
 msgid "%d day"
 msgid_plural "%d days"
 msgstr[0] "%d jour"
 msgstr[1] "%d jours"
 
-#: hardinfo/util.c:105 modules/computer/uptime.c:54
+#: hardinfo/util.c:105 modules/computer/uptime.c:55
 #, c-format
 msgid "%d hour"
 msgid_plural "%d hours"
 msgstr[0] "%d heure"
 msgstr[1] "%d heures"
 
-#: hardinfo/util.c:106 modules/computer/uptime.c:55
+#: hardinfo/util.c:106 modules/computer/uptime.c:56
 #, c-format
 msgid "%d minute"
 msgid_plural "%d minutes"
@@ -174,43 +359,51 @@ msgstr "Attention"
 msgid "Fatal Error"
 msgstr "Erreur Fatale"
 
-#: hardinfo/util.c:401
+#: hardinfo/util.c:403
 msgid "creates a report and prints to standard output"
 msgstr "crée un rapport et imprime sur la sortie standard"
 
-#: hardinfo/util.c:407
+#: hardinfo/util.c:409
 msgid "chooses a report format (text, html)"
 msgstr "choisir un format de rapport (texte, html)"
 
-#: hardinfo/util.c:413
+#: hardinfo/util.c:415
 msgid "run benchmark; requires benchmark.so to be loaded"
 msgstr "Envoyé le benchmark; nécessite benchmark.so"
 
-#: hardinfo/util.c:419
+#: hardinfo/util.c:421
+msgid "benchmark result format ([short], conf, shell)"
+msgstr ""
+
+#: hardinfo/util.c:427
 msgid "lists modules"
 msgstr "Listes des modules"
 
-#: hardinfo/util.c:425
+#: hardinfo/util.c:433
 msgid "specify module to load"
 msgstr "spécifie les modules à charger"
 
-#: hardinfo/util.c:431
+#: hardinfo/util.c:439
 msgid "automatically load module dependencies"
 msgstr "charger automatiquement les dépendances entre modules"
 
-#: hardinfo/util.c:438
+#: hardinfo/util.c:446
 msgid "run in XML-RPC server mode"
 msgstr "fonctionner en mode serveur XML-RPC"
 
-#: hardinfo/util.c:445
+#: hardinfo/util.c:453
 msgid "shows program version and quit"
 msgstr "Affiche la version du programme et quitter"
 
-#: hardinfo/util.c:450
+#: hardinfo/util.c:459
+msgid "do not run benchmarks"
+msgstr ""
+
+#: hardinfo/util.c:464
 msgid "- System Profiler and Benchmark tool"
 msgstr "- Profil du Systeme et outil d'évaluation Benchmark"
 
-#: hardinfo/util.c:460
+#: hardinfo/util.c:474
 #, c-format
 msgid ""
 "Unrecognized arguments.\n"
@@ -219,29 +412,29 @@ msgstr ""
 "commandes inconnues.\n"
 "taper ``%s --help'' pour plus d'informations.\n"
 
-#: hardinfo/util.c:526
+#: hardinfo/util.c:542
 #, c-format
 msgid "Couldn't find a Web browser to open URL %s."
 msgstr "Impossible de trouver un navigateur Web pour ouvrir l'URL %s."
 
-#: hardinfo/util.c:875
+#: hardinfo/util.c:891
 #, c-format
 msgid "Module \"%s\" depends on module \"%s\", load it?"
 msgstr "Module \"%s\" depends du module \"%s\", le charger?"
 
-#: hardinfo/util.c:898
+#: hardinfo/util.c:914
 #, c-format
 msgid "Module \"%s\" depends on module \"%s\"."
 msgstr "Module \"%s\" depends du module \"%s\"."
 
-#: hardinfo/util.c:943
+#: hardinfo/util.c:959
 #, c-format
 msgid "No module could be loaded. Check permissions on \"%s\" and try again."
 msgstr ""
 "Aucun module peut être chargé. Vérifiez les permissions sur \"%s\" et "
 "essayez à nouveau."
 
-#: hardinfo/util.c:947
+#: hardinfo/util.c:963
 msgid ""
 "No module could be loaded. Please use hardinfo -l to list all available "
 "modules and try again with a valid module list."
@@ -250,20 +443,15 @@ msgstr ""
 "répertorier tous les modules disponibles et essayez à nouveau avec une liste "
 "de modules valides."
 
-#: hardinfo/util.c:1024
+#: hardinfo/util.c:1040
 #, c-format
 msgid "Scanning: %s..."
 msgstr "Scanne: %s..."
 
-#: hardinfo/util.c:1034 shell/shell.c:301 shell/shell.c:760 shell/shell.c:1795
-#: modules/benchmark.c:449 modules/benchmark.c:457
+#: hardinfo/util.c:1050 shell/shell.c:301 shell/shell.c:772 shell/shell.c:1850
+#: modules/benchmark.c:549 modules/benchmark.c:557
 msgid "Done."
 msgstr "Réalisé."
-
-#: shell/callbacks.c:117
-#, c-format
-msgid "%s Module"
-msgstr "%s Module"
 
 #: shell/callbacks.c:128
 #, c-format
@@ -443,35 +631,51 @@ msgstr "Basculer visibilité du panneau latéral "
 msgid "_Toolbar"
 msgstr "_Barre d'outils"
 
-#: shell/report.c:494 shell/report.c:502
+#: shell/report.c:500 shell/report.c:508
 msgid "Save File"
 msgstr "Sauvegarder le fichier"
 
-#: shell/report.c:629
+#: shell/report.c:503 shell/report.c:935 shell/syncmanager.c:748
+msgid "_Cancel"
+msgstr ""
+
+#: shell/report.c:505
+msgid "_Save"
+msgstr ""
+
+#: shell/report.c:635
 msgid "Cannot create ReportContext. Programming bug?"
 msgstr "Impossible de créer un rapport général. Bug?"
 
-#: shell/report.c:648
+#: shell/report.c:654
 msgid "Open the report with your web browser?"
 msgstr "Ouvrez le rapport avec votre navigateur Web?"
 
-#: shell/report.c:682
+#: shell/report.c:657
+msgid "_No"
+msgstr ""
+
+#: shell/report.c:658
+msgid "_Open"
+msgstr ""
+
+#: shell/report.c:688
 msgid "Generating report..."
 msgstr "Création du rapport..."
 
-#: shell/report.c:692
+#: shell/report.c:698
 msgid "Report saved."
 msgstr "Rapport sauvegardé"
 
-#: shell/report.c:694
+#: shell/report.c:700
 msgid "Error while creating the report."
 msgstr "Erreur lors de la création du rapport."
 
-#: shell/report.c:796
+#: shell/report.c:802
 msgid "Generate Report"
 msgstr "Réalisation du Rapport"
 
-#: shell/report.c:821
+#: shell/report.c:827
 msgid ""
 "<big><b>Generate Report</b></big>\n"
 "Please choose the information that you wish to view in your report:"
@@ -480,19 +684,15 @@ msgstr ""
 " S'il vous plaît choisissez les informations que vous souhaitez afficher "
 "dans votre rapport:"
 
-#: shell/report.c:893
+#: shell/report.c:899
 msgid "Select _None"
 msgstr "Désélectionner _Tout"
 
-#: shell/report.c:904
+#: shell/report.c:910
 msgid "Select _All"
 msgstr "Sélectionner _Tout"
 
-#: shell/report.c:929 shell/syncmanager.c:748
-msgid "_Cancel"
-msgstr ""
-
-#: shell/report.c:939
+#: shell/report.c:945
 msgid "_Generate"
 msgstr "_Création"
 
@@ -505,16 +705,16 @@ msgstr "%s - Informations du Système"
 msgid "System Information"
 msgstr "Informations du Système"
 
-#: shell/shell.c:747
+#: shell/shell.c:759
 msgid "Loading modules..."
 msgstr "Chargement des modules..."
 
-#: shell/shell.c:1660
+#: shell/shell.c:1715
 #, c-format
 msgid "<b>%s → Summary</b>"
 msgstr "<b>%s → Résumé</b>"
 
-#: shell/shell.c:1769
+#: shell/shell.c:1824
 msgid "Updating..."
 msgstr "Mise à jour..."
 
@@ -607,95 +807,219 @@ msgstr "Mises à jour"
 msgid "_Synchronize"
 msgstr "_Synchronisation"
 
-#: modules/benchmark.c:52
+#: modules/benchmark/benches.c:74
 msgid "CPU Blowfish"
 msgstr "Test CPU Blowfish"
 
-#: modules/benchmark.c:53
+#: modules/benchmark/benches.c:75
 msgid "CPU CryptoHash"
 msgstr "Test CPU CryptoHash"
 
-#: modules/benchmark.c:54
+#: modules/benchmark/benches.c:76
 msgid "CPU Fibonacci"
 msgstr "Test CPU Fibonacci "
 
-#: modules/benchmark.c:55
+#: modules/benchmark/benches.c:77
 msgid "CPU N-Queens"
 msgstr "Test CPU N-Queens"
 
-#: modules/benchmark.c:56
+#: modules/benchmark/benches.c:78
 msgid "CPU Zlib"
 msgstr ""
 
-#: modules/benchmark.c:57
+#: modules/benchmark/benches.c:79
 msgid "FPU FFT"
 msgstr "Test FPU FFT"
 
-#: modules/benchmark.c:58
+#: modules/benchmark/benches.c:80
 msgid "FPU Raytracing"
 msgstr "Test FPU Raytracing"
 
-#: modules/benchmark.c:60
+#: modules/benchmark/benches.c:82
 msgid "GPU Drawing"
 msgstr "Test GPU Drawing"
 
-#: modules/benchmark.c:239 modules/benchmark.c:255
+#: modules/benchmark/benches.c:91
+msgid "Results in MiB/second. Higher is better."
+msgstr "Résultats en MiB/seconde. Plus c'est élevé meilleur c'est."
+
+#: modules/benchmark/benches.c:95
+msgid "Results in HIMarks. Higher is better."
+msgstr "Résultats en HIMarks. Plus c'est élevé meilleur c'est."
+
+#: modules/benchmark/benches.c:102
+msgid "Results in seconds. Lower is better."
+msgstr "Résultats en secondes. Plus c'est bas meilleur c'est."
+
+#. /or modify
+#. *    it under the terms of the GNU General Public License as published by
+#. *    the Free Software Foundation, version 2.
+#. *
+#. *    This program is distributed in the hope that it will be useful,
+#. *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#. *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#. *    GNU General Public License for more details.
+#. *
+#. *    You should have received a copy of the GNU General Public License
+#. *    along with this program; if not, write to the Free Software
+#. *    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+#.
+#. / Used for an unknown value. Having it in only one place cleans up the .po line references
+#: modules/benchmark/bench_results.c:22 modules/computer.c:41
+#: modules/computer/display.c:41 modules/computer/os.c:279
+#: modules/devices.c:383 modules/devices/gpu.c:42 modules/devices/gpu.c:58
+#: modules/devices/gpu.c:150 modules/devices/gpu.c:151 modules/devices/pci.c:25
+#: modules/devices/pci.c:117 modules/devices/pci.c:118 modules/devices/usb.c:27
+#: modules/network/net.c:437 includes/cpu_util.h:11
+msgid "(Unknown)"
+msgstr ""
+
+#: modules/benchmark/bench_results.c:47 modules/benchmark/bench_results.c:322
+#: modules/devices/alpha/processor.c:90 modules/devices/arm/processor.c:276
+#: modules/devices/arm/processor.c:289 modules/devices/arm/processor.c:331
+#: modules/devices/arm/processor.c:478 modules/devices.c:310
+#: modules/devices.c:318 modules/devices.c:346
+#: modules/devices/ia64/processor.c:167 modules/devices/ia64/processor.c:196
+#: modules/devices/m68k/processor.c:87 modules/devices/mips/processor.c:77
+#: modules/devices/parisc/processor.c:158
+#: modules/devices/parisc/processor.c:191 modules/devices/ppc/processor.c:160
+#: modules/devices/ppc/processor.c:187 modules/devices/riscv/processor.c:186
+#: modules/devices/riscv/processor.c:214 modules/devices/s390/processor.c:160
+#: modules/devices/sh/processor.c:87 modules/devices/sh/processor.c:88
+#: modules/devices/sh/processor.c:89 modules/devices/x86/processor.c:318
+#: modules/devices/x86/processor.c:331 modules/devices/x86/processor.c:655
+#: modules/devices/x86/processor.c:726
+msgid "MHz"
+msgstr ""
+
+#: modules/benchmark/bench_results.c:374 modules/benchmark/bench_results.c:441
+msgid "kiB"
+msgstr ""
+
+#: modules/benchmark/bench_results.c:389 modules/benchmark/bench_results.c:426
+msgid "Benchmark Result"
+msgstr ""
+
+#: modules/benchmark/bench_results.c:390 modules/benchmark/bench_results.c:428
+msgid "Threads"
+msgstr ""
+
+#: modules/benchmark/bench_results.c:391 modules/benchmark/bench_results.c:431
+msgid "Note"
+msgstr ""
+
+#: modules/benchmark/bench_results.c:392 modules/benchmark/bench_results.c:432
+msgid ""
+"This result is from an old version of HardInfo. Results might not be "
+"comparable to current version. Some details are missing."
+msgstr ""
+
+#: modules/benchmark/bench_results.c:393 modules/benchmark/bench_results.c:433
+#: modules/devices/devicetree/pmac_data.c:81 modules/devices/sh/processor.c:85
+msgid "Machine"
+msgstr ""
+
+#: modules/benchmark/bench_results.c:394 modules/benchmark/bench_results.c:434
+#: modules/devices/devicetree.c:206 modules/devices/dmi.c:45
+msgid "Board"
+msgstr ""
+
+#: modules/benchmark/bench_results.c:395 modules/benchmark/bench_results.c:435
+msgid "CPU Name"
+msgstr ""
+
+#: modules/benchmark/bench_results.c:396 modules/benchmark/bench_results.c:436
+msgid "CPU Description"
+msgstr ""
+
+#: modules/benchmark/bench_results.c:397 modules/benchmark/bench_results.c:437
+#: modules/benchmark.c:390
 msgid "CPU Config"
 msgstr ""
 
-#: modules/benchmark.c:239 modules/benchmark.c:255
+#: modules/benchmark/bench_results.c:398 modules/benchmark/bench_results.c:438
+msgid "Threads Available"
+msgstr ""
+
+#: modules/benchmark/bench_results.c:399 modules/benchmark/bench_results.c:439
+msgid "GPU"
+msgstr ""
+
+#: modules/benchmark/bench_results.c:400 modules/benchmark/bench_results.c:440
+#: modules/computer.c:479
+msgid "OpenGL Renderer"
+msgstr ""
+
+#: modules/benchmark/bench_results.c:401 modules/benchmark/bench_results.c:441
+#: modules/computer.c:110 modules/computer.c:468 modules/devices.c:99
+msgid "Memory"
+msgstr "Mémoire"
+
+#: modules/benchmark/bench_results.c:427
+msgid "Benchmark"
+msgstr ""
+
+#: modules/benchmark/bench_results.c:429
+msgid "Result"
+msgstr ""
+
+#: modules/benchmark/bench_results.c:430
+msgid "Elapsed Time"
+msgstr ""
+
+#: modules/benchmark/bench_results.c:442
+msgid "Handles"
+msgstr ""
+
+#: modules/benchmark/bench_results.c:443
+msgid "mid"
+msgstr ""
+
+#: modules/benchmark/bench_results.c:444
+msgid "cfg_val"
+msgstr ""
+
+#: modules/benchmark.c:390
 msgid "Results"
 msgstr ""
 
-#: modules/benchmark.c:239 modules/benchmark.c:255 modules/computer.c:751
+#: modules/benchmark.c:390 modules/computer.c:811
 #: modules/devices/sparc/processor.c:75
 msgid "CPU"
 msgstr ""
 
-#: modules/benchmark.c:381
+#: modules/benchmark.c:460
 #, c-format
 msgid "Benchmarking: <b>%s</b>."
 msgstr "Benchmarking: <b>%s</b>."
 
-#: modules/benchmark.c:395
+#: modules/benchmark.c:479 modules/benchmark.c:498
+msgid "Cancel"
+msgstr "Annuler"
+
+#: modules/benchmark.c:483 modules/benchmark.c:495
 msgid "Benchmarking. Please do not move your mouse or press any keys."
 msgstr ""
 "Benchmarking. S'il vous plaît ne pas déplacer votre souris ou appuyer sur "
 "les touches"
 
-#: modules/benchmark.c:399
-msgid "Cancel"
-msgstr "Annuler"
-
-#: modules/benchmark.c:536
-msgid "Results in MiB/second. Higher is better."
-msgstr "Résultats en MiB/seconde. Plus c'est élevé meilleur c'est."
-
-#: modules/benchmark.c:540
-msgid "Results in HIMarks. Higher is better."
-msgstr "Résultats en HIMarks. Plus c'est élevé meilleur c'est."
-
-#: modules/benchmark.c:547
-msgid "Results in seconds. Lower is better."
-msgstr "Résultats en secondes. Plus c'est bas meilleur c'est."
-
-#: modules/benchmark.c:555
+#: modules/benchmark.c:567
 msgid "Benchmarks"
 msgstr "Benchmarks"
 
-#: modules/benchmark.c:573
+#: modules/benchmark.c:585
 msgid "Perform tasks and compare with other systems"
 msgstr "Effectuer des tâches et les comparer avec d'autres systèmes"
 
-#: modules/benchmark.c:663
+#: modules/benchmark.c:692
 msgid "Send benchmark results"
 msgstr "Envoyer vos résultats de référence"
 
-#: modules/benchmark.c:668
+#: modules/benchmark.c:697
 msgid "Receive benchmark results"
 msgstr "Recevoir les résultats de benchmark"
 
-#: modules/computer/alsa.c:26 modules/computer.c:489
+#: modules/computer/alsa.c:26 modules/computer.c:483
 msgid "Audio Devices"
 msgstr ""
 
@@ -703,501 +1027,501 @@ msgstr ""
 msgid "Audio Adapter"
 msgstr "Adapteur Audio"
 
-#: modules/computer/boots.c:33 modules/computer.c:73 modules/computer.c:546
-msgid "Boots"
-msgstr "Boots"
-
-#: modules/computer.c:70
+#: modules/computer.c:76
 msgid "Summary"
 msgstr "Résumé"
 
-#: modules/computer.c:71 modules/computer.c:476 modules/computer.c:750
+#: modules/computer.c:77 modules/computer.c:471 modules/computer.c:810
 msgid "Operating System"
 msgstr "Systeme d'exploitation"
 
-#: modules/computer.c:72
+#: modules/computer.c:78 modules/devices/gpu.c:151 modules/devices/pci.c:118
 msgid "Kernel Modules"
 msgstr "Modules du kernel"
 
-#: modules/computer.c:74
+#: modules/computer.c:79 modules/computer.c:540
+msgid "Boots"
+msgstr "Boots"
+
+#: modules/computer.c:80
 msgid "Languages"
 msgstr "Langues"
 
-#: modules/computer.c:75
+#: modules/computer.c:81
 msgid "Filesystems"
 msgstr "Fichiers Systeme"
 
-#: modules/computer.c:76 modules/computer.c:481 modules/computer.c:590
+#: modules/computer.c:82 modules/computer.c:476
 msgid "Display"
 msgstr "Affichage"
 
-#: modules/computer.c:77 modules/computer/environment.c:32
+#: modules/computer.c:83 modules/computer/environment.c:32
 msgid "Environment Variables"
 msgstr "Variables d'environnement"
 
-#: modules/computer.c:79
+#: modules/computer.c:85
 msgid "Development"
 msgstr "Developpement"
 
-#: modules/computer.c:81 modules/computer.c:617
+#: modules/computer.c:87 modules/computer.c:661
 msgid "Users"
 msgstr "Utilisateurs"
 
-#: modules/computer.c:82
+#: modules/computer.c:88
 msgid "Groups"
 msgstr "Groupes"
 
-#: modules/computer.c:104 modules/computer.c:473 modules/devices.c:96
-#: modules/devices/pci.c:149
-msgid "Memory"
-msgstr "Mémoire"
-
-#: modules/computer.c:106
+#: modules/computer.c:112
 #, c-format
 msgid "%dMB (%dMB used)"
 msgstr "%dMB (%dMB utilisé)"
 
-#: modules/computer.c:108 modules/computer.c:520
+#: modules/computer.c:114 modules/computer.c:514
 msgid "Uptime"
 msgstr "durée de fonctionnent"
 
-#: modules/computer.c:110 modules/computer.c:478
+#: modules/computer.c:116 modules/computer.c:473
 msgid "Date/Time"
 msgstr "Date/Heure"
 
-#: modules/computer.c:115 modules/computer.c:521
+#: modules/computer.c:121 modules/computer.c:515
 msgid "Load Average"
 msgstr ""
 
-#: modules/computer.c:117 modules/computer.c:522
+#: modules/computer.c:123 modules/computer.c:516
 msgid "Available entropy in /dev/random"
 msgstr ""
 
-#: modules/computer.c:203
+#: modules/computer.c:211
 msgid "Scripting Languages"
 msgstr "Type de script"
 
-#: modules/computer.c:204
+#: modules/computer.c:212
 msgid "Gambas3 (gbr3)"
 msgstr ""
 
-#: modules/computer.c:205
+#: modules/computer.c:213
 msgid "Python"
 msgstr ""
 
-#: modules/computer.c:206
+#: modules/computer.c:214
 msgid "Python2"
 msgstr ""
 
-#: modules/computer.c:207
+#: modules/computer.c:215
 msgid "Python3"
 msgstr ""
 
-#: modules/computer.c:208
+#: modules/computer.c:216
 msgid "Perl"
 msgstr "Perl"
 
-#: modules/computer.c:209
+#: modules/computer.c:217
 msgid "Perl6 (VM)"
 msgstr ""
 
-#: modules/computer.c:210
+#: modules/computer.c:218
 msgid "Perl6"
 msgstr ""
 
-#: modules/computer.c:211
+#: modules/computer.c:219
 msgid "PHP"
 msgstr "PHP"
 
-#: modules/computer.c:212
+#: modules/computer.c:220
 msgid "Ruby"
 msgstr "Ruby"
 
-#: modules/computer.c:213
+#: modules/computer.c:221
 msgid "Bash"
 msgstr "Bash"
 
-#: modules/computer.c:214
+#: modules/computer.c:222
 msgid "Compilers"
 msgstr "Compilateurs"
 
-#: modules/computer.c:215
+#: modules/computer.c:223
 msgid "C (GCC)"
 msgstr "C (GCC)"
 
-#: modules/computer.c:216
+#: modules/computer.c:224
 msgid "C (Clang)"
 msgstr ""
 
-#: modules/computer.c:217
+#: modules/computer.c:225
 msgid "D (dmd)"
 msgstr ""
 
-#: modules/computer.c:218
+#: modules/computer.c:226
 msgid "Gambas3 (gbc3)"
 msgstr ""
 
-#: modules/computer.c:219
+#: modules/computer.c:227
 msgid "Java"
 msgstr "Java"
 
-#: modules/computer.c:220
+#: modules/computer.c:228
 msgid "CSharp (Mono, old)"
 msgstr "CSharp (Mono, old)"
 
-#: modules/computer.c:221
+#: modules/computer.c:229
 msgid "CSharp (Mono)"
 msgstr "CSharp (Mono)"
 
-#: modules/computer.c:222
+#: modules/computer.c:230
 msgid "Vala"
 msgstr "Vala"
 
-#: modules/computer.c:223
+#: modules/computer.c:231
 msgid "Haskell (GHC)"
 msgstr "Haskell (GHC)"
 
-#: modules/computer.c:224
+#: modules/computer.c:232
 msgid "FreePascal"
 msgstr "FreePascal"
 
-#: modules/computer.c:225
+#: modules/computer.c:233
 msgid "Go"
 msgstr ""
 
-#: modules/computer.c:226
+#: modules/computer.c:234
 msgid "Tools"
 msgstr "Outils"
 
-#: modules/computer.c:227
+#: modules/computer.c:235
 msgid "make"
 msgstr ""
 
-#: modules/computer.c:228
+#: modules/computer.c:236
 msgid "GDB"
 msgstr ""
 
-#: modules/computer.c:229
+#: modules/computer.c:237
 msgid "strace"
 msgstr ""
 
-#: modules/computer.c:230
+#: modules/computer.c:238
 msgid "valgrind"
 msgstr ""
 
-#: modules/computer.c:231
+#: modules/computer.c:239
 msgid "QMake"
 msgstr ""
 
-#: modules/computer.c:232
+#: modules/computer.c:240
 msgid "CMake"
 msgstr ""
 
-#: modules/computer.c:233
+#: modules/computer.c:241
 msgid "Gambas3 IDE"
 msgstr ""
 
-#: modules/computer.c:274
+#: modules/computer.c:282
 msgid "Not found"
 msgstr "Non trouvé"
 
-#: modules/computer.c:279
+#: modules/computer.c:287
 #, c-format
 msgid "Detecting version: %s"
 msgstr "Version détectée: %s"
 
-#: modules/computer.c:296
+#: modules/computer.c:304
 msgid "Program"
 msgstr "Programme"
 
-#: modules/computer.c:308
-msgid "Invalid chassis type (0)"
-msgstr ""
-
-#: modules/computer.c:309 modules/computer.c:310
-msgid "Unknown chassis type"
-msgstr ""
-
-#: modules/computer.c:311
-msgid "Desktop"
-msgstr ""
-
-#: modules/computer.c:312
-msgid "Low-profile Desktop"
-msgstr ""
-
-#: modules/computer.c:313
-msgid "Pizza Box"
-msgstr ""
-
-#: modules/computer.c:314
-msgid "Mini Tower"
-msgstr ""
-
-#: modules/computer.c:315
-msgid "Tower"
-msgstr ""
-
-#: modules/computer.c:316
-msgid "Portable"
-msgstr ""
-
-#: modules/computer.c:317 modules/computer.c:341 modules/computer.c:350
-#: modules/computer.c:372
-msgid "Laptop"
-msgstr ""
-
-#: modules/computer.c:318
-msgid "Notebook"
-msgstr ""
-
-#: modules/computer.c:319
-msgid "Handheld"
-msgstr ""
-
-#: modules/computer.c:320
-msgid "Docking Station"
-msgstr ""
-
-#: modules/computer.c:321
-msgid "All-in-one"
-msgstr ""
-
-#: modules/computer.c:322
-msgid "Subnotebook"
-msgstr ""
-
-#: modules/computer.c:323
-msgid "Space-saving"
-msgstr ""
-
 #: modules/computer.c:324
-msgid "Lunch Box"
-msgstr ""
-
-#: modules/computer.c:325
-msgid "Main Server Chassis"
-msgstr ""
-
-#: modules/computer.c:326
-msgid "Expansion Chassis"
-msgstr ""
-
-#: modules/computer.c:327
-msgid "Sub Chassis"
-msgstr ""
-
-#: modules/computer.c:328
-msgid "Bus Expansion Chassis"
-msgstr ""
-
-#: modules/computer.c:329
-msgid "Peripheral Chassis"
-msgstr ""
-
-#: modules/computer.c:330
-msgid "RAID Chassis"
-msgstr ""
-
-#: modules/computer.c:331
-msgid "Rack Mount Chassis"
-msgstr ""
-
-#: modules/computer.c:332
-msgid "Sealed-case PC"
+msgid "Single-board computer"
 msgstr ""
 
 #. /proc/apm
-#. FIXME: use dmidecode if available to get chassis type
-#: modules/computer.c:386
+#: modules/computer.c:373
 msgid "Unknown physical machine type"
 msgstr ""
 
-#: modules/computer.c:470 modules/computer.c:709
+#: modules/computer.c:393 modules/computer.c:394
+msgid "Virtual (VMware)"
+msgstr ""
+
+#: modules/computer.c:396 modules/computer.c:397 modules/computer.c:398
+#: modules/computer.c:399
+msgid "Virtual (QEMU)"
+msgstr ""
+
+#: modules/computer.c:401 modules/computer.c:402
+msgid "Virtual (Unknown)"
+msgstr ""
+
+#: modules/computer.c:404 modules/computer.c:405 modules/computer.c:406
+#: modules/computer.c:427
+msgid "Virtual (VirtualBox)"
+msgstr ""
+
+#: modules/computer.c:408 modules/computer.c:409 modules/computer.c:410
+#: modules/computer.c:421
+msgid "Virtual (Xen)"
+msgstr ""
+
+#: modules/computer.c:412
+msgid "Virtual (hypervisor present)"
+msgstr ""
+
+#: modules/computer.c:465 modules/computer.c:769
 msgid "Computer"
 msgstr "Ordinateur"
 
-#: modules/computer.c:471 modules/devices/alpha/processor.c:87
-#: modules/devices/arm/processor.c:236 modules/devices.c:95
+#: modules/computer.c:466 modules/devices/alpha/processor.c:87
+#: modules/devices/arm/processor.c:327 modules/devices.c:98
 #: modules/devices/ia64/processor.c:159 modules/devices/m68k/processor.c:83
 #: modules/devices/mips/processor.c:74 modules/devices/parisc/processor.c:154
 #: modules/devices/ppc/processor.c:157 modules/devices/riscv/processor.c:181
 #: modules/devices/s390/processor.c:131 modules/devices/sh/processor.c:83
-#: modules/devices/sparc/processor.c:74 modules/devices/x86/processor.c:409
+#: modules/devices/sparc/processor.c:74 modules/devices/x86/processor.c:644
 msgid "Processor"
 msgstr "Processeur"
 
-#: modules/computer.c:474
+#: modules/computer.c:469
 msgid "Machine Type"
 msgstr ""
 
-#: modules/computer.c:477 modules/computer.c:514
+#: modules/computer.c:472 modules/computer.c:508
 msgid "User Name"
 msgstr "Utilisateur"
 
-#: modules/computer.c:482 modules/computer.c:591
+#: modules/computer.c:477
 msgid "Resolution"
 msgstr "Résolution"
 
-#: modules/computer.c:483 modules/computer.c:592
+#: modules/computer.c:477 modules/computer.c:607
 #, c-format
 msgid "%dx%d pixels"
 msgstr ""
 
-#: modules/computer.c:485
-msgid "OpenGL Renderer"
+#: modules/computer.c:480
+msgid "Session Display Server"
 msgstr ""
 
-#: modules/computer.c:486
-msgid "X11 Vendor"
-msgstr ""
-
-#: modules/computer.c:491 modules/devices.c:102
+#: modules/computer.c:485 modules/devices.c:106
 msgid "Input Devices"
 msgstr "Périphériques d'entrée"
 
-#: modules/computer.c:493 modules/computer.c:752 modules/devices.c:99
-msgid "Printers"
-msgstr "Imprimantes"
-
-#: modules/computer.c:495 modules/computer.c:752 modules/devices.c:103
-msgid "Storage"
-msgstr "Stockage"
-
-#: modules/computer.c:506
+#: modules/computer.c:500
 msgid "Kernel"
 msgstr ""
 
-#: modules/computer.c:508
+#: modules/computer.c:502
 msgid "C Library"
 msgstr ""
 
-#: modules/computer.c:509
+#: modules/computer.c:503
 msgid "Distribution"
 msgstr ""
 
-#: modules/computer.c:512
+#: modules/computer.c:506
 msgid "Current Session"
 msgstr ""
 
-#: modules/computer.c:513
+#: modules/computer.c:507
 msgid "Computer Name"
 msgstr "Ordinateur"
 
-#: modules/computer.c:515 modules/computer/languages.c:108
+#: modules/computer.c:509 modules/computer/languages.c:108
 msgid "Language"
 msgstr ""
 
-#: modules/computer.c:516 modules/computer/users.c:50
+#: modules/computer.c:510 modules/computer/users.c:50
 msgid "Home Directory"
 msgstr "Dossier Home"
 
-#: modules/computer.c:519 modules/devices/usb.c:87 modules/devices/usb.c:234
-#: modules/devices/usb.c:351
+#: modules/computer.c:513
 msgid "Misc"
 msgstr ""
 
-#: modules/computer.c:532
+#: modules/computer.c:526
 msgid "Loaded Modules"
 msgstr ""
 
-#: modules/computer.c:535 modules/computer/modules.c:145
-#: modules/computer/modules.c:147 modules/devices/arm/processor.c:337
-#: modules/devices.c:559 modules/devices/x86/processor.c:456
+#: modules/computer.c:529 modules/computer/modules.c:145
+#: modules/computer/modules.c:147 modules/devices/arm/processor.c:448
+#: modules/devices.c:575
 msgid "Description"
 msgstr ""
 
-#: modules/computer.c:548
+#: modules/computer.c:542
 msgid "Date & Time"
 msgstr ""
 
-#: modules/computer.c:549
+#: modules/computer.c:543
 msgid "Kernel Version"
 msgstr ""
 
-#: modules/computer.c:559
+#: modules/computer.c:553
 msgid "Available Languages"
 msgstr ""
 
-#: modules/computer.c:561
+#: modules/computer.c:555
 msgid "Language Code"
 msgstr "Type Code"
 
-#: modules/computer.c:573
+#: modules/computer.c:567
 msgid "Mounted File Systems"
 msgstr ""
 
-#: modules/computer.c:575 modules/computer/filesystem.c:85
+#: modules/computer.c:569 modules/computer/filesystem.c:85
 msgid "Mount Point"
 msgstr "Point de montage"
 
-#: modules/computer.c:576
+#: modules/computer.c:570
 msgid "Usage"
 msgstr ""
 
-#: modules/computer.c:577
+#: modules/computer.c:571 modules/devices/gpu.c:93 modules/devices/gpu.c:101
+#: modules/devices/gpu.c:187 modules/devices/pci.c:70 modules/devices/pci.c:78
+#: modules/devices/pci.c:122 modules/devices/usb.c:72
 msgid "Device"
 msgstr "Périphérique"
 
-#: modules/computer.c:594 modules/computer.c:601
+#: modules/computer.c:590
+msgid "Session"
+msgstr ""
+
+#: modules/computer.c:591 modules/devices.c:614 modules/devices/dmi.c:53
+#: modules/devices/inputdevices.c:117
+msgid "Type"
+msgstr ""
+
+#: modules/computer.c:594
+msgid "Wayland"
+msgstr ""
+
+#: modules/computer.c:595 modules/computer.c:600
+msgid "Current Display Name"
+msgstr ""
+
+#: modules/computer.c:599
+msgid "X Server"
+msgstr ""
+
+#: modules/computer.c:601 modules/computer.c:641 modules/devices/dmi.c:39
+#: modules/devices/dmi.c:43 modules/devices/dmi.c:47 modules/devices/dmi.c:52
+#: modules/devices/gpu.c:92 modules/devices/gpu.c:100 modules/devices/gpu.c:186
 #: modules/devices/ia64/processor.c:161 modules/devices/inputdevices.c:119
-#: modules/devices/pci.c:225 modules/devices/usb.c:349
-#: modules/devices/x86/processor.c:416
+#: modules/devices/pci.c:69 modules/devices/pci.c:77 modules/devices/usb.c:64
+#: modules/devices/x86/processor.c:651
 msgid "Vendor"
 msgstr "Fabricant"
 
-#: modules/computer.c:598
-msgid "Monitors"
+#: modules/computer.c:603
+msgid "Release Number"
 msgstr ""
 
-#: modules/computer.c:600
-msgid "OpenGL"
+#: modules/computer.c:611
+msgid "Screens"
 msgstr ""
 
-#: modules/computer.c:602
+#: modules/computer.c:617
+msgid "Disconnected"
+msgstr ""
+
+#: modules/computer.c:620
+msgid "Connected"
+msgstr ""
+
+#: modules/computer.c:624 modules/computer/os.c:78 modules/computer/os.c:234
+#: modules/computer/os.c:392 modules/devices.c:344 modules/devices.c:396
+#: modules/devices/printers.c:99 modules/devices/printers.c:106
+#: modules/devices/printers.c:116 modules/devices/printers.c:131
+#: modules/devices/printers.c:140 modules/devices/printers.c:243
+msgid "Unknown"
+msgstr "Inconnu"
+
+#: modules/computer.c:628
+msgid "Unused"
+msgstr ""
+
+#: modules/computer.c:629
+#, c-format
+msgid "%dx%d pixels, offset (%d, %d)"
+msgstr ""
+
+#: modules/computer.c:638
+msgid "Outputs (XRandR)"
+msgstr ""
+
+#: modules/computer.c:640
+msgid "OpenGL (GLX)"
+msgstr ""
+
+#: modules/computer.c:642
 msgid "Renderer"
 msgstr ""
 
-#: modules/computer.c:604
+#: modules/computer.c:643
 msgid "Direct Rendering"
 msgstr ""
 
-#: modules/computer.c:608
-msgid "Extensions"
+#: modules/computer.c:645
+msgid "Version (Compatibility)"
 msgstr ""
 
-#: modules/computer.c:628
+#: modules/computer.c:646
+msgid "Shading Language Version (Compatibility)"
+msgstr ""
+
+#: modules/computer.c:647
+msgid "Version (Core)"
+msgstr ""
+
+#: modules/computer.c:648
+msgid "Shading Language Version (Core)"
+msgstr ""
+
+#: modules/computer.c:649
+msgid "Version (ES)"
+msgstr ""
+
+#: modules/computer.c:650
+msgid "Shading Language Version (ES)"
+msgstr ""
+
+#: modules/computer.c:651
+msgid "GLX Version"
+msgstr ""
+
+#: modules/computer.c:672
 msgid "Group"
 msgstr ""
 
-#: modules/computer.c:631 modules/computer/users.c:49
+#: modules/computer.c:675 modules/computer/users.c:49
 msgid "Group ID"
 msgstr ""
 
-#: modules/computer.c:751
+#: modules/computer.c:811
 msgid "RAM"
 msgstr ""
 
-#: modules/computer.c:751 modules/devices/devicetree/pmac_data.c:82
+#: modules/computer.c:811 modules/devices/devicetree/pmac_data.c:82
 msgid "Motherboard"
 msgstr ""
 
-#: modules/computer.c:751
+#: modules/computer.c:811
 msgid "Graphics"
 msgstr ""
 
-#: modules/computer.c:752
+#: modules/computer.c:812 modules/devices.c:107
+msgid "Storage"
+msgstr "Stockage"
+
+#: modules/computer.c:812 modules/devices.c:103
+msgid "Printers"
+msgstr "Imprimantes"
+
+#: modules/computer.c:812
 msgid "Audio"
 msgstr ""
 
-#: modules/computer.c:807
+#: modules/computer.c:857
 msgid "Gathers high-level computer information"
 msgstr "Collecte des informations de l'ordinateur"
-
-#: modules/computer/display.c:122
-#, c-format
-msgid "Monitor %d=%dx%d pixels\n"
-msgstr "Moniteur %d=%dx%d pixels\n"
 
 #: modules/computer/filesystem.c:83
 msgid "Filesystem"
@@ -1247,13 +1571,13 @@ msgstr ""
 msgid "Territory"
 msgstr ""
 
-#: modules/computer/languages.c:110 modules/devices/arm/processor.c:250
-#: modules/devices/ia64/processor.c:166 modules/devices/ppc/processor.c:159
-#: modules/devices/usb.c:236
+#: modules/computer/languages.c:110 modules/devices/arm/processor.c:341
+#: modules/devices/gpu.c:146 modules/devices/ia64/processor.c:166
+#: modules/devices/pci.c:114 modules/devices/ppc/processor.c:159
 msgid "Revision"
 msgstr ""
 
-#: modules/computer/languages.c:111
+#: modules/computer/languages.c:111 modules/devices/dmi.c:42
 msgid "Date"
 msgstr ""
 
@@ -1267,7 +1591,7 @@ msgstr ""
 
 #: modules/computer/modules.c:125 modules/computer/modules.c:126
 #: modules/computer/modules.c:127 modules/computer/modules.c:128
-#: modules/computer/modules.c:129
+#: modules/computer/modules.c:129 modules/devices/dmi.c:115
 msgid "(Not available)"
 msgstr ""
 
@@ -1283,7 +1607,7 @@ msgstr ""
 msgid "Used Memory"
 msgstr ""
 
-#: modules/computer/modules.c:144
+#: modules/computer/modules.c:144 modules/devices/devmemory.c:72
 msgid "KiB"
 msgstr ""
 
@@ -1319,14 +1643,6 @@ msgstr ""
 #: modules/computer/os.c:40
 msgid "diet libc"
 msgstr ""
-
-#: modules/computer/os.c:78 modules/computer/os.c:234 modules/computer/os.c:359
-#: modules/devices.c:333 modules/devices.c:387 modules/devices/printers.c:99
-#: modules/devices/printers.c:106 modules/devices/printers.c:116
-#: modules/devices/printers.c:131 modules/devices/printers.c:140
-#: modules/devices/printers.c:243
-msgid "Unknown"
-msgstr "Inconnu"
 
 #: modules/computer/os.c:112 modules/computer/os.c:115
 msgid "GNOME Shell "
@@ -1374,11 +1690,6 @@ msgstr ""
 msgid "%d bits (healthy)"
 msgstr ""
 
-#: modules/computer/os.c:279 modules/devices/usb.c:48 modules/devices/usb.c:307
-#: modules/devices/usb.c:310 modules/network/net.c:442 includes/cpu_util.h:11
-msgid "(Unknown)"
-msgstr ""
-
 #: modules/computer/users.c:47
 msgid "User Information"
 msgstr ""
@@ -1391,12 +1702,13 @@ msgstr ""
 msgid "Default Shell"
 msgstr ""
 
-#: modules/devices/alpha/processor.c:88 modules/devices/devicetree.c:141
-#: modules/devices/devicetree.c:176 modules/devices/devicetree/pmac_data.c:80
-#: modules/devices/ia64/processor.c:165 modules/devices/m68k/processor.c:84
-#: modules/devices/mips/processor.c:75 modules/devices/parisc/processor.c:155
-#: modules/devices/ppc/processor.c:158 modules/devices/riscv/processor.c:182
-#: modules/devices/s390/processor.c:132 modules/devices/spd-decode.c:1510
+#: modules/devices/alpha/processor.c:88 modules/devices/devicetree.c:161
+#: modules/devices/devicetree.c:207 modules/devices/devicetree/pmac_data.c:80
+#: modules/devices/gpu.c:124 modules/devices/ia64/processor.c:165
+#: modules/devices/m68k/processor.c:84 modules/devices/mips/processor.c:75
+#: modules/devices/parisc/processor.c:155 modules/devices/ppc/processor.c:158
+#: modules/devices/riscv/processor.c:182 modules/devices/s390/processor.c:132
+#: modules/devices/spd-decode.c:1510
 msgid "Model"
 msgstr ""
 
@@ -1404,44 +1716,28 @@ msgstr ""
 msgid "Platform String"
 msgstr ""
 
-#: modules/devices/alpha/processor.c:90 modules/devices/arm/processor.c:240
+#: modules/devices/alpha/processor.c:90 modules/devices/arm/processor.c:331
 #: modules/devices/ia64/processor.c:167 modules/devices/m68k/processor.c:87
 #: modules/devices/mips/processor.c:77 modules/devices/parisc/processor.c:158
-#: modules/devices/pci.c:108 modules/devices/ppc/processor.c:160
-#: modules/devices/riscv/processor.c:186 modules/devices/sh/processor.c:87
-#: modules/devices/x86/processor.c:420
+#: modules/devices/ppc/processor.c:160 modules/devices/riscv/processor.c:186
+#: modules/devices/sh/processor.c:87 modules/devices/x86/processor.c:655
 msgid "Frequency"
 msgstr ""
 
-#: modules/devices/alpha/processor.c:90 modules/devices/arm/processor.c:240
-#: modules/devices/arm/processor.c:365 modules/devices.c:299
-#: modules/devices.c:307 modules/devices.c:335
-#: modules/devices/ia64/processor.c:167 modules/devices/ia64/processor.c:196
-#: modules/devices/m68k/processor.c:87 modules/devices/mips/processor.c:77
-#: modules/devices/parisc/processor.c:158
-#: modules/devices/parisc/processor.c:191 modules/devices/pci.c:108
-#: modules/devices/ppc/processor.c:160 modules/devices/ppc/processor.c:187
-#: modules/devices/riscv/processor.c:186 modules/devices/riscv/processor.c:214
-#: modules/devices/s390/processor.c:160 modules/devices/sh/processor.c:87
-#: modules/devices/sh/processor.c:88 modules/devices/sh/processor.c:89
-#: modules/devices/x86/processor.c:420 modules/devices/x86/processor.c:479
-msgid "MHz"
-msgstr ""
-
-#: modules/devices/alpha/processor.c:91 modules/devices/arm/processor.c:241
+#: modules/devices/alpha/processor.c:91 modules/devices/arm/processor.c:332
 #: modules/devices/ia64/processor.c:168 modules/devices/m68k/processor.c:88
 #: modules/devices/mips/processor.c:78 modules/devices/parisc/processor.c:159
 #: modules/devices/ppc/processor.c:161 modules/devices/s390/processor.c:134
-#: modules/devices/sh/processor.c:90 modules/devices/x86/processor.c:421
+#: modules/devices/sh/processor.c:90 modules/devices/x86/processor.c:656
 msgid "BogoMips"
 msgstr ""
 
-#: modules/devices/alpha/processor.c:92 modules/devices/arm/processor.c:242
+#: modules/devices/alpha/processor.c:92 modules/devices/arm/processor.c:333
 #: modules/devices/ia64/processor.c:169 modules/devices/m68k/processor.c:89
 #: modules/devices/mips/processor.c:79 modules/devices/parisc/processor.c:160
 #: modules/devices/ppc/processor.c:162 modules/devices/riscv/processor.c:187
 #: modules/devices/s390/processor.c:135 modules/devices/sh/processor.c:91
-#: modules/devices/sparc/processor.c:77 modules/devices/x86/processor.c:422
+#: modules/devices/sparc/processor.c:77 modules/devices/x86/processor.c:657
 msgid "Byte Order"
 msgstr ""
 
@@ -1620,61 +1916,67 @@ msgid "ARM Processor"
 msgstr ""
 
 #: modules/devices/arm/processor.c:200 modules/devices/riscv/processor.c:147
-#: modules/devices/x86/processor.c:371
+#: modules/devices/x86/processor.c:606
 msgid "Empty List"
 msgstr ""
 
-#: modules/devices/arm/processor.c:237
+#: modules/devices/arm/processor.c:226 modules/devices/x86/processor.c:268
+msgid "Clocks"
+msgstr ""
+
+#: modules/devices/arm/processor.c:272 modules/devices/arm/processor.c:285
+#: modules/devices/x86/processor.c:314 modules/devices/x86/processor.c:327
+#, c-format
+msgid "%.2f-%.2f %s=%dx\n"
+msgstr ""
+
+#: modules/devices/arm/processor.c:328
 msgid "Linux Name"
 msgstr ""
 
-#: modules/devices/arm/processor.c:238
+#: modules/devices/arm/processor.c:329
 msgid "Decoded Name"
 msgstr ""
 
-#: modules/devices/arm/processor.c:239 modules/network/net.c:458
+#: modules/devices/arm/processor.c:330 modules/network/net.c:453
 msgid "Mode"
 msgstr ""
 
-#: modules/devices/arm/processor.c:245
+#: modules/devices/arm/processor.c:336
 msgid "ARM"
 msgstr ""
 
-#: modules/devices/arm/processor.c:246
+#: modules/devices/arm/processor.c:337
 msgid "Implementer"
 msgstr ""
 
-#: modules/devices/arm/processor.c:247
+#: modules/devices/arm/processor.c:338
 msgid "Part"
 msgstr ""
 
-#: modules/devices/arm/processor.c:248 modules/devices/ia64/processor.c:162
+#: modules/devices/arm/processor.c:339 modules/devices/ia64/processor.c:162
 #: modules/devices/parisc/processor.c:156 modules/devices/riscv/processor.c:183
 msgid "Architecture"
 msgstr ""
 
-#: modules/devices/arm/processor.c:249
+#: modules/devices/arm/processor.c:340
 msgid "Variant"
 msgstr ""
 
-#: modules/devices/arm/processor.c:251 modules/devices/riscv/processor.c:190
-#: modules/devices/sparc/processor.c:78 modules/devices/x86/processor.c:428
+#: modules/devices/arm/processor.c:342 modules/devices/riscv/processor.c:190
+#: modules/devices/sparc/processor.c:78 modules/devices/x86/processor.c:663
 msgid "Capabilities"
 msgstr ""
 
-#: modules/devices/arm/processor.c:335
+#: modules/devices/arm/processor.c:446
 msgid "SOC/Package"
 msgstr ""
 
-#: modules/devices/arm/processor.c:338 modules/devices/cpu_util.c:222
-msgid "Topology"
+#: modules/devices/arm/processor.c:450 modules/devices/x86/processor.c:698
+msgid "Logical CPU Config"
 msgstr ""
 
-#: modules/devices/arm/processor.c:339
-msgid "Clocks"
-msgstr ""
-
-#: modules/devices/arm/processor.c:354
+#: modules/devices/arm/processor.c:467
 msgid "SOC/Package Information"
 msgstr ""
 
@@ -1756,54 +2058,57 @@ msgstr ""
 "[Aucune batterie]\n"
 "Aucune batterie trouvée sur ce système=\n"
 
-#: modules/devices.c:97
+#: modules/devices.c:100
+msgid "Graphics Processors"
+msgstr ""
+
+#: modules/devices.c:101 modules/devices/pci.c:143
 msgid "PCI Devices"
 msgstr "Périphériques PCI"
 
-#: modules/devices.c:98 modules/devices/usb.c:117 modules/devices/usb.c:156
-#: modules/devices/usb.c:415
+#: modules/devices.c:102 modules/devices/usb.c:92
 msgid "USB Devices"
 msgstr "Périphériques USB"
 
-#: modules/devices.c:100
+#: modules/devices.c:104
 msgid "Battery"
 msgstr "Batterie"
 
-#: modules/devices.c:101
+#: modules/devices.c:105
 msgid "Sensors"
 msgstr "Capteurs"
 
-#: modules/devices.c:105
+#: modules/devices.c:109
 msgid "DMI"
 msgstr "DMI"
 
-#: modules/devices.c:106
+#: modules/devices.c:110
 msgid "Memory SPD"
 msgstr "Mémoire SPD"
 
-#: modules/devices.c:111
+#: modules/devices.c:115
 msgid "Device Tree"
 msgstr ""
 
-#: modules/devices.c:113
+#: modules/devices.c:117
 msgid "Resources"
 msgstr "Ressources"
 
-#: modules/devices.c:151
+#: modules/devices.c:162
 #, c-format
 msgid "%d physical processor"
 msgid_plural "%d physical processors"
 msgstr[0] ""
 msgstr[1] ""
 
-#: modules/devices.c:152
+#: modules/devices.c:163
 #, c-format
 msgid "%d core"
 msgid_plural "%d cores"
 msgstr[0] ""
 msgstr[1] ""
 
-#: modules/devices.c:153
+#: modules/devices.c:164
 #, c-format
 msgid "%d thread"
 msgid_plural "%d threads"
@@ -1811,211 +2116,111 @@ msgstr[0] ""
 msgstr[1] ""
 
 #. /NP procs; NC cores; NT threads
-#: modules/devices.c:154
+#: modules/devices.c:165
 #, c-format
 msgid "%s; %s; %s"
 msgstr ""
 
-#: modules/devices.c:372
-msgid " (model unknown)"
-msgstr " (modèle inconnu)"
-
-#: modules/devices.c:374
-msgid " (vendor unknown)"
-msgstr " (Fabricant inconnu)"
-
-#: modules/devices.c:559
+#: modules/devices.c:575
 msgid "Field"
 msgstr ""
 
-#: modules/devices.c:559 modules/devices.c:591
+#: modules/devices.c:575 modules/devices.c:614
 msgid "Value"
 msgstr ""
 
-#: modules/devices.c:591
+#: modules/devices.c:614
 msgid "Sensor"
 msgstr ""
 
-#: modules/devices.c:591 modules/devices/inputdevices.c:117
-msgid "Type"
-msgstr ""
-
-#: modules/devices.c:637
+#: modules/devices.c:661
 msgid "Devices"
 msgstr "Périphériques"
 
-#: modules/devices.c:649
+#: modules/devices.c:673
 msgid "Update PCI ID listing"
 msgstr "Mise à jour de la liste ID PCI "
 
-#: modules/devices.c:661
+#: modules/devices.c:685
 msgid "Update CPU feature database"
 msgstr "Mise à jour des bases de données caractéristiques CPU"
 
-#: modules/devices.c:689
+#: modules/devices.c:713
 msgid "Gathers information about hardware devices"
 msgstr "Collecte des informations des périphériques"
 
-#: modules/devices.c:708
+#: modules/devices.c:732
 msgid "Resource information requires superuser privileges"
 msgstr ""
 
-#: modules/devices/cpu_util.c:30
-msgid "Little Endian"
-msgstr ""
-
-#: modules/devices/cpu_util.c:32
-msgid "Big Endian"
-msgstr ""
-
-#: modules/devices/cpu_util.c:178 modules/devices/cpu_util.c:189
-msgid "Frequency Scaling"
-msgstr ""
-
-#: modules/devices/cpu_util.c:179
-msgid "Minimum"
-msgstr ""
-
-#: modules/devices/cpu_util.c:179 modules/devices/cpu_util.c:180
-#: modules/devices/cpu_util.c:181
-msgid "kHz"
-msgstr ""
-
-#: modules/devices/cpu_util.c:180
-msgid "Maximum"
-msgstr ""
-
-#: modules/devices/cpu_util.c:181
-msgid "Current"
-msgstr ""
-
-#: modules/devices/cpu_util.c:182
-msgid "Transition Latency"
-msgstr ""
-
-#: modules/devices/cpu_util.c:182
-msgid "ns"
-msgstr ""
-
-#: modules/devices/cpu_util.c:183
-msgid "Governor"
-msgstr ""
-
-#: modules/devices/cpu_util.c:184 modules/devices/cpu_util.c:190
-msgid "Driver"
-msgstr ""
-
-#: modules/devices/cpu_util.c:196 modules/devices/x86/processor.c:297
-msgid "(Not Available)"
-msgstr ""
-
-#: modules/devices/cpu_util.c:204 modules/devices/cpu_util.c:206
-msgid "Socket"
-msgstr ""
-
-#: modules/devices/cpu_util.c:209 modules/devices/cpu_util.c:211
-msgid "Core"
-msgstr ""
-
-#: modules/devices/cpu_util.c:214
-msgid "Book"
-msgstr ""
-
-#: modules/devices/cpu_util.c:216
-msgid "Drawer"
-msgstr ""
-
-#: modules/devices/cpu_util.c:223
-msgid "ID"
-msgstr ""
-
-#: modules/devices/devicetree.c:47
+#: modules/devices/devicetree.c:50
 msgid "Properties"
 msgstr ""
 
-#: modules/devices/devicetree.c:48
+#: modules/devices/devicetree.c:51
 msgid "Children"
 msgstr ""
 
-#: modules/devices/devicetree.c:84
+#: modules/devices/devicetree.c:87
 msgid "Node"
 msgstr ""
 
-#: modules/devices/devicetree.c:85
+#: modules/devices/devicetree.c:88
 msgid "Node Path"
 msgstr ""
 
-#: modules/devices/devicetree.c:86
+#: modules/devices/devicetree.c:89
 msgid "Alias"
 msgstr ""
 
-#: modules/devices/devicetree.c:86 modules/devices/devicetree.c:87
+#: modules/devices/devicetree.c:89 modules/devices/devicetree.c:90
 msgid "(None)"
 msgstr ""
 
-#: modules/devices/devicetree.c:87
+#: modules/devices/devicetree.c:90
 msgid "Symbol"
 msgstr ""
 
-#: modules/devices/devicetree.c:132 modules/devices/devicetree/pmac_data.c:79
+#: modules/devices/devicetree.c:143 modules/devices/devicetree/pmac_data.c:79
 msgid "Platform"
 msgstr ""
 
-#: modules/devices/devicetree.c:133 modules/devices/devicetree.c:178
+#: modules/devices/devicetree.c:144 modules/devices/devicetree.c:209
 msgid "Compatible"
 msgstr ""
 
-#: modules/devices/devicetree.c:134
+#: modules/devices/devicetree.c:145
 msgid "GPU-compatible"
 msgstr ""
 
-#: modules/devices/devicetree.c:140
+#: modules/devices/devicetree.c:160
 msgid "Raspberry Pi or Compatible"
 msgstr ""
 
-#: modules/devices/devicetree.c:142 modules/devices/devicetree.c:160
-#: modules/devices/devicetree.c:177 modules/devices/devicetree/rpi_data.c:160
+#: modules/devices/devicetree.c:162 modules/devices/devicetree.c:189
+#: modules/devices/devicetree.c:208 modules/devices/devicetree/rpi_data.c:161
+#: modules/devices/dmi.c:49 modules/devices/dmi.c:55
 msgid "Serial Number"
 msgstr ""
 
-#: modules/devices/devicetree.c:143 modules/devices/devicetree/rpi_data.c:157
+#: modules/devices/devicetree.c:163 modules/devices/devicetree/rpi_data.c:158
 msgid "RCode"
 msgstr ""
 
-#: modules/devices/devicetree.c:143
+#: modules/devices/devicetree.c:163
 msgid "No revision code available; unable to lookup model details."
 msgstr ""
 
-#: modules/devices/devicetree.c:159
+#: modules/devices/devicetree.c:188
 msgid "More"
 msgstr ""
 
-#: modules/devices/devicetree.c:175
-msgid "Board"
-msgstr ""
-
-#: modules/devices/devicetree.c:234
+#: modules/devices/devicetree.c:268
 msgid "Messages"
-msgstr ""
-
-#: modules/devices/devicetree/dt_util.c:1013
-msgid "phandle Map"
-msgstr ""
-
-#: modules/devices/devicetree/dt_util.c:1014
-msgid "Alias Map"
-msgstr ""
-
-#: modules/devices/devicetree/dt_util.c:1015
-msgid "Symbol Map"
 msgstr ""
 
 #: modules/devices/devicetree/pmac_data.c:78
 msgid "Apple Power Macintosh"
-msgstr ""
-
-#: modules/devices/devicetree/pmac_data.c:81 modules/devices/sh/processor.c:85
-msgid "Machine"
 msgstr ""
 
 #: modules/devices/devicetree/pmac_data.c:83
@@ -2034,88 +2239,179 @@ msgstr ""
 msgid "PMAC Generation"
 msgstr ""
 
-#: modules/devices/devicetree/rpi_data.c:152
 #: modules/devices/devicetree/rpi_data.c:153
+#: modules/devices/devicetree/rpi_data.c:154
 msgid "Raspberry Pi"
 msgstr ""
 
-#: modules/devices/devicetree/rpi_data.c:153
+#: modules/devices/devicetree/rpi_data.c:154
 msgid "Board Name"
 msgstr ""
 
-#: modules/devices/devicetree/rpi_data.c:154
+#: modules/devices/devicetree/rpi_data.c:155
 msgid "PCB Revision"
 msgstr ""
 
-#: modules/devices/devicetree/rpi_data.c:155
+#: modules/devices/devicetree/rpi_data.c:156
 msgid "Introduction"
 msgstr ""
 
-#: modules/devices/devicetree/rpi_data.c:156 modules/devices/spd-decode.c:1510
-#: modules/devices/usb.c:84 modules/devices/usb.c:217
+#: modules/devices/devicetree/rpi_data.c:157 modules/devices/spd-decode.c:1510
 msgid "Manufacturer"
 msgstr ""
 
-#: modules/devices/devicetree/rpi_data.c:158
+#: modules/devices/devicetree/rpi_data.c:159
 msgid "SOC (spec)"
 msgstr ""
 
-#: modules/devices/devicetree/rpi_data.c:159
+#: modules/devices/devicetree/rpi_data.c:160
 msgid "Memory (spec)"
 msgstr ""
 
-#: modules/devices/devicetree/rpi_data.c:161
+#: modules/devices/devicetree/rpi_data.c:162
 msgid "Permanent overvolt bit"
 msgstr ""
 
-#: modules/devices/devicetree/rpi_data.c:161
+#: modules/devices/devicetree/rpi_data.c:162
 msgctxt "rpi-ov-bit"
 msgid "Set"
 msgstr ""
 
-#: modules/devices/devicetree/rpi_data.c:161
+#: modules/devices/devicetree/rpi_data.c:162
 msgctxt "rpi-ov-bit"
 msgid "Not set"
 msgstr ""
 
-#: modules/devices/devmemory.c:93
+#: modules/devices/devmemory.c:101
 msgid "Total Memory"
 msgstr "Mémoire totale"
 
-#: modules/devices/devmemory.c:94
+#: modules/devices/devmemory.c:102
 msgid "Free Memory"
 msgstr ""
 
-#: modules/devices/devmemory.c:95
+#: modules/devices/devmemory.c:103
 msgid "Cached Swap"
 msgstr ""
 
-#: modules/devices/devmemory.c:96
+#: modules/devices/devmemory.c:104
 msgid "High Memory"
 msgstr ""
 
-#: modules/devices/devmemory.c:97
+#: modules/devices/devmemory.c:105
 msgid "Free High Memory"
 msgstr ""
 
-#: modules/devices/devmemory.c:98
+#: modules/devices/devmemory.c:106
 msgid "Low Memory"
 msgstr ""
 
-#: modules/devices/devmemory.c:99
+#: modules/devices/devmemory.c:107
 msgid "Free Low Memory"
 msgstr ""
 
-#: modules/devices/devmemory.c:100
+#: modules/devices/devmemory.c:108
 msgid "Virtual Memory"
 msgstr ""
 
-#: modules/devices/devmemory.c:101
+#: modules/devices/devmemory.c:109
 msgid "Free Virtual Memory"
 msgstr ""
 
-#: modules/devices/dmi.c:188
+#: modules/devices/dmi.c:36 modules/devices/inputdevices.c:120
+#: modules/devices/usb.c:63
+msgid "Product"
+msgstr ""
+
+#: modules/devices/dmi.c:38 modules/devices/ia64/processor.c:164
+#: modules/devices/sh/processor.c:86
+msgid "Family"
+msgstr ""
+
+#: modules/devices/dmi.c:41
+msgid "BIOS"
+msgstr ""
+
+#: modules/devices/dmi.c:50 modules/devices/dmi.c:56
+msgid "Asset Tag"
+msgstr ""
+
+#: modules/devices/dmi.c:51
+msgid "Chassis"
+msgstr ""
+
+#: modules/devices/dmi.c:116
 msgid "(Not available; Perhaps try running HardInfo as root.)"
+msgstr ""
+
+#: modules/devices/gpu.c:102 modules/devices/pci.c:79
+msgid "SVendor"
+msgstr ""
+
+#: modules/devices/gpu.c:103 modules/devices/pci.c:80
+msgid "SDevice"
+msgstr ""
+
+#: modules/devices/gpu.c:111 modules/devices/pci.c:90
+msgid "PCI Express"
+msgstr ""
+
+#: modules/devices/gpu.c:112 modules/devices/pci.c:92
+msgid "Maximum Link Width"
+msgstr ""
+
+#: modules/devices/gpu.c:113 modules/devices/pci.c:94
+msgid "Maximum Link Speed"
+msgstr ""
+
+#: modules/devices/gpu.c:113 modules/devices/pci.c:93 modules/devices/pci.c:94
+msgid "GT/s"
+msgstr ""
+
+#: modules/devices/gpu.c:123
+msgid "NVIDIA"
+msgstr ""
+
+#: modules/devices/gpu.c:125
+msgid "BIOS Version"
+msgstr ""
+
+#: modules/devices/gpu.c:126
+msgid "UUID"
+msgstr ""
+
+#: modules/devices/gpu.c:141 modules/devices/gpu.c:183
+#: modules/devices/inputdevices.c:115 modules/devices/pci.c:111
+#: modules/devices/usb.c:62
+msgid "Device Information"
+msgstr ""
+
+#: modules/devices/gpu.c:142 modules/devices/gpu.c:184
+msgid "Location"
+msgstr ""
+
+#: modules/devices/gpu.c:143
+msgid "DRM Device"
+msgstr ""
+
+#: modules/devices/gpu.c:144 modules/devices/pci.c:112 modules/devices/usb.c:67
+msgid "Class"
+msgstr ""
+
+#: modules/devices/gpu.c:150 modules/devices/pci.c:117
+msgid "In Use"
+msgstr ""
+
+#: modules/devices/gpu.c:174
+msgid "Unknown integrated GPU"
+msgstr ""
+
+#: modules/devices/gpu.c:185
+msgid "DT Compatibility"
+msgstr ""
+
+#: modules/devices/gpu.c:201
+msgid "GPUs"
 msgstr ""
 
 #: modules/devices/ia64/processor.c:108
@@ -2126,10 +2422,6 @@ msgstr ""
 msgid "Architecture Revision"
 msgstr ""
 
-#: modules/devices/ia64/processor.c:164 modules/devices/sh/processor.c:86
-msgid "Family"
-msgstr ""
-
 #: modules/devices/ia64/processor.c:170
 msgid "CPU regs"
 msgstr ""
@@ -2138,19 +2430,9 @@ msgstr ""
 msgid "Features"
 msgstr ""
 
-#: modules/devices/inputdevices.c:115 modules/devices/pci.c:214
-#: modules/devices/usb.c:82 modules/devices/usb.c:215 modules/devices/usb.c:347
-msgid "Device Information"
-msgstr ""
-
-#: modules/devices/inputdevices.c:118 modules/devices/usb.c:92
-#: modules/devices/usb.c:240 modules/devices/usb.c:356
+#: modules/devices/inputdevices.c:118 modules/devices/pci.c:121
+#: modules/devices/usb.c:71
 msgid "Bus"
-msgstr ""
-
-#: modules/devices/inputdevices.c:120 modules/devices/usb.c:83
-#: modules/devices/usb.c:216 modules/devices/usb.c:348
-msgid "Product"
 msgstr ""
 
 #: modules/devices/inputdevices.c:124
@@ -2193,61 +2475,31 @@ msgstr ""
 msgid "SVersion"
 msgstr ""
 
-#: modules/devices/parisc/processor.c:163 modules/devices/x86/processor.c:425
+#: modules/devices/parisc/processor.c:163 modules/devices/x86/processor.c:660
 msgid "Cache"
 msgstr ""
 
-#: modules/devices/pci.c:106
-msgid "IRQ"
+#: modules/devices/pci.c:91
+msgid "Link Width"
 msgstr ""
 
-#: modules/devices/pci.c:110
-msgid "Latency"
+#: modules/devices/pci.c:93
+msgid "Link Speed"
 msgstr ""
 
-#: modules/devices/pci.c:112
-msgid "Bus Master"
+#: modules/devices/pci.c:119 modules/devices/usb.c:70
+msgid "Connection"
 msgstr ""
 
-#: modules/devices/pci.c:118
-msgid "Kernel modules"
-msgstr ""
-
-#: modules/devices/pci.c:124
-#, c-format
-msgid "%s=%s (%s)\n"
-msgstr ""
-
-#: modules/devices/pci.c:126
-msgid "OEM Vendor"
-msgstr ""
-
-#: modules/devices/pci.c:153
-msgid "prefetchable"
-msgstr ""
-
-#: modules/devices/pci.c:154
-msgid "non-prefetchable"
-msgstr ""
-
-#: modules/devices/pci.c:163
-msgid "I/O ports at"
-msgstr ""
-
-#: modules/devices/pci.c:216 modules/devices/usb.c:89 modules/devices/usb.c:237
-#: modules/devices/usb.c:353
-msgid "Class"
-msgstr ""
-
-#: modules/devices/pci.c:217
+#: modules/devices/pci.c:120
 msgid "Domain"
 msgstr ""
 
-#: modules/devices/pci.c:218
-msgid "Bus, device, function"
+#: modules/devices/pci.c:123
+msgid "Function"
 msgstr ""
 
-#: modules/devices/pci.c:243
+#: modules/devices/pci.c:161
 msgid "No PCI devices found"
 msgstr ""
 
@@ -2477,7 +2729,7 @@ msgstr ""
 msgid "Bank"
 msgstr ""
 
-#: modules/devices/storage.c:46
+#: modules/devices/storage.c:43
 msgid ""
 "\n"
 "[SCSI Disks]\n"
@@ -2485,7 +2737,7 @@ msgstr ""
 "\n"
 "[SCSI Disks]\n"
 
-#: modules/devices/storage.c:110 modules/devices/storage.c:313
+#: modules/devices/storage.c:114 modules/devices/storage.c:320
 #, c-format
 msgid ""
 "[Device Information]\n"
@@ -2494,17 +2746,17 @@ msgstr ""
 "[Device Information]\n"
 "Modele=%s\n"
 
-#: modules/devices/storage.c:115 modules/devices/storage.c:319
+#: modules/devices/storage.c:119 modules/devices/storage.c:326
 #, c-format
 msgid "Vendor=%s (%s)\n"
 msgstr "Vendeur=%s (%s)\n"
 
-#: modules/devices/storage.c:120 modules/devices/storage.c:321
+#: modules/devices/storage.c:124 modules/devices/storage.c:328
 #, c-format
 msgid "Vendor=%s\n"
 msgstr "Vendeur=%s\n"
 
-#: modules/devices/storage.c:125
+#: modules/devices/storage.c:129
 #, c-format
 msgid ""
 "Type=%s\n"
@@ -2523,7 +2775,7 @@ msgstr ""
 "ID=%d\n"
 "LUN=%d\n"
 
-#: modules/devices/storage.c:167
+#: modules/devices/storage.c:174
 msgid ""
 "\n"
 "[IDE Disks]\n"
@@ -2531,12 +2783,12 @@ msgstr ""
 "\n"
 "[IDE Disks]\n"
 
-#: modules/devices/storage.c:250
+#: modules/devices/storage.c:257
 #, c-format
 msgid "Driver=%s\n"
 msgstr "Driver=%s\n"
 
-#: modules/devices/storage.c:324
+#: modules/devices/storage.c:331
 #, c-format
 msgid ""
 "Device Name=hd%c\n"
@@ -2544,7 +2796,7 @@ msgid ""
 "Cache=%dkb\n"
 msgstr ""
 
-#: modules/devices/storage.c:334
+#: modules/devices/storage.c:341
 #, c-format
 msgid ""
 "[Geometry]\n"
@@ -2555,69 +2807,46 @@ msgstr ""
 "Physique=%s\n"
 "Logique=%s\n"
 
-#: modules/devices/storage.c:344
-#, c-format
-msgid ""
-"[Capabilities]\n"
-"%s"
-msgstr ""
-"[Capabilities]\n"
-"%s"
-
 #: modules/devices/storage.c:351
 #, c-format
 msgid ""
+"[Capabilities]\n"
+"%s"
+msgstr ""
+"[Capabilities]\n"
+"%s"
+
+#: modules/devices/storage.c:358
+#, c-format
+msgid ""
 "[Speeds]\n"
 "%s"
 msgstr ""
 "[Speeds]\n"
 "%s"
 
-#: modules/devices/usb.c:44 modules/devices/usb.c:326
-msgid "mA"
-msgstr ""
-
-#. /%.2f is version
-#: modules/devices/usb.c:53 modules/devices/usb.c:190
-#, c-format
-msgid "USB %.2f Hub"
-msgstr ""
-
-#: modules/devices/usb.c:55 modules/devices/usb.c:192
-#, c-format
-msgid "Unknown USB %.2f Device (class %d)"
-msgstr ""
-
-#: modules/devices/usb.c:85 modules/devices/usb.c:232
-msgid "Speed"
-msgstr ""
-
-#: modules/devices/usb.c:85 modules/devices/usb.c:232
-msgid "Mbit/s"
-msgstr ""
-
-#: modules/devices/usb.c:86 modules/devices/usb.c:233 modules/devices/usb.c:350
+#: modules/devices/usb.c:65
 msgid "Max Current"
 msgstr ""
 
-#: modules/devices/usb.c:88 modules/devices/usb.c:235 modules/devices/usb.c:352
+#: modules/devices/usb.c:65
+msgid "mA"
+msgstr ""
+
+#: modules/devices/usb.c:66
 msgid "USB Version"
 msgstr ""
 
-#: modules/devices/usb.c:90 modules/devices/usb.c:238 modules/devices/usb.c:354
-msgid "Vendor ID"
+#: modules/devices/usb.c:68
+msgid "Sub-class"
 msgstr ""
 
-#: modules/devices/usb.c:91 modules/devices/usb.c:239 modules/devices/usb.c:355
-msgid "Product ID"
+#: modules/devices/usb.c:69
+msgid "Device Version"
 msgstr ""
 
-#: modules/devices/usb.c:231
-msgid "Port"
-msgstr ""
-
-#: modules/devices/usb.c:241
-msgid "Level"
+#: modules/devices/usb.c:103
+msgid "No USB devices found."
 msgstr ""
 
 #: modules/devices/x86/processor.c:149
@@ -2647,40 +2876,57 @@ msgctxt "cache-type"
 msgid "Unified"
 msgstr ""
 
-#: modules/devices/x86/processor.c:410
+#: modules/devices/x86/processor.c:367
+msgid "Caches"
+msgstr ""
+
+#: modules/devices/x86/processor.c:418 modules/devices/x86/processor.c:435
+#, c-format
+msgid "Level %d (%s)#%d=%dx %dKB (%dKB), %d-way set-associative, %d sets\n"
+msgstr ""
+
+#: modules/devices/x86/processor.c:645
 msgid "Model Name"
 msgstr ""
 
-#: modules/devices/x86/processor.c:411
+#: modules/devices/x86/processor.c:646
 msgid "Family, model, stepping"
 msgstr ""
 
-#: modules/devices/x86/processor.c:417
+#: modules/devices/x86/processor.c:652
 msgid "Microcode Version"
 msgstr ""
 
-#: modules/devices/x86/processor.c:418
+#: modules/devices/x86/processor.c:653
 msgid "Configuration"
 msgstr ""
 
-#: modules/devices/x86/processor.c:419
+#: modules/devices/x86/processor.c:654
 msgid "Cache Size"
 msgstr ""
 
-#: modules/devices/x86/processor.c:419
+#: modules/devices/x86/processor.c:654
 msgid "kb"
 msgstr ""
 
-#: modules/devices/x86/processor.c:426
+#: modules/devices/x86/processor.c:661
 msgid "Power Management"
 msgstr ""
 
-#: modules/devices/x86/processor.c:427
+#: modules/devices/x86/processor.c:662
 msgid "Bug Workarounds"
 msgstr ""
 
-#: modules/devices/x86/processor.c:454 modules/devices/x86/processor.c:468
+#: modules/devices/x86/processor.c:695 modules/devices/x86/processor.c:715
 msgid "Package Information"
+msgstr ""
+
+#: modules/devices/x86/processor.c:742
+msgid "Socket:Core"
+msgstr ""
+
+#: modules/devices/x86/processor.c:742
+msgid "Thread"
 msgstr ""
 
 #. /flag:fpu
@@ -3994,75 +4240,100 @@ msgctxt "x86-flag"
 msgid "IPI required to wake up remote CPU"
 msgstr ""
 
+#. /bug:cpu_insecure & bug:cpu_meltdown
+#: modules/devices/x86/x86_data.c:281 modules/devices/x86/x86_data.c:282
+msgctxt "x86-flag"
+msgid ""
+"CPU is affected by meltdown attack and needs kernel page table isolation"
+msgstr ""
+
+#. /bug:spectre_v1
+#: modules/devices/x86/x86_data.c:283
+msgctxt "x86-flag"
+msgid "CPU is affected by Spectre variant 1 attack with conditional branches"
+msgstr ""
+
+#. /bug:spectre_v2
+#: modules/devices/x86/x86_data.c:284
+msgctxt "x86-flag"
+msgid "CPU is affected by Spectre variant 2 attack with indirect branches"
+msgstr ""
+
+#. /bug:spec_store_bypass
+#: modules/devices/x86/x86_data.c:285
+msgctxt "x86-flag"
+msgid "CPU is affected by speculative store bypass attack"
+msgstr ""
+
 #. /x86/kernel/cpu/powerflags.h
 #. /flag:pm:ts
-#: modules/devices/x86/x86_data.c:283
+#: modules/devices/x86/x86_data.c:288
 msgctxt "x86-flag"
 msgid "temperature sensor"
 msgstr ""
 
 #. /flag:pm:fid
-#: modules/devices/x86/x86_data.c:284
+#: modules/devices/x86/x86_data.c:289
 msgctxt "x86-flag"
 msgid "frequency id control"
 msgstr ""
 
 #. /flag:pm:vid
-#: modules/devices/x86/x86_data.c:285
+#: modules/devices/x86/x86_data.c:290
 msgctxt "x86-flag"
 msgid "voltage id control"
 msgstr ""
 
 #. /flag:pm:ttp
-#: modules/devices/x86/x86_data.c:286
+#: modules/devices/x86/x86_data.c:291
 msgctxt "x86-flag"
 msgid "thermal trip"
 msgstr ""
 
 #. /flag:pm:tm
-#: modules/devices/x86/x86_data.c:287
+#: modules/devices/x86/x86_data.c:292
 msgctxt "x86-flag"
 msgid "hardware thermal control"
 msgstr ""
 
 #. /flag:pm:stc
-#: modules/devices/x86/x86_data.c:288
+#: modules/devices/x86/x86_data.c:293
 msgctxt "x86-flag"
 msgid "software thermal control"
 msgstr ""
 
 #. /flag:pm:100mhzsteps
-#: modules/devices/x86/x86_data.c:289
+#: modules/devices/x86/x86_data.c:294
 msgctxt "x86-flag"
 msgid "100 MHz multiplier control"
 msgstr ""
 
 #. /flag:pm:hwpstate
-#: modules/devices/x86/x86_data.c:290
+#: modules/devices/x86/x86_data.c:295
 msgctxt "x86-flag"
 msgid "hardware P-state control"
 msgstr ""
 
 #. /flag:pm:cpb
-#: modules/devices/x86/x86_data.c:291
+#: modules/devices/x86/x86_data.c:296
 msgctxt "x86-flag"
 msgid "core performance boost"
 msgstr ""
 
 #. /flag:pm:eff_freq_ro
-#: modules/devices/x86/x86_data.c:292
+#: modules/devices/x86/x86_data.c:297
 msgctxt "x86-flag"
 msgid "Readonly aperf/mperf"
 msgstr ""
 
 #. /flag:pm:proc_feedback
-#: modules/devices/x86/x86_data.c:293
+#: modules/devices/x86/x86_data.c:298
 msgctxt "x86-flag"
 msgid "processor feedback interface"
 msgstr ""
 
 #. /flag:pm:acc_power
-#: modules/devices/x86/x86_data.c:294
+#: modules/devices/x86/x86_data.c:299
 msgctxt "x86-flag"
 msgid "accumulated power mechanism"
 msgstr ""
@@ -4096,7 +4367,7 @@ msgid "Shared Directories"
 msgstr "Dossiers d'interopérabilités"
 
 #: modules/network.c:304 modules/network.c:326 modules/network.c:357
-#: modules/network/net.c:477
+#: modules/network/net.c:472
 msgid "IP Address"
 msgstr "Addresse IP"
 
@@ -4160,7 +4431,7 @@ msgstr ""
 msgid "Flags"
 msgstr ""
 
-#: modules/network.c:374 modules/network/net.c:478
+#: modules/network.c:374 modules/network/net.c:473
 msgid "Mask"
 msgstr ""
 
@@ -4330,100 +4601,115 @@ msgctxt "net-if-type"
 msgid "(Unknown)"
 msgstr ""
 
-#: modules/network/net.c:348 modules/network/net.c:358
+#: modules/network/net.c:343 modules/network/net.c:353
 msgid "Network Interfaces"
 msgstr ""
 
-#: modules/network/net.c:348
+#: modules/network/net.c:343
 msgid "None Found"
 msgstr ""
 
-#: modules/network/net.c:400 modules/network/net.c:422
-#: modules/network/net.c:423
+#: modules/network/net.c:395 modules/network/net.c:417
+#: modules/network/net.c:418
 msgid "MiB"
 msgstr ""
 
-#: modules/network/net.c:414
+#: modules/network/net.c:409
 msgid "Network Adapter Properties"
 msgstr ""
 
-#: modules/network/net.c:415
+#: modules/network/net.c:410
 msgid "Interface Type"
 msgstr ""
 
-#: modules/network/net.c:416
+#: modules/network/net.c:411
 msgid "Hardware Address (MAC)"
 msgstr ""
 
-#: modules/network/net.c:420
+#: modules/network/net.c:415
 msgid "MTU"
 msgstr ""
 
-#: modules/network/net.c:421
+#: modules/network/net.c:416
 msgid "Transfer Details"
 msgstr ""
 
-#: modules/network/net.c:422
+#: modules/network/net.c:417
 msgid "Bytes Received"
 msgstr ""
 
-#: modules/network/net.c:423
+#: modules/network/net.c:418
 msgid "Bytes Sent"
 msgstr ""
 
-#: modules/network/net.c:440 modules/network/net.c:462
-#: modules/network/net.c:463
+#: modules/network/net.c:435 modules/network/net.c:457
+#: modules/network/net.c:458
 msgid "dBm"
 msgstr ""
 
-#: modules/network/net.c:440
+#: modules/network/net.c:435
 msgid "mW"
 msgstr ""
 
-#: modules/network/net.c:454
+#: modules/network/net.c:449
 msgid "Wireless Properties"
 msgstr ""
 
-#: modules/network/net.c:455
+#: modules/network/net.c:450
 msgid "Network Name (SSID)"
 msgstr ""
 
-#: modules/network/net.c:456
+#: modules/network/net.c:451
 msgid "Bit Rate"
 msgstr ""
 
-#: modules/network/net.c:456
+#: modules/network/net.c:451
 msgid "Mb/s"
 msgstr ""
 
-#: modules/network/net.c:457
+#: modules/network/net.c:452
 msgid "Transmission Power"
 msgstr ""
 
-#: modules/network/net.c:459
+#: modules/network/net.c:454
 msgid "Status"
 msgstr ""
 
-#: modules/network/net.c:460
+#: modules/network/net.c:455
 msgid "Link Quality"
 msgstr ""
 
-#: modules/network/net.c:461
+#: modules/network/net.c:456
 msgid "Signal / Noise"
 msgstr ""
 
-#: modules/network/net.c:476
+#: modules/network/net.c:471
 msgid "Internet Protocol (IPv4)"
 msgstr ""
 
-#: modules/network/net.c:477 modules/network/net.c:478
-#: modules/network/net.c:480
+#: modules/network/net.c:472 modules/network/net.c:473
+#: modules/network/net.c:475
 msgid "(Not set)"
 msgstr ""
 
-#: modules/network/net.c:479
+#: modules/network/net.c:474
 msgid "Broadcast Address"
 msgstr ""
+
+#~ msgid "Unknown benchmark ``%s'' or libbenchmark.so not loaded"
+#~ msgstr "Benchmark inconnu ``%s'' ou libbenchmark.so non chargé"
+
+#~ msgid "%s Module"
+#~ msgstr "%s Module"
+
+#~ msgid "Monitor %d=%dx%d pixels\n"
+#~ msgstr "Moniteur %d=%dx%d pixels\n"
+
+#~ msgid " (model unknown)"
+#~ msgstr " (modèle inconnu)"
+
+#~ msgid " (vendor unknown)"
+#~ msgstr " (Fabricant inconnu)"
 
 #~ msgid "Desktop Environment"
 #~ msgstr "Environnement de bureau"

--- a/po/hardinfo.pot
+++ b/po/hardinfo.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-08-14 22:23-0500\n"
+"POT-Creation-Date: 2018-06-09 14:09-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,15 +18,200 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
 
+#: hardinfo/cpu_util.c:30
+msgid "Little Endian"
+msgstr ""
+
+#: hardinfo/cpu_util.c:32
+msgid "Big Endian"
+msgstr ""
+
+#: hardinfo/cpu_util.c:184 hardinfo/cpu_util.c:195
+msgid "Frequency Scaling"
+msgstr ""
+
+#: hardinfo/cpu_util.c:185
+msgid "Minimum"
+msgstr ""
+
+#: hardinfo/cpu_util.c:185 hardinfo/cpu_util.c:186 hardinfo/cpu_util.c:187
+msgid "kHz"
+msgstr ""
+
+#: hardinfo/cpu_util.c:186
+msgid "Maximum"
+msgstr ""
+
+#: hardinfo/cpu_util.c:187
+msgid "Current"
+msgstr ""
+
+#: hardinfo/cpu_util.c:188
+msgid "Transition Latency"
+msgstr ""
+
+#: hardinfo/cpu_util.c:188
+msgid "ns"
+msgstr ""
+
+#: hardinfo/cpu_util.c:189
+msgid "Governor"
+msgstr ""
+
+#: hardinfo/cpu_util.c:190 hardinfo/cpu_util.c:196 modules/devices/gpu.c:149
+#: modules/devices/pci.c:116
+msgid "Driver"
+msgstr ""
+
+#: hardinfo/cpu_util.c:202 modules/computer.c:596
+#: modules/devices/arm/processor.c:242 modules/devices/x86/processor.c:284
+#: modules/devices/x86/processor.c:388 modules/devices/x86/processor.c:524
+msgid "(Not Available)"
+msgstr ""
+
+#: hardinfo/cpu_util.c:210 hardinfo/cpu_util.c:212
+msgid "Socket"
+msgstr ""
+
+#: hardinfo/cpu_util.c:215 hardinfo/cpu_util.c:217
+msgid "Core"
+msgstr ""
+
+#: hardinfo/cpu_util.c:220
+msgid "Book"
+msgstr ""
+
+#: hardinfo/cpu_util.c:222
+msgid "Drawer"
+msgstr ""
+
+#: hardinfo/cpu_util.c:228 modules/devices/arm/processor.c:449
+#: modules/devices/x86/processor.c:697
+msgid "Topology"
+msgstr ""
+
+#: hardinfo/cpu_util.c:229
+msgid "ID"
+msgstr ""
+
+#: hardinfo/dmi_util.c:130
+msgid "Invalid chassis type (0)"
+msgstr ""
+
+#: hardinfo/dmi_util.c:131 hardinfo/dmi_util.c:132
+msgid "Unknown chassis type"
+msgstr ""
+
+#: hardinfo/dmi_util.c:133
+msgid "Desktop"
+msgstr ""
+
+#: hardinfo/dmi_util.c:134
+msgid "Low-profile Desktop"
+msgstr ""
+
+#: hardinfo/dmi_util.c:135
+msgid "Pizza Box"
+msgstr ""
+
+#: hardinfo/dmi_util.c:136
+msgid "Mini Tower"
+msgstr ""
+
+#: hardinfo/dmi_util.c:137
+msgid "Tower"
+msgstr ""
+
+#: hardinfo/dmi_util.c:138
+msgid "Portable"
+msgstr ""
+
+#: hardinfo/dmi_util.c:139 modules/computer.c:330 modules/computer.c:339
+#: modules/computer.c:361
+msgid "Laptop"
+msgstr ""
+
+#: hardinfo/dmi_util.c:140
+msgid "Notebook"
+msgstr ""
+
+#: hardinfo/dmi_util.c:141
+msgid "Handheld"
+msgstr ""
+
+#: hardinfo/dmi_util.c:142
+msgid "Docking Station"
+msgstr ""
+
+#: hardinfo/dmi_util.c:143
+msgid "All-in-one"
+msgstr ""
+
+#: hardinfo/dmi_util.c:144
+msgid "Subnotebook"
+msgstr ""
+
+#: hardinfo/dmi_util.c:145
+msgid "Space-saving"
+msgstr ""
+
+#: hardinfo/dmi_util.c:146
+msgid "Lunch Box"
+msgstr ""
+
+#: hardinfo/dmi_util.c:147
+msgid "Main Server Chassis"
+msgstr ""
+
+#: hardinfo/dmi_util.c:148
+msgid "Expansion Chassis"
+msgstr ""
+
+#: hardinfo/dmi_util.c:149
+msgid "Sub Chassis"
+msgstr ""
+
+#: hardinfo/dmi_util.c:150
+msgid "Bus Expansion Chassis"
+msgstr ""
+
+#: hardinfo/dmi_util.c:151
+msgid "Peripheral Chassis"
+msgstr ""
+
+#: hardinfo/dmi_util.c:152
+msgid "RAID Chassis"
+msgstr ""
+
+#: hardinfo/dmi_util.c:153
+msgid "Rack Mount Chassis"
+msgstr ""
+
+#: hardinfo/dmi_util.c:154
+msgid "Sealed-case PC"
+msgstr ""
+
+#: hardinfo/dt_util.c:1011
+msgid "phandle Map"
+msgstr ""
+
+#: hardinfo/dt_util.c:1012
+msgid "Alias Map"
+msgstr ""
+
+#: hardinfo/dt_util.c:1013
+msgid "Symbol Map"
+msgstr ""
+
 #. / %d will be latest year of copyright
-#: hardinfo/hardinfo.c:49
+#: hardinfo/hardinfo.c:50
 #, c-format
 msgid ""
 "Copyright (C) 2003-%d Leandro A. F. Pereira. See COPYING for details.\n"
 "\n"
 msgstr ""
 
-#: hardinfo/hardinfo.c:51
+#: hardinfo/hardinfo.c:52
 #, c-format
 msgid ""
 "Compile-time options:\n"
@@ -37,18 +222,16 @@ msgid ""
 "  Compiled for:      %s\n"
 msgstr ""
 
-#: hardinfo/hardinfo.c:57 hardinfo/hardinfo.c:58 modules/computer.c:605
-#: modules/devices/inputdevices.c:128 modules/devices/pci.c:112
-#: modules/devices/printers.c:138
+#: hardinfo/hardinfo.c:58 hardinfo/hardinfo.c:59 modules/computer.c:644
+#: modules/devices/inputdevices.c:128 modules/devices/printers.c:138
 msgid "Yes"
 msgstr ""
 
-#: hardinfo/hardinfo.c:58 modules/computer.c:605 modules/devices/pci.c:112
-#: modules/devices/printers.c:138
+#: hardinfo/hardinfo.c:59 modules/computer.c:644 modules/devices/printers.c:138
 msgid "No"
 msgstr ""
 
-#: hardinfo/hardinfo.c:69
+#: hardinfo/hardinfo.c:70
 #, c-format
 msgid ""
 "Failed to find runtime data.\n"
@@ -57,56 +240,58 @@ msgid ""
 "• See if %s and %s exists and you have read permission."
 msgstr ""
 
-#: hardinfo/hardinfo.c:76
+#: hardinfo/hardinfo.c:77
 #, c-format
 msgid ""
 "Modules:\n"
 "%-20s %-15s %-12s\n"
 msgstr ""
 
-#: hardinfo/hardinfo.c:77
+#: hardinfo/hardinfo.c:78
 msgid "File Name"
 msgstr ""
 
-#: hardinfo/hardinfo.c:77 modules/computer.c:534 modules/computer.c:562
-#: modules/computer.c:630 modules/computer/languages.c:104
-#: modules/computer/modules.c:146 modules/devices/arm/processor.c:336
+#: hardinfo/hardinfo.c:78 modules/computer.c:528 modules/computer.c:556
+#: modules/computer.c:674 modules/computer/languages.c:104
+#: modules/computer/modules.c:146 modules/devices/arm/processor.c:447
+#: modules/devices/dmi.c:37 modules/devices/dmi.c:46
 #: modules/devices/ia64/processor.c:160 modules/devices/inputdevices.c:116
-#: modules/devices/pci.c:215 modules/devices/sh/processor.c:84
-#: modules/devices/x86/processor.c:455 modules/network.c:326
+#: modules/devices/sh/processor.c:84 modules/devices/x86/processor.c:696
+#: modules/network.c:326
 msgid "Name"
 msgstr ""
 
-#: hardinfo/hardinfo.c:77 modules/computer.c:296 modules/computer.c:505
-#: modules/computer.c:507 modules/computer.c:595 modules/computer.c:603
+#: hardinfo/hardinfo.c:78 modules/computer.c:304 modules/computer.c:499
+#: modules/computer.c:501 modules/computer.c:602 modules/devices/dmi.c:40
+#: modules/devices/dmi.c:44 modules/devices/dmi.c:48 modules/devices/dmi.c:54
 #: modules/devices/inputdevices.c:121
 msgid "Version"
 msgstr ""
 
-#: hardinfo/hardinfo.c:124
+#: hardinfo/hardinfo.c:125
 #, c-format
-msgid "Unknown benchmark ``%s'' or libbenchmark.so not loaded"
+msgid "Unknown benchmark ``%s'' or benchmark.so not loaded"
 msgstr ""
 
-#: hardinfo/hardinfo.c:152
+#: hardinfo/hardinfo.c:155
 msgid "Don't know what to do. Exiting."
 msgstr ""
 
-#: hardinfo/util.c:104 modules/computer/uptime.c:53
+#: hardinfo/util.c:104 modules/computer/uptime.c:54
 #, c-format
 msgid "%d day"
 msgid_plural "%d days"
 msgstr[0] ""
 msgstr[1] ""
 
-#: hardinfo/util.c:105 modules/computer/uptime.c:54
+#: hardinfo/util.c:105 modules/computer/uptime.c:55
 #, c-format
 msgid "%d hour"
 msgid_plural "%d hours"
 msgstr[0] ""
 msgstr[1] ""
 
-#: hardinfo/util.c:106 modules/computer/uptime.c:55
+#: hardinfo/util.c:106 modules/computer/uptime.c:56
 #, c-format
 msgid "%d minute"
 msgid_plural "%d minutes"
@@ -162,88 +347,91 @@ msgstr ""
 msgid "Fatal Error"
 msgstr ""
 
-#: hardinfo/util.c:401
+#: hardinfo/util.c:403
 msgid "creates a report and prints to standard output"
 msgstr ""
 
-#: hardinfo/util.c:407
+#: hardinfo/util.c:409
 msgid "chooses a report format (text, html)"
 msgstr ""
 
-#: hardinfo/util.c:413
+#: hardinfo/util.c:415
 msgid "run benchmark; requires benchmark.so to be loaded"
 msgstr ""
 
-#: hardinfo/util.c:419
+#: hardinfo/util.c:421
+msgid "benchmark result format ([short], conf, shell)"
+msgstr ""
+
+#: hardinfo/util.c:427
 msgid "lists modules"
 msgstr ""
 
-#: hardinfo/util.c:425
+#: hardinfo/util.c:433
 msgid "specify module to load"
 msgstr ""
 
-#: hardinfo/util.c:431
+#: hardinfo/util.c:439
 msgid "automatically load module dependencies"
 msgstr ""
 
-#: hardinfo/util.c:438
+#: hardinfo/util.c:446
 msgid "run in XML-RPC server mode"
 msgstr ""
 
-#: hardinfo/util.c:445
+#: hardinfo/util.c:453
 msgid "shows program version and quit"
 msgstr ""
 
-#: hardinfo/util.c:450
+#: hardinfo/util.c:459
+msgid "do not run benchmarks"
+msgstr ""
+
+#: hardinfo/util.c:464
 msgid "- System Profiler and Benchmark tool"
 msgstr ""
 
-#: hardinfo/util.c:460
+#: hardinfo/util.c:474
 #, c-format
 msgid ""
 "Unrecognized arguments.\n"
 "Try ``%s --help'' for more information.\n"
 msgstr ""
 
-#: hardinfo/util.c:526
+#: hardinfo/util.c:542
 #, c-format
 msgid "Couldn't find a Web browser to open URL %s."
 msgstr ""
 
-#: hardinfo/util.c:875
+#: hardinfo/util.c:891
 #, c-format
 msgid "Module \"%s\" depends on module \"%s\", load it?"
 msgstr ""
 
-#: hardinfo/util.c:898
+#: hardinfo/util.c:914
 #, c-format
 msgid "Module \"%s\" depends on module \"%s\"."
 msgstr ""
 
-#: hardinfo/util.c:943
+#: hardinfo/util.c:959
 #, c-format
 msgid "No module could be loaded. Check permissions on \"%s\" and try again."
 msgstr ""
 
-#: hardinfo/util.c:947
+#: hardinfo/util.c:963
 msgid ""
 "No module could be loaded. Please use hardinfo -l to list all available "
 "modules and try again with a valid module list."
 msgstr ""
 
-#: hardinfo/util.c:1024
+#: hardinfo/util.c:1040
 #, c-format
 msgid "Scanning: %s..."
 msgstr ""
 
-#: hardinfo/util.c:1034 shell/shell.c:301 shell/shell.c:760 shell/shell.c:1795
-#: modules/benchmark.c:449 modules/benchmark.c:457
+#: hardinfo/util.c:1050 shell/shell.c:301 shell/shell.c:772 shell/shell.c:1850
+#: modules/benchmark.c:549 modules/benchmark.c:557
 msgid "Done."
-msgstr ""
-
-#: shell/callbacks.c:117
-#, c-format
-msgid "%s Module"
 msgstr ""
 
 #: shell/callbacks.c:128
@@ -418,53 +606,65 @@ msgstr ""
 msgid "_Toolbar"
 msgstr ""
 
-#: shell/report.c:494 shell/report.c:502
+#: shell/report.c:500 shell/report.c:508
 msgid "Save File"
 msgstr ""
 
-#: shell/report.c:629
+#: shell/report.c:503 shell/report.c:935 shell/syncmanager.c:748
+msgid "_Cancel"
+msgstr ""
+
+#: shell/report.c:505
+msgid "_Save"
+msgstr ""
+
+#: shell/report.c:635
 msgid "Cannot create ReportContext. Programming bug?"
 msgstr ""
 
-#: shell/report.c:648
+#: shell/report.c:654
 msgid "Open the report with your web browser?"
 msgstr ""
 
-#: shell/report.c:682
+#: shell/report.c:657
+msgid "_No"
+msgstr ""
+
+#: shell/report.c:658
+msgid "_Open"
+msgstr ""
+
+#: shell/report.c:688
 msgid "Generating report..."
 msgstr ""
 
-#: shell/report.c:692
+#: shell/report.c:698
 msgid "Report saved."
 msgstr ""
 
-#: shell/report.c:694
+#: shell/report.c:700
 msgid "Error while creating the report."
 msgstr ""
 
-#: shell/report.c:796
+#: shell/report.c:802
 msgid "Generate Report"
 msgstr ""
 
-#: shell/report.c:821
+#: shell/report.c:827
 msgid ""
 "<big><b>Generate Report</b></big>\n"
 "Please choose the information that you wish to view in your report:"
 msgstr ""
 
-#: shell/report.c:893
+#: shell/report.c:899
 msgid "Select _None"
 msgstr ""
 
-#: shell/report.c:904
+#: shell/report.c:910
 msgid "Select _All"
 msgstr ""
 
-#: shell/report.c:929 shell/syncmanager.c:748
-msgid "_Cancel"
-msgstr ""
-
-#: shell/report.c:939
+#: shell/report.c:945
 msgid "_Generate"
 msgstr ""
 
@@ -477,16 +677,16 @@ msgstr ""
 msgid "System Information"
 msgstr ""
 
-#: shell/shell.c:747
+#: shell/shell.c:759
 msgid "Loading modules..."
 msgstr ""
 
-#: shell/shell.c:1660
+#: shell/shell.c:1715
 #, c-format
 msgid "<b>%s → Summary</b>"
 msgstr ""
 
-#: shell/shell.c:1769
+#: shell/shell.c:1824
 msgid "Updating..."
 msgstr ""
 
@@ -564,93 +764,217 @@ msgstr ""
 msgid "_Synchronize"
 msgstr ""
 
-#: modules/benchmark.c:52
+#: modules/benchmark/benches.c:74
 msgid "CPU Blowfish"
 msgstr ""
 
-#: modules/benchmark.c:53
+#: modules/benchmark/benches.c:75
 msgid "CPU CryptoHash"
 msgstr ""
 
-#: modules/benchmark.c:54
+#: modules/benchmark/benches.c:76
 msgid "CPU Fibonacci"
 msgstr ""
 
-#: modules/benchmark.c:55
+#: modules/benchmark/benches.c:77
 msgid "CPU N-Queens"
 msgstr ""
 
-#: modules/benchmark.c:56
+#: modules/benchmark/benches.c:78
 msgid "CPU Zlib"
 msgstr ""
 
-#: modules/benchmark.c:57
+#: modules/benchmark/benches.c:79
 msgid "FPU FFT"
 msgstr ""
 
-#: modules/benchmark.c:58
+#: modules/benchmark/benches.c:80
 msgid "FPU Raytracing"
 msgstr ""
 
-#: modules/benchmark.c:60
+#: modules/benchmark/benches.c:82
 msgid "GPU Drawing"
 msgstr ""
 
-#: modules/benchmark.c:239 modules/benchmark.c:255
+#: modules/benchmark/benches.c:91
+msgid "Results in MiB/second. Higher is better."
+msgstr ""
+
+#: modules/benchmark/benches.c:95
+msgid "Results in HIMarks. Higher is better."
+msgstr ""
+
+#: modules/benchmark/benches.c:102
+msgid "Results in seconds. Lower is better."
+msgstr ""
+
+#. /or modify
+#. *    it under the terms of the GNU General Public License as published by
+#. *    the Free Software Foundation, version 2.
+#. *
+#. *    This program is distributed in the hope that it will be useful,
+#. *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#. *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#. *    GNU General Public License for more details.
+#. *
+#. *    You should have received a copy of the GNU General Public License
+#. *    along with this program; if not, write to the Free Software
+#. *    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+#.
+#. / Used for an unknown value. Having it in only one place cleans up the .po line references
+#: modules/benchmark/bench_results.c:22 modules/computer.c:41
+#: modules/computer/display.c:41 modules/computer/os.c:279
+#: modules/devices.c:383 modules/devices/gpu.c:42 modules/devices/gpu.c:58
+#: modules/devices/gpu.c:150 modules/devices/gpu.c:151 modules/devices/pci.c:25
+#: modules/devices/pci.c:117 modules/devices/pci.c:118 modules/devices/usb.c:27
+#: modules/network/net.c:437 includes/cpu_util.h:11
+msgid "(Unknown)"
+msgstr ""
+
+#: modules/benchmark/bench_results.c:47 modules/benchmark/bench_results.c:322
+#: modules/devices/alpha/processor.c:90 modules/devices/arm/processor.c:276
+#: modules/devices/arm/processor.c:289 modules/devices/arm/processor.c:331
+#: modules/devices/arm/processor.c:478 modules/devices.c:310
+#: modules/devices.c:318 modules/devices.c:346
+#: modules/devices/ia64/processor.c:167 modules/devices/ia64/processor.c:196
+#: modules/devices/m68k/processor.c:87 modules/devices/mips/processor.c:77
+#: modules/devices/parisc/processor.c:158
+#: modules/devices/parisc/processor.c:191 modules/devices/ppc/processor.c:160
+#: modules/devices/ppc/processor.c:187 modules/devices/riscv/processor.c:186
+#: modules/devices/riscv/processor.c:214 modules/devices/s390/processor.c:160
+#: modules/devices/sh/processor.c:87 modules/devices/sh/processor.c:88
+#: modules/devices/sh/processor.c:89 modules/devices/x86/processor.c:318
+#: modules/devices/x86/processor.c:331 modules/devices/x86/processor.c:655
+#: modules/devices/x86/processor.c:726
+msgid "MHz"
+msgstr ""
+
+#: modules/benchmark/bench_results.c:374 modules/benchmark/bench_results.c:441
+msgid "kiB"
+msgstr ""
+
+#: modules/benchmark/bench_results.c:389 modules/benchmark/bench_results.c:426
+msgid "Benchmark Result"
+msgstr ""
+
+#: modules/benchmark/bench_results.c:390 modules/benchmark/bench_results.c:428
+msgid "Threads"
+msgstr ""
+
+#: modules/benchmark/bench_results.c:391 modules/benchmark/bench_results.c:431
+msgid "Note"
+msgstr ""
+
+#: modules/benchmark/bench_results.c:392 modules/benchmark/bench_results.c:432
+msgid ""
+"This result is from an old version of HardInfo. Results might not be "
+"comparable to current version. Some details are missing."
+msgstr ""
+
+#: modules/benchmark/bench_results.c:393 modules/benchmark/bench_results.c:433
+#: modules/devices/devicetree/pmac_data.c:81 modules/devices/sh/processor.c:85
+msgid "Machine"
+msgstr ""
+
+#: modules/benchmark/bench_results.c:394 modules/benchmark/bench_results.c:434
+#: modules/devices/devicetree.c:206 modules/devices/dmi.c:45
+msgid "Board"
+msgstr ""
+
+#: modules/benchmark/bench_results.c:395 modules/benchmark/bench_results.c:435
+msgid "CPU Name"
+msgstr ""
+
+#: modules/benchmark/bench_results.c:396 modules/benchmark/bench_results.c:436
+msgid "CPU Description"
+msgstr ""
+
+#: modules/benchmark/bench_results.c:397 modules/benchmark/bench_results.c:437
+#: modules/benchmark.c:390
 msgid "CPU Config"
 msgstr ""
 
-#: modules/benchmark.c:239 modules/benchmark.c:255
+#: modules/benchmark/bench_results.c:398 modules/benchmark/bench_results.c:438
+msgid "Threads Available"
+msgstr ""
+
+#: modules/benchmark/bench_results.c:399 modules/benchmark/bench_results.c:439
+msgid "GPU"
+msgstr ""
+
+#: modules/benchmark/bench_results.c:400 modules/benchmark/bench_results.c:440
+#: modules/computer.c:479
+msgid "OpenGL Renderer"
+msgstr ""
+
+#: modules/benchmark/bench_results.c:401 modules/benchmark/bench_results.c:441
+#: modules/computer.c:110 modules/computer.c:468 modules/devices.c:99
+msgid "Memory"
+msgstr ""
+
+#: modules/benchmark/bench_results.c:427
+msgid "Benchmark"
+msgstr ""
+
+#: modules/benchmark/bench_results.c:429
+msgid "Result"
+msgstr ""
+
+#: modules/benchmark/bench_results.c:430
+msgid "Elapsed Time"
+msgstr ""
+
+#: modules/benchmark/bench_results.c:442
+msgid "Handles"
+msgstr ""
+
+#: modules/benchmark/bench_results.c:443
+msgid "mid"
+msgstr ""
+
+#: modules/benchmark/bench_results.c:444
+msgid "cfg_val"
+msgstr ""
+
+#: modules/benchmark.c:390
 msgid "Results"
 msgstr ""
 
-#: modules/benchmark.c:239 modules/benchmark.c:255 modules/computer.c:751
+#: modules/benchmark.c:390 modules/computer.c:811
 #: modules/devices/sparc/processor.c:75
 msgid "CPU"
 msgstr ""
 
-#: modules/benchmark.c:381
+#: modules/benchmark.c:460
 #, c-format
 msgid "Benchmarking: <b>%s</b>."
 msgstr ""
 
-#: modules/benchmark.c:395
-msgid "Benchmarking. Please do not move your mouse or press any keys."
-msgstr ""
-
-#: modules/benchmark.c:399
+#: modules/benchmark.c:479 modules/benchmark.c:498
 msgid "Cancel"
 msgstr ""
 
-#: modules/benchmark.c:536
-msgid "Results in MiB/second. Higher is better."
+#: modules/benchmark.c:483 modules/benchmark.c:495
+msgid "Benchmarking. Please do not move your mouse or press any keys."
 msgstr ""
 
-#: modules/benchmark.c:540
-msgid "Results in HIMarks. Higher is better."
-msgstr ""
-
-#: modules/benchmark.c:547
-msgid "Results in seconds. Lower is better."
-msgstr ""
-
-#: modules/benchmark.c:555
+#: modules/benchmark.c:567
 msgid "Benchmarks"
 msgstr ""
 
-#: modules/benchmark.c:573
+#: modules/benchmark.c:585
 msgid "Perform tasks and compare with other systems"
 msgstr ""
 
-#: modules/benchmark.c:663
+#: modules/benchmark.c:692
 msgid "Send benchmark results"
 msgstr ""
 
-#: modules/benchmark.c:668
+#: modules/benchmark.c:697
 msgid "Receive benchmark results"
 msgstr ""
 
-#: modules/computer/alsa.c:26 modules/computer.c:489
+#: modules/computer/alsa.c:26 modules/computer.c:483
 msgid "Audio Devices"
 msgstr ""
 
@@ -658,500 +982,500 @@ msgstr ""
 msgid "Audio Adapter"
 msgstr ""
 
-#: modules/computer/boots.c:33 modules/computer.c:73 modules/computer.c:546
-msgid "Boots"
-msgstr ""
-
-#: modules/computer.c:70
+#: modules/computer.c:76
 msgid "Summary"
 msgstr ""
 
-#: modules/computer.c:71 modules/computer.c:476 modules/computer.c:750
+#: modules/computer.c:77 modules/computer.c:471 modules/computer.c:810
 msgid "Operating System"
 msgstr ""
 
-#: modules/computer.c:72
+#: modules/computer.c:78 modules/devices/gpu.c:151 modules/devices/pci.c:118
 msgid "Kernel Modules"
 msgstr ""
 
-#: modules/computer.c:74
+#: modules/computer.c:79 modules/computer.c:540
+msgid "Boots"
+msgstr ""
+
+#: modules/computer.c:80
 msgid "Languages"
 msgstr ""
 
-#: modules/computer.c:75
+#: modules/computer.c:81
 msgid "Filesystems"
 msgstr ""
 
-#: modules/computer.c:76 modules/computer.c:481 modules/computer.c:590
+#: modules/computer.c:82 modules/computer.c:476
 msgid "Display"
 msgstr ""
 
-#: modules/computer.c:77 modules/computer/environment.c:32
+#: modules/computer.c:83 modules/computer/environment.c:32
 msgid "Environment Variables"
 msgstr ""
 
-#: modules/computer.c:79
+#: modules/computer.c:85
 msgid "Development"
 msgstr ""
 
-#: modules/computer.c:81 modules/computer.c:617
+#: modules/computer.c:87 modules/computer.c:661
 msgid "Users"
 msgstr ""
 
-#: modules/computer.c:82
+#: modules/computer.c:88
 msgid "Groups"
 msgstr ""
 
-#: modules/computer.c:104 modules/computer.c:473 modules/devices.c:96
-#: modules/devices/pci.c:149
-msgid "Memory"
-msgstr ""
-
-#: modules/computer.c:106
+#: modules/computer.c:112
 #, c-format
 msgid "%dMB (%dMB used)"
 msgstr ""
 
-#: modules/computer.c:108 modules/computer.c:520
+#: modules/computer.c:114 modules/computer.c:514
 msgid "Uptime"
 msgstr ""
 
-#: modules/computer.c:110 modules/computer.c:478
+#: modules/computer.c:116 modules/computer.c:473
 msgid "Date/Time"
 msgstr ""
 
-#: modules/computer.c:115 modules/computer.c:521
+#: modules/computer.c:121 modules/computer.c:515
 msgid "Load Average"
 msgstr ""
 
-#: modules/computer.c:117 modules/computer.c:522
+#: modules/computer.c:123 modules/computer.c:516
 msgid "Available entropy in /dev/random"
 msgstr ""
 
-#: modules/computer.c:203
+#: modules/computer.c:211
 msgid "Scripting Languages"
 msgstr ""
 
-#: modules/computer.c:204
+#: modules/computer.c:212
 msgid "Gambas3 (gbr3)"
 msgstr ""
 
-#: modules/computer.c:205
+#: modules/computer.c:213
 msgid "Python"
 msgstr ""
 
-#: modules/computer.c:206
+#: modules/computer.c:214
 msgid "Python2"
 msgstr ""
 
-#: modules/computer.c:207
+#: modules/computer.c:215
 msgid "Python3"
 msgstr ""
 
-#: modules/computer.c:208
+#: modules/computer.c:216
 msgid "Perl"
 msgstr ""
 
-#: modules/computer.c:209
+#: modules/computer.c:217
 msgid "Perl6 (VM)"
 msgstr ""
 
-#: modules/computer.c:210
+#: modules/computer.c:218
 msgid "Perl6"
 msgstr ""
 
-#: modules/computer.c:211
+#: modules/computer.c:219
 msgid "PHP"
 msgstr ""
 
-#: modules/computer.c:212
+#: modules/computer.c:220
 msgid "Ruby"
 msgstr ""
 
-#: modules/computer.c:213
+#: modules/computer.c:221
 msgid "Bash"
 msgstr ""
 
-#: modules/computer.c:214
+#: modules/computer.c:222
 msgid "Compilers"
 msgstr ""
 
-#: modules/computer.c:215
+#: modules/computer.c:223
 msgid "C (GCC)"
 msgstr ""
 
-#: modules/computer.c:216
+#: modules/computer.c:224
 msgid "C (Clang)"
 msgstr ""
 
-#: modules/computer.c:217
+#: modules/computer.c:225
 msgid "D (dmd)"
 msgstr ""
 
-#: modules/computer.c:218
+#: modules/computer.c:226
 msgid "Gambas3 (gbc3)"
 msgstr ""
 
-#: modules/computer.c:219
+#: modules/computer.c:227
 msgid "Java"
 msgstr ""
 
-#: modules/computer.c:220
+#: modules/computer.c:228
 msgid "CSharp (Mono, old)"
 msgstr ""
 
-#: modules/computer.c:221
+#: modules/computer.c:229
 msgid "CSharp (Mono)"
 msgstr ""
 
-#: modules/computer.c:222
+#: modules/computer.c:230
 msgid "Vala"
 msgstr ""
 
-#: modules/computer.c:223
+#: modules/computer.c:231
 msgid "Haskell (GHC)"
 msgstr ""
 
-#: modules/computer.c:224
+#: modules/computer.c:232
 msgid "FreePascal"
 msgstr ""
 
-#: modules/computer.c:225
+#: modules/computer.c:233
 msgid "Go"
 msgstr ""
 
-#: modules/computer.c:226
+#: modules/computer.c:234
 msgid "Tools"
 msgstr ""
 
-#: modules/computer.c:227
+#: modules/computer.c:235
 msgid "make"
 msgstr ""
 
-#: modules/computer.c:228
+#: modules/computer.c:236
 msgid "GDB"
 msgstr ""
 
-#: modules/computer.c:229
+#: modules/computer.c:237
 msgid "strace"
 msgstr ""
 
-#: modules/computer.c:230
+#: modules/computer.c:238
 msgid "valgrind"
 msgstr ""
 
-#: modules/computer.c:231
+#: modules/computer.c:239
 msgid "QMake"
 msgstr ""
 
-#: modules/computer.c:232
+#: modules/computer.c:240
 msgid "CMake"
 msgstr ""
 
-#: modules/computer.c:233
+#: modules/computer.c:241
 msgid "Gambas3 IDE"
 msgstr ""
 
-#: modules/computer.c:274
+#: modules/computer.c:282
 msgid "Not found"
 msgstr ""
 
-#: modules/computer.c:279
+#: modules/computer.c:287
 #, c-format
 msgid "Detecting version: %s"
 msgstr ""
 
-#: modules/computer.c:296
+#: modules/computer.c:304
 msgid "Program"
 msgstr ""
 
-#: modules/computer.c:308
-msgid "Invalid chassis type (0)"
-msgstr ""
-
-#: modules/computer.c:309 modules/computer.c:310
-msgid "Unknown chassis type"
-msgstr ""
-
-#: modules/computer.c:311
-msgid "Desktop"
-msgstr ""
-
-#: modules/computer.c:312
-msgid "Low-profile Desktop"
-msgstr ""
-
-#: modules/computer.c:313
-msgid "Pizza Box"
-msgstr ""
-
-#: modules/computer.c:314
-msgid "Mini Tower"
-msgstr ""
-
-#: modules/computer.c:315
-msgid "Tower"
-msgstr ""
-
-#: modules/computer.c:316
-msgid "Portable"
-msgstr ""
-
-#: modules/computer.c:317 modules/computer.c:341 modules/computer.c:350
-#: modules/computer.c:372
-msgid "Laptop"
-msgstr ""
-
-#: modules/computer.c:318
-msgid "Notebook"
-msgstr ""
-
-#: modules/computer.c:319
-msgid "Handheld"
-msgstr ""
-
-#: modules/computer.c:320
-msgid "Docking Station"
-msgstr ""
-
-#: modules/computer.c:321
-msgid "All-in-one"
-msgstr ""
-
-#: modules/computer.c:322
-msgid "Subnotebook"
-msgstr ""
-
-#: modules/computer.c:323
-msgid "Space-saving"
-msgstr ""
-
 #: modules/computer.c:324
-msgid "Lunch Box"
-msgstr ""
-
-#: modules/computer.c:325
-msgid "Main Server Chassis"
-msgstr ""
-
-#: modules/computer.c:326
-msgid "Expansion Chassis"
-msgstr ""
-
-#: modules/computer.c:327
-msgid "Sub Chassis"
-msgstr ""
-
-#: modules/computer.c:328
-msgid "Bus Expansion Chassis"
-msgstr ""
-
-#: modules/computer.c:329
-msgid "Peripheral Chassis"
-msgstr ""
-
-#: modules/computer.c:330
-msgid "RAID Chassis"
-msgstr ""
-
-#: modules/computer.c:331
-msgid "Rack Mount Chassis"
-msgstr ""
-
-#: modules/computer.c:332
-msgid "Sealed-case PC"
+msgid "Single-board computer"
 msgstr ""
 
 #. /proc/apm
-#. FIXME: use dmidecode if available to get chassis type
-#: modules/computer.c:386
+#: modules/computer.c:373
 msgid "Unknown physical machine type"
 msgstr ""
 
-#: modules/computer.c:470 modules/computer.c:709
+#: modules/computer.c:393 modules/computer.c:394
+msgid "Virtual (VMware)"
+msgstr ""
+
+#: modules/computer.c:396 modules/computer.c:397 modules/computer.c:398
+#: modules/computer.c:399
+msgid "Virtual (QEMU)"
+msgstr ""
+
+#: modules/computer.c:401 modules/computer.c:402
+msgid "Virtual (Unknown)"
+msgstr ""
+
+#: modules/computer.c:404 modules/computer.c:405 modules/computer.c:406
+#: modules/computer.c:427
+msgid "Virtual (VirtualBox)"
+msgstr ""
+
+#: modules/computer.c:408 modules/computer.c:409 modules/computer.c:410
+#: modules/computer.c:421
+msgid "Virtual (Xen)"
+msgstr ""
+
+#: modules/computer.c:412
+msgid "Virtual (hypervisor present)"
+msgstr ""
+
+#: modules/computer.c:465 modules/computer.c:769
 msgid "Computer"
 msgstr ""
 
-#: modules/computer.c:471 modules/devices/alpha/processor.c:87
-#: modules/devices/arm/processor.c:236 modules/devices.c:95
+#: modules/computer.c:466 modules/devices/alpha/processor.c:87
+#: modules/devices/arm/processor.c:327 modules/devices.c:98
 #: modules/devices/ia64/processor.c:159 modules/devices/m68k/processor.c:83
 #: modules/devices/mips/processor.c:74 modules/devices/parisc/processor.c:154
 #: modules/devices/ppc/processor.c:157 modules/devices/riscv/processor.c:181
 #: modules/devices/s390/processor.c:131 modules/devices/sh/processor.c:83
-#: modules/devices/sparc/processor.c:74 modules/devices/x86/processor.c:409
+#: modules/devices/sparc/processor.c:74 modules/devices/x86/processor.c:644
 msgid "Processor"
 msgstr ""
 
-#: modules/computer.c:474
+#: modules/computer.c:469
 msgid "Machine Type"
 msgstr ""
 
-#: modules/computer.c:477 modules/computer.c:514
+#: modules/computer.c:472 modules/computer.c:508
 msgid "User Name"
 msgstr ""
 
-#: modules/computer.c:482 modules/computer.c:591
+#: modules/computer.c:477
 msgid "Resolution"
 msgstr ""
 
-#: modules/computer.c:483 modules/computer.c:592
+#: modules/computer.c:477 modules/computer.c:607
 #, c-format
 msgid "%dx%d pixels"
 msgstr ""
 
-#: modules/computer.c:485
-msgid "OpenGL Renderer"
+#: modules/computer.c:480
+msgid "Session Display Server"
 msgstr ""
 
-#: modules/computer.c:486
-msgid "X11 Vendor"
-msgstr ""
-
-#: modules/computer.c:491 modules/devices.c:102
+#: modules/computer.c:485 modules/devices.c:106
 msgid "Input Devices"
 msgstr ""
 
-#: modules/computer.c:493 modules/computer.c:752 modules/devices.c:99
-msgid "Printers"
-msgstr ""
-
-#: modules/computer.c:495 modules/computer.c:752 modules/devices.c:103
-msgid "Storage"
-msgstr ""
-
-#: modules/computer.c:506
+#: modules/computer.c:500
 msgid "Kernel"
 msgstr ""
 
-#: modules/computer.c:508
+#: modules/computer.c:502
 msgid "C Library"
 msgstr ""
 
-#: modules/computer.c:509
+#: modules/computer.c:503
 msgid "Distribution"
 msgstr ""
 
-#: modules/computer.c:512
+#: modules/computer.c:506
 msgid "Current Session"
 msgstr ""
 
-#: modules/computer.c:513
+#: modules/computer.c:507
 msgid "Computer Name"
 msgstr ""
 
-#: modules/computer.c:515 modules/computer/languages.c:108
+#: modules/computer.c:509 modules/computer/languages.c:108
 msgid "Language"
 msgstr ""
 
-#: modules/computer.c:516 modules/computer/users.c:50
+#: modules/computer.c:510 modules/computer/users.c:50
 msgid "Home Directory"
 msgstr ""
 
-#: modules/computer.c:519 modules/devices/usb.c:87 modules/devices/usb.c:234
-#: modules/devices/usb.c:351
+#: modules/computer.c:513
 msgid "Misc"
 msgstr ""
 
-#: modules/computer.c:532
+#: modules/computer.c:526
 msgid "Loaded Modules"
 msgstr ""
 
-#: modules/computer.c:535 modules/computer/modules.c:145
-#: modules/computer/modules.c:147 modules/devices/arm/processor.c:337
-#: modules/devices.c:559 modules/devices/x86/processor.c:456
+#: modules/computer.c:529 modules/computer/modules.c:145
+#: modules/computer/modules.c:147 modules/devices/arm/processor.c:448
+#: modules/devices.c:575
 msgid "Description"
 msgstr ""
 
-#: modules/computer.c:548
+#: modules/computer.c:542
 msgid "Date & Time"
 msgstr ""
 
-#: modules/computer.c:549
+#: modules/computer.c:543
 msgid "Kernel Version"
 msgstr ""
 
-#: modules/computer.c:559
+#: modules/computer.c:553
 msgid "Available Languages"
 msgstr ""
 
-#: modules/computer.c:561
+#: modules/computer.c:555
 msgid "Language Code"
 msgstr ""
 
-#: modules/computer.c:573
+#: modules/computer.c:567
 msgid "Mounted File Systems"
 msgstr ""
 
-#: modules/computer.c:575 modules/computer/filesystem.c:85
+#: modules/computer.c:569 modules/computer/filesystem.c:85
 msgid "Mount Point"
 msgstr ""
 
-#: modules/computer.c:576
+#: modules/computer.c:570
 msgid "Usage"
 msgstr ""
 
-#: modules/computer.c:577
+#: modules/computer.c:571 modules/devices/gpu.c:93 modules/devices/gpu.c:101
+#: modules/devices/gpu.c:187 modules/devices/pci.c:70 modules/devices/pci.c:78
+#: modules/devices/pci.c:122 modules/devices/usb.c:72
 msgid "Device"
 msgstr ""
 
-#: modules/computer.c:594 modules/computer.c:601
+#: modules/computer.c:590
+msgid "Session"
+msgstr ""
+
+#: modules/computer.c:591 modules/devices.c:614 modules/devices/dmi.c:53
+#: modules/devices/inputdevices.c:117
+msgid "Type"
+msgstr ""
+
+#: modules/computer.c:594
+msgid "Wayland"
+msgstr ""
+
+#: modules/computer.c:595 modules/computer.c:600
+msgid "Current Display Name"
+msgstr ""
+
+#: modules/computer.c:599
+msgid "X Server"
+msgstr ""
+
+#: modules/computer.c:601 modules/computer.c:641 modules/devices/dmi.c:39
+#: modules/devices/dmi.c:43 modules/devices/dmi.c:47 modules/devices/dmi.c:52
+#: modules/devices/gpu.c:92 modules/devices/gpu.c:100 modules/devices/gpu.c:186
 #: modules/devices/ia64/processor.c:161 modules/devices/inputdevices.c:119
-#: modules/devices/pci.c:225 modules/devices/usb.c:349
-#: modules/devices/x86/processor.c:416
+#: modules/devices/pci.c:69 modules/devices/pci.c:77 modules/devices/usb.c:64
+#: modules/devices/x86/processor.c:651
 msgid "Vendor"
 msgstr ""
 
-#: modules/computer.c:598
-msgid "Monitors"
+#: modules/computer.c:603
+msgid "Release Number"
 msgstr ""
 
-#: modules/computer.c:600
-msgid "OpenGL"
+#: modules/computer.c:611
+msgid "Screens"
 msgstr ""
 
-#: modules/computer.c:602
-msgid "Renderer"
+#: modules/computer.c:617
+msgid "Disconnected"
 msgstr ""
 
-#: modules/computer.c:604
-msgid "Direct Rendering"
+#: modules/computer.c:620
+msgid "Connected"
 msgstr ""
 
-#: modules/computer.c:608
-msgid "Extensions"
+#: modules/computer.c:624 modules/computer/os.c:78 modules/computer/os.c:234
+#: modules/computer/os.c:392 modules/devices.c:344 modules/devices.c:396
+#: modules/devices/printers.c:99 modules/devices/printers.c:106
+#: modules/devices/printers.c:116 modules/devices/printers.c:131
+#: modules/devices/printers.c:140 modules/devices/printers.c:243
+msgid "Unknown"
 msgstr ""
 
 #: modules/computer.c:628
+msgid "Unused"
+msgstr ""
+
+#: modules/computer.c:629
+#, c-format
+msgid "%dx%d pixels, offset (%d, %d)"
+msgstr ""
+
+#: modules/computer.c:638
+msgid "Outputs (XRandR)"
+msgstr ""
+
+#: modules/computer.c:640
+msgid "OpenGL (GLX)"
+msgstr ""
+
+#: modules/computer.c:642
+msgid "Renderer"
+msgstr ""
+
+#: modules/computer.c:643
+msgid "Direct Rendering"
+msgstr ""
+
+#: modules/computer.c:645
+msgid "Version (Compatibility)"
+msgstr ""
+
+#: modules/computer.c:646
+msgid "Shading Language Version (Compatibility)"
+msgstr ""
+
+#: modules/computer.c:647
+msgid "Version (Core)"
+msgstr ""
+
+#: modules/computer.c:648
+msgid "Shading Language Version (Core)"
+msgstr ""
+
+#: modules/computer.c:649
+msgid "Version (ES)"
+msgstr ""
+
+#: modules/computer.c:650
+msgid "Shading Language Version (ES)"
+msgstr ""
+
+#: modules/computer.c:651
+msgid "GLX Version"
+msgstr ""
+
+#: modules/computer.c:672
 msgid "Group"
 msgstr ""
 
-#: modules/computer.c:631 modules/computer/users.c:49
+#: modules/computer.c:675 modules/computer/users.c:49
 msgid "Group ID"
 msgstr ""
 
-#: modules/computer.c:751
+#: modules/computer.c:811
 msgid "RAM"
 msgstr ""
 
-#: modules/computer.c:751 modules/devices/devicetree/pmac_data.c:82
+#: modules/computer.c:811 modules/devices/devicetree/pmac_data.c:82
 msgid "Motherboard"
 msgstr ""
 
-#: modules/computer.c:751
+#: modules/computer.c:811
 msgid "Graphics"
 msgstr ""
 
-#: modules/computer.c:752
+#: modules/computer.c:812 modules/devices.c:107
+msgid "Storage"
+msgstr ""
+
+#: modules/computer.c:812 modules/devices.c:103
+msgid "Printers"
+msgstr ""
+
+#: modules/computer.c:812
 msgid "Audio"
 msgstr ""
 
-#: modules/computer.c:807
+#: modules/computer.c:857
 msgid "Gathers high-level computer information"
-msgstr ""
-
-#: modules/computer/display.c:122
-#, c-format
-msgid "Monitor %d=%dx%d pixels\n"
 msgstr ""
 
 #: modules/computer/filesystem.c:83
@@ -1202,13 +1526,13 @@ msgstr ""
 msgid "Territory"
 msgstr ""
 
-#: modules/computer/languages.c:110 modules/devices/arm/processor.c:250
-#: modules/devices/ia64/processor.c:166 modules/devices/ppc/processor.c:159
-#: modules/devices/usb.c:236
+#: modules/computer/languages.c:110 modules/devices/arm/processor.c:341
+#: modules/devices/gpu.c:146 modules/devices/ia64/processor.c:166
+#: modules/devices/pci.c:114 modules/devices/ppc/processor.c:159
 msgid "Revision"
 msgstr ""
 
-#: modules/computer/languages.c:111
+#: modules/computer/languages.c:111 modules/devices/dmi.c:42
 msgid "Date"
 msgstr ""
 
@@ -1222,7 +1546,7 @@ msgstr ""
 
 #: modules/computer/modules.c:125 modules/computer/modules.c:126
 #: modules/computer/modules.c:127 modules/computer/modules.c:128
-#: modules/computer/modules.c:129
+#: modules/computer/modules.c:129 modules/devices/dmi.c:115
 msgid "(Not available)"
 msgstr ""
 
@@ -1238,7 +1562,7 @@ msgstr ""
 msgid "Used Memory"
 msgstr ""
 
-#: modules/computer/modules.c:144
+#: modules/computer/modules.c:144 modules/devices/devmemory.c:72
 msgid "KiB"
 msgstr ""
 
@@ -1273,14 +1597,6 @@ msgstr ""
 
 #: modules/computer/os.c:40
 msgid "diet libc"
-msgstr ""
-
-#: modules/computer/os.c:78 modules/computer/os.c:234 modules/computer/os.c:359
-#: modules/devices.c:333 modules/devices.c:387 modules/devices/printers.c:99
-#: modules/devices/printers.c:106 modules/devices/printers.c:116
-#: modules/devices/printers.c:131 modules/devices/printers.c:140
-#: modules/devices/printers.c:243
-msgid "Unknown"
 msgstr ""
 
 #: modules/computer/os.c:112 modules/computer/os.c:115
@@ -1329,11 +1645,6 @@ msgstr ""
 msgid "%d bits (healthy)"
 msgstr ""
 
-#: modules/computer/os.c:279 modules/devices/usb.c:48 modules/devices/usb.c:307
-#: modules/devices/usb.c:310 modules/network/net.c:442 includes/cpu_util.h:11
-msgid "(Unknown)"
-msgstr ""
-
 #: modules/computer/users.c:47
 msgid "User Information"
 msgstr ""
@@ -1346,12 +1657,13 @@ msgstr ""
 msgid "Default Shell"
 msgstr ""
 
-#: modules/devices/alpha/processor.c:88 modules/devices/devicetree.c:141
-#: modules/devices/devicetree.c:176 modules/devices/devicetree/pmac_data.c:80
-#: modules/devices/ia64/processor.c:165 modules/devices/m68k/processor.c:84
-#: modules/devices/mips/processor.c:75 modules/devices/parisc/processor.c:155
-#: modules/devices/ppc/processor.c:158 modules/devices/riscv/processor.c:182
-#: modules/devices/s390/processor.c:132 modules/devices/spd-decode.c:1510
+#: modules/devices/alpha/processor.c:88 modules/devices/devicetree.c:161
+#: modules/devices/devicetree.c:207 modules/devices/devicetree/pmac_data.c:80
+#: modules/devices/gpu.c:124 modules/devices/ia64/processor.c:165
+#: modules/devices/m68k/processor.c:84 modules/devices/mips/processor.c:75
+#: modules/devices/parisc/processor.c:155 modules/devices/ppc/processor.c:158
+#: modules/devices/riscv/processor.c:182 modules/devices/s390/processor.c:132
+#: modules/devices/spd-decode.c:1510
 msgid "Model"
 msgstr ""
 
@@ -1359,44 +1671,28 @@ msgstr ""
 msgid "Platform String"
 msgstr ""
 
-#: modules/devices/alpha/processor.c:90 modules/devices/arm/processor.c:240
+#: modules/devices/alpha/processor.c:90 modules/devices/arm/processor.c:331
 #: modules/devices/ia64/processor.c:167 modules/devices/m68k/processor.c:87
 #: modules/devices/mips/processor.c:77 modules/devices/parisc/processor.c:158
-#: modules/devices/pci.c:108 modules/devices/ppc/processor.c:160
-#: modules/devices/riscv/processor.c:186 modules/devices/sh/processor.c:87
-#: modules/devices/x86/processor.c:420
+#: modules/devices/ppc/processor.c:160 modules/devices/riscv/processor.c:186
+#: modules/devices/sh/processor.c:87 modules/devices/x86/processor.c:655
 msgid "Frequency"
 msgstr ""
 
-#: modules/devices/alpha/processor.c:90 modules/devices/arm/processor.c:240
-#: modules/devices/arm/processor.c:365 modules/devices.c:299
-#: modules/devices.c:307 modules/devices.c:335
-#: modules/devices/ia64/processor.c:167 modules/devices/ia64/processor.c:196
-#: modules/devices/m68k/processor.c:87 modules/devices/mips/processor.c:77
-#: modules/devices/parisc/processor.c:158
-#: modules/devices/parisc/processor.c:191 modules/devices/pci.c:108
-#: modules/devices/ppc/processor.c:160 modules/devices/ppc/processor.c:187
-#: modules/devices/riscv/processor.c:186 modules/devices/riscv/processor.c:214
-#: modules/devices/s390/processor.c:160 modules/devices/sh/processor.c:87
-#: modules/devices/sh/processor.c:88 modules/devices/sh/processor.c:89
-#: modules/devices/x86/processor.c:420 modules/devices/x86/processor.c:479
-msgid "MHz"
-msgstr ""
-
-#: modules/devices/alpha/processor.c:91 modules/devices/arm/processor.c:241
+#: modules/devices/alpha/processor.c:91 modules/devices/arm/processor.c:332
 #: modules/devices/ia64/processor.c:168 modules/devices/m68k/processor.c:88
 #: modules/devices/mips/processor.c:78 modules/devices/parisc/processor.c:159
 #: modules/devices/ppc/processor.c:161 modules/devices/s390/processor.c:134
-#: modules/devices/sh/processor.c:90 modules/devices/x86/processor.c:421
+#: modules/devices/sh/processor.c:90 modules/devices/x86/processor.c:656
 msgid "BogoMips"
 msgstr ""
 
-#: modules/devices/alpha/processor.c:92 modules/devices/arm/processor.c:242
+#: modules/devices/alpha/processor.c:92 modules/devices/arm/processor.c:333
 #: modules/devices/ia64/processor.c:169 modules/devices/m68k/processor.c:89
 #: modules/devices/mips/processor.c:79 modules/devices/parisc/processor.c:160
 #: modules/devices/ppc/processor.c:162 modules/devices/riscv/processor.c:187
 #: modules/devices/s390/processor.c:135 modules/devices/sh/processor.c:91
-#: modules/devices/sparc/processor.c:77 modules/devices/x86/processor.c:422
+#: modules/devices/sparc/processor.c:77 modules/devices/x86/processor.c:657
 msgid "Byte Order"
 msgstr ""
 
@@ -1575,61 +1871,67 @@ msgid "ARM Processor"
 msgstr ""
 
 #: modules/devices/arm/processor.c:200 modules/devices/riscv/processor.c:147
-#: modules/devices/x86/processor.c:371
+#: modules/devices/x86/processor.c:606
 msgid "Empty List"
 msgstr ""
 
-#: modules/devices/arm/processor.c:237
+#: modules/devices/arm/processor.c:226 modules/devices/x86/processor.c:268
+msgid "Clocks"
+msgstr ""
+
+#: modules/devices/arm/processor.c:272 modules/devices/arm/processor.c:285
+#: modules/devices/x86/processor.c:314 modules/devices/x86/processor.c:327
+#, c-format
+msgid "%.2f-%.2f %s=%dx\n"
+msgstr ""
+
+#: modules/devices/arm/processor.c:328
 msgid "Linux Name"
 msgstr ""
 
-#: modules/devices/arm/processor.c:238
+#: modules/devices/arm/processor.c:329
 msgid "Decoded Name"
 msgstr ""
 
-#: modules/devices/arm/processor.c:239 modules/network/net.c:458
+#: modules/devices/arm/processor.c:330 modules/network/net.c:453
 msgid "Mode"
 msgstr ""
 
-#: modules/devices/arm/processor.c:245
+#: modules/devices/arm/processor.c:336
 msgid "ARM"
 msgstr ""
 
-#: modules/devices/arm/processor.c:246
+#: modules/devices/arm/processor.c:337
 msgid "Implementer"
 msgstr ""
 
-#: modules/devices/arm/processor.c:247
+#: modules/devices/arm/processor.c:338
 msgid "Part"
 msgstr ""
 
-#: modules/devices/arm/processor.c:248 modules/devices/ia64/processor.c:162
+#: modules/devices/arm/processor.c:339 modules/devices/ia64/processor.c:162
 #: modules/devices/parisc/processor.c:156 modules/devices/riscv/processor.c:183
 msgid "Architecture"
 msgstr ""
 
-#: modules/devices/arm/processor.c:249
+#: modules/devices/arm/processor.c:340
 msgid "Variant"
 msgstr ""
 
-#: modules/devices/arm/processor.c:251 modules/devices/riscv/processor.c:190
-#: modules/devices/sparc/processor.c:78 modules/devices/x86/processor.c:428
+#: modules/devices/arm/processor.c:342 modules/devices/riscv/processor.c:190
+#: modules/devices/sparc/processor.c:78 modules/devices/x86/processor.c:663
 msgid "Capabilities"
 msgstr ""
 
-#: modules/devices/arm/processor.c:335
+#: modules/devices/arm/processor.c:446
 msgid "SOC/Package"
 msgstr ""
 
-#: modules/devices/arm/processor.c:338 modules/devices/cpu_util.c:222
-msgid "Topology"
+#: modules/devices/arm/processor.c:450 modules/devices/x86/processor.c:698
+msgid "Logical CPU Config"
 msgstr ""
 
-#: modules/devices/arm/processor.c:339
-msgid "Clocks"
-msgstr ""
-
-#: modules/devices/arm/processor.c:354
+#: modules/devices/arm/processor.c:467
 msgid "SOC/Package Information"
 msgstr ""
 
@@ -1688,54 +1990,57 @@ msgid ""
 "No batteries found on this system=\n"
 msgstr ""
 
-#: modules/devices.c:97
+#: modules/devices.c:100
+msgid "Graphics Processors"
+msgstr ""
+
+#: modules/devices.c:101 modules/devices/pci.c:143
 msgid "PCI Devices"
 msgstr ""
 
-#: modules/devices.c:98 modules/devices/usb.c:117 modules/devices/usb.c:156
-#: modules/devices/usb.c:415
+#: modules/devices.c:102 modules/devices/usb.c:92
 msgid "USB Devices"
 msgstr ""
 
-#: modules/devices.c:100
+#: modules/devices.c:104
 msgid "Battery"
 msgstr ""
 
-#: modules/devices.c:101
+#: modules/devices.c:105
 msgid "Sensors"
 msgstr ""
 
-#: modules/devices.c:105
+#: modules/devices.c:109
 msgid "DMI"
 msgstr ""
 
-#: modules/devices.c:106
+#: modules/devices.c:110
 msgid "Memory SPD"
 msgstr ""
 
-#: modules/devices.c:111
+#: modules/devices.c:115
 msgid "Device Tree"
 msgstr ""
 
-#: modules/devices.c:113
+#: modules/devices.c:117
 msgid "Resources"
 msgstr ""
 
-#: modules/devices.c:151
+#: modules/devices.c:162
 #, c-format
 msgid "%d physical processor"
 msgid_plural "%d physical processors"
 msgstr[0] ""
 msgstr[1] ""
 
-#: modules/devices.c:152
+#: modules/devices.c:163
 #, c-format
 msgid "%d core"
 msgid_plural "%d cores"
 msgstr[0] ""
 msgstr[1] ""
 
-#: modules/devices.c:153
+#: modules/devices.c:164
 #, c-format
 msgid "%d thread"
 msgid_plural "%d threads"
@@ -1743,211 +2048,111 @@ msgstr[0] ""
 msgstr[1] ""
 
 #. /NP procs; NC cores; NT threads
-#: modules/devices.c:154
+#: modules/devices.c:165
 #, c-format
 msgid "%s; %s; %s"
 msgstr ""
 
-#: modules/devices.c:372
-msgid " (model unknown)"
-msgstr ""
-
-#: modules/devices.c:374
-msgid " (vendor unknown)"
-msgstr ""
-
-#: modules/devices.c:559
+#: modules/devices.c:575
 msgid "Field"
 msgstr ""
 
-#: modules/devices.c:559 modules/devices.c:591
+#: modules/devices.c:575 modules/devices.c:614
 msgid "Value"
 msgstr ""
 
-#: modules/devices.c:591
+#: modules/devices.c:614
 msgid "Sensor"
 msgstr ""
 
-#: modules/devices.c:591 modules/devices/inputdevices.c:117
-msgid "Type"
-msgstr ""
-
-#: modules/devices.c:637
+#: modules/devices.c:661
 msgid "Devices"
 msgstr ""
 
-#: modules/devices.c:649
+#: modules/devices.c:673
 msgid "Update PCI ID listing"
 msgstr ""
 
-#: modules/devices.c:661
+#: modules/devices.c:685
 msgid "Update CPU feature database"
 msgstr ""
 
-#: modules/devices.c:689
+#: modules/devices.c:713
 msgid "Gathers information about hardware devices"
 msgstr ""
 
-#: modules/devices.c:708
+#: modules/devices.c:732
 msgid "Resource information requires superuser privileges"
 msgstr ""
 
-#: modules/devices/cpu_util.c:30
-msgid "Little Endian"
-msgstr ""
-
-#: modules/devices/cpu_util.c:32
-msgid "Big Endian"
-msgstr ""
-
-#: modules/devices/cpu_util.c:178 modules/devices/cpu_util.c:189
-msgid "Frequency Scaling"
-msgstr ""
-
-#: modules/devices/cpu_util.c:179
-msgid "Minimum"
-msgstr ""
-
-#: modules/devices/cpu_util.c:179 modules/devices/cpu_util.c:180
-#: modules/devices/cpu_util.c:181
-msgid "kHz"
-msgstr ""
-
-#: modules/devices/cpu_util.c:180
-msgid "Maximum"
-msgstr ""
-
-#: modules/devices/cpu_util.c:181
-msgid "Current"
-msgstr ""
-
-#: modules/devices/cpu_util.c:182
-msgid "Transition Latency"
-msgstr ""
-
-#: modules/devices/cpu_util.c:182
-msgid "ns"
-msgstr ""
-
-#: modules/devices/cpu_util.c:183
-msgid "Governor"
-msgstr ""
-
-#: modules/devices/cpu_util.c:184 modules/devices/cpu_util.c:190
-msgid "Driver"
-msgstr ""
-
-#: modules/devices/cpu_util.c:196 modules/devices/x86/processor.c:297
-msgid "(Not Available)"
-msgstr ""
-
-#: modules/devices/cpu_util.c:204 modules/devices/cpu_util.c:206
-msgid "Socket"
-msgstr ""
-
-#: modules/devices/cpu_util.c:209 modules/devices/cpu_util.c:211
-msgid "Core"
-msgstr ""
-
-#: modules/devices/cpu_util.c:214
-msgid "Book"
-msgstr ""
-
-#: modules/devices/cpu_util.c:216
-msgid "Drawer"
-msgstr ""
-
-#: modules/devices/cpu_util.c:223
-msgid "ID"
-msgstr ""
-
-#: modules/devices/devicetree.c:47
+#: modules/devices/devicetree.c:50
 msgid "Properties"
 msgstr ""
 
-#: modules/devices/devicetree.c:48
+#: modules/devices/devicetree.c:51
 msgid "Children"
 msgstr ""
 
-#: modules/devices/devicetree.c:84
+#: modules/devices/devicetree.c:87
 msgid "Node"
 msgstr ""
 
-#: modules/devices/devicetree.c:85
+#: modules/devices/devicetree.c:88
 msgid "Node Path"
 msgstr ""
 
-#: modules/devices/devicetree.c:86
+#: modules/devices/devicetree.c:89
 msgid "Alias"
 msgstr ""
 
-#: modules/devices/devicetree.c:86 modules/devices/devicetree.c:87
+#: modules/devices/devicetree.c:89 modules/devices/devicetree.c:90
 msgid "(None)"
 msgstr ""
 
-#: modules/devices/devicetree.c:87
+#: modules/devices/devicetree.c:90
 msgid "Symbol"
 msgstr ""
 
-#: modules/devices/devicetree.c:132 modules/devices/devicetree/pmac_data.c:79
+#: modules/devices/devicetree.c:143 modules/devices/devicetree/pmac_data.c:79
 msgid "Platform"
 msgstr ""
 
-#: modules/devices/devicetree.c:133 modules/devices/devicetree.c:178
+#: modules/devices/devicetree.c:144 modules/devices/devicetree.c:209
 msgid "Compatible"
 msgstr ""
 
-#: modules/devices/devicetree.c:134
+#: modules/devices/devicetree.c:145
 msgid "GPU-compatible"
 msgstr ""
 
-#: modules/devices/devicetree.c:140
+#: modules/devices/devicetree.c:160
 msgid "Raspberry Pi or Compatible"
 msgstr ""
 
-#: modules/devices/devicetree.c:142 modules/devices/devicetree.c:160
-#: modules/devices/devicetree.c:177 modules/devices/devicetree/rpi_data.c:160
+#: modules/devices/devicetree.c:162 modules/devices/devicetree.c:189
+#: modules/devices/devicetree.c:208 modules/devices/devicetree/rpi_data.c:161
+#: modules/devices/dmi.c:49 modules/devices/dmi.c:55
 msgid "Serial Number"
 msgstr ""
 
-#: modules/devices/devicetree.c:143 modules/devices/devicetree/rpi_data.c:157
+#: modules/devices/devicetree.c:163 modules/devices/devicetree/rpi_data.c:158
 msgid "RCode"
 msgstr ""
 
-#: modules/devices/devicetree.c:143
+#: modules/devices/devicetree.c:163
 msgid "No revision code available; unable to lookup model details."
 msgstr ""
 
-#: modules/devices/devicetree.c:159
+#: modules/devices/devicetree.c:188
 msgid "More"
 msgstr ""
 
-#: modules/devices/devicetree.c:175
-msgid "Board"
-msgstr ""
-
-#: modules/devices/devicetree.c:234
+#: modules/devices/devicetree.c:268
 msgid "Messages"
-msgstr ""
-
-#: modules/devices/devicetree/dt_util.c:1013
-msgid "phandle Map"
-msgstr ""
-
-#: modules/devices/devicetree/dt_util.c:1014
-msgid "Alias Map"
-msgstr ""
-
-#: modules/devices/devicetree/dt_util.c:1015
-msgid "Symbol Map"
 msgstr ""
 
 #: modules/devices/devicetree/pmac_data.c:78
 msgid "Apple Power Macintosh"
-msgstr ""
-
-#: modules/devices/devicetree/pmac_data.c:81 modules/devices/sh/processor.c:85
-msgid "Machine"
 msgstr ""
 
 #: modules/devices/devicetree/pmac_data.c:83
@@ -1966,88 +2171,179 @@ msgstr ""
 msgid "PMAC Generation"
 msgstr ""
 
-#: modules/devices/devicetree/rpi_data.c:152
 #: modules/devices/devicetree/rpi_data.c:153
+#: modules/devices/devicetree/rpi_data.c:154
 msgid "Raspberry Pi"
 msgstr ""
 
-#: modules/devices/devicetree/rpi_data.c:153
+#: modules/devices/devicetree/rpi_data.c:154
 msgid "Board Name"
 msgstr ""
 
-#: modules/devices/devicetree/rpi_data.c:154
+#: modules/devices/devicetree/rpi_data.c:155
 msgid "PCB Revision"
 msgstr ""
 
-#: modules/devices/devicetree/rpi_data.c:155
+#: modules/devices/devicetree/rpi_data.c:156
 msgid "Introduction"
 msgstr ""
 
-#: modules/devices/devicetree/rpi_data.c:156 modules/devices/spd-decode.c:1510
-#: modules/devices/usb.c:84 modules/devices/usb.c:217
+#: modules/devices/devicetree/rpi_data.c:157 modules/devices/spd-decode.c:1510
 msgid "Manufacturer"
 msgstr ""
 
-#: modules/devices/devicetree/rpi_data.c:158
+#: modules/devices/devicetree/rpi_data.c:159
 msgid "SOC (spec)"
 msgstr ""
 
-#: modules/devices/devicetree/rpi_data.c:159
+#: modules/devices/devicetree/rpi_data.c:160
 msgid "Memory (spec)"
 msgstr ""
 
-#: modules/devices/devicetree/rpi_data.c:161
+#: modules/devices/devicetree/rpi_data.c:162
 msgid "Permanent overvolt bit"
 msgstr ""
 
-#: modules/devices/devicetree/rpi_data.c:161
+#: modules/devices/devicetree/rpi_data.c:162
 msgctxt "rpi-ov-bit"
 msgid "Set"
 msgstr ""
 
-#: modules/devices/devicetree/rpi_data.c:161
+#: modules/devices/devicetree/rpi_data.c:162
 msgctxt "rpi-ov-bit"
 msgid "Not set"
 msgstr ""
 
-#: modules/devices/devmemory.c:93
+#: modules/devices/devmemory.c:101
 msgid "Total Memory"
 msgstr ""
 
-#: modules/devices/devmemory.c:94
+#: modules/devices/devmemory.c:102
 msgid "Free Memory"
 msgstr ""
 
-#: modules/devices/devmemory.c:95
+#: modules/devices/devmemory.c:103
 msgid "Cached Swap"
 msgstr ""
 
-#: modules/devices/devmemory.c:96
+#: modules/devices/devmemory.c:104
 msgid "High Memory"
 msgstr ""
 
-#: modules/devices/devmemory.c:97
+#: modules/devices/devmemory.c:105
 msgid "Free High Memory"
 msgstr ""
 
-#: modules/devices/devmemory.c:98
+#: modules/devices/devmemory.c:106
 msgid "Low Memory"
 msgstr ""
 
-#: modules/devices/devmemory.c:99
+#: modules/devices/devmemory.c:107
 msgid "Free Low Memory"
 msgstr ""
 
-#: modules/devices/devmemory.c:100
+#: modules/devices/devmemory.c:108
 msgid "Virtual Memory"
 msgstr ""
 
-#: modules/devices/devmemory.c:101
+#: modules/devices/devmemory.c:109
 msgid "Free Virtual Memory"
 msgstr ""
 
-#: modules/devices/dmi.c:188
+#: modules/devices/dmi.c:36 modules/devices/inputdevices.c:120
+#: modules/devices/usb.c:63
+msgid "Product"
+msgstr ""
+
+#: modules/devices/dmi.c:38 modules/devices/ia64/processor.c:164
+#: modules/devices/sh/processor.c:86
+msgid "Family"
+msgstr ""
+
+#: modules/devices/dmi.c:41
+msgid "BIOS"
+msgstr ""
+
+#: modules/devices/dmi.c:50 modules/devices/dmi.c:56
+msgid "Asset Tag"
+msgstr ""
+
+#: modules/devices/dmi.c:51
+msgid "Chassis"
+msgstr ""
+
+#: modules/devices/dmi.c:116
 msgid "(Not available; Perhaps try running HardInfo as root.)"
+msgstr ""
+
+#: modules/devices/gpu.c:102 modules/devices/pci.c:79
+msgid "SVendor"
+msgstr ""
+
+#: modules/devices/gpu.c:103 modules/devices/pci.c:80
+msgid "SDevice"
+msgstr ""
+
+#: modules/devices/gpu.c:111 modules/devices/pci.c:90
+msgid "PCI Express"
+msgstr ""
+
+#: modules/devices/gpu.c:112 modules/devices/pci.c:92
+msgid "Maximum Link Width"
+msgstr ""
+
+#: modules/devices/gpu.c:113 modules/devices/pci.c:94
+msgid "Maximum Link Speed"
+msgstr ""
+
+#: modules/devices/gpu.c:113 modules/devices/pci.c:93 modules/devices/pci.c:94
+msgid "GT/s"
+msgstr ""
+
+#: modules/devices/gpu.c:123
+msgid "NVIDIA"
+msgstr ""
+
+#: modules/devices/gpu.c:125
+msgid "BIOS Version"
+msgstr ""
+
+#: modules/devices/gpu.c:126
+msgid "UUID"
+msgstr ""
+
+#: modules/devices/gpu.c:141 modules/devices/gpu.c:183
+#: modules/devices/inputdevices.c:115 modules/devices/pci.c:111
+#: modules/devices/usb.c:62
+msgid "Device Information"
+msgstr ""
+
+#: modules/devices/gpu.c:142 modules/devices/gpu.c:184
+msgid "Location"
+msgstr ""
+
+#: modules/devices/gpu.c:143
+msgid "DRM Device"
+msgstr ""
+
+#: modules/devices/gpu.c:144 modules/devices/pci.c:112 modules/devices/usb.c:67
+msgid "Class"
+msgstr ""
+
+#: modules/devices/gpu.c:150 modules/devices/pci.c:117
+msgid "In Use"
+msgstr ""
+
+#: modules/devices/gpu.c:174
+msgid "Unknown integrated GPU"
+msgstr ""
+
+#: modules/devices/gpu.c:185
+msgid "DT Compatibility"
+msgstr ""
+
+#: modules/devices/gpu.c:201
+msgid "GPUs"
 msgstr ""
 
 #: modules/devices/ia64/processor.c:108
@@ -2058,10 +2354,6 @@ msgstr ""
 msgid "Architecture Revision"
 msgstr ""
 
-#: modules/devices/ia64/processor.c:164 modules/devices/sh/processor.c:86
-msgid "Family"
-msgstr ""
-
 #: modules/devices/ia64/processor.c:170
 msgid "CPU regs"
 msgstr ""
@@ -2070,19 +2362,9 @@ msgstr ""
 msgid "Features"
 msgstr ""
 
-#: modules/devices/inputdevices.c:115 modules/devices/pci.c:214
-#: modules/devices/usb.c:82 modules/devices/usb.c:215 modules/devices/usb.c:347
-msgid "Device Information"
-msgstr ""
-
-#: modules/devices/inputdevices.c:118 modules/devices/usb.c:92
-#: modules/devices/usb.c:240 modules/devices/usb.c:356
+#: modules/devices/inputdevices.c:118 modules/devices/pci.c:121
+#: modules/devices/usb.c:71
 msgid "Bus"
-msgstr ""
-
-#: modules/devices/inputdevices.c:120 modules/devices/usb.c:83
-#: modules/devices/usb.c:216 modules/devices/usb.c:348
-msgid "Product"
 msgstr ""
 
 #: modules/devices/inputdevices.c:124
@@ -2125,61 +2407,31 @@ msgstr ""
 msgid "SVersion"
 msgstr ""
 
-#: modules/devices/parisc/processor.c:163 modules/devices/x86/processor.c:425
+#: modules/devices/parisc/processor.c:163 modules/devices/x86/processor.c:660
 msgid "Cache"
 msgstr ""
 
-#: modules/devices/pci.c:106
-msgid "IRQ"
+#: modules/devices/pci.c:91
+msgid "Link Width"
 msgstr ""
 
-#: modules/devices/pci.c:110
-msgid "Latency"
+#: modules/devices/pci.c:93
+msgid "Link Speed"
 msgstr ""
 
-#: modules/devices/pci.c:112
-msgid "Bus Master"
+#: modules/devices/pci.c:119 modules/devices/usb.c:70
+msgid "Connection"
 msgstr ""
 
-#: modules/devices/pci.c:118
-msgid "Kernel modules"
-msgstr ""
-
-#: modules/devices/pci.c:124
-#, c-format
-msgid "%s=%s (%s)\n"
-msgstr ""
-
-#: modules/devices/pci.c:126
-msgid "OEM Vendor"
-msgstr ""
-
-#: modules/devices/pci.c:153
-msgid "prefetchable"
-msgstr ""
-
-#: modules/devices/pci.c:154
-msgid "non-prefetchable"
-msgstr ""
-
-#: modules/devices/pci.c:163
-msgid "I/O ports at"
-msgstr ""
-
-#: modules/devices/pci.c:216 modules/devices/usb.c:89 modules/devices/usb.c:237
-#: modules/devices/usb.c:353
-msgid "Class"
-msgstr ""
-
-#: modules/devices/pci.c:217
+#: modules/devices/pci.c:120
 msgid "Domain"
 msgstr ""
 
-#: modules/devices/pci.c:218
-msgid "Bus, device, function"
+#: modules/devices/pci.c:123
+msgid "Function"
 msgstr ""
 
-#: modules/devices/pci.c:243
+#: modules/devices/pci.c:161
 msgid "No PCI devices found"
 msgstr ""
 
@@ -2405,30 +2657,30 @@ msgstr ""
 msgid "Bank"
 msgstr ""
 
-#: modules/devices/storage.c:46
+#: modules/devices/storage.c:43
 msgid ""
 "\n"
 "[SCSI Disks]\n"
 msgstr ""
 
-#: modules/devices/storage.c:110 modules/devices/storage.c:313
+#: modules/devices/storage.c:114 modules/devices/storage.c:320
 #, c-format
 msgid ""
 "[Device Information]\n"
 "Model=%s\n"
 msgstr ""
 
-#: modules/devices/storage.c:115 modules/devices/storage.c:319
+#: modules/devices/storage.c:119 modules/devices/storage.c:326
 #, c-format
 msgid "Vendor=%s (%s)\n"
 msgstr ""
 
-#: modules/devices/storage.c:120 modules/devices/storage.c:321
+#: modules/devices/storage.c:124 modules/devices/storage.c:328
 #, c-format
 msgid "Vendor=%s\n"
 msgstr ""
 
-#: modules/devices/storage.c:125
+#: modules/devices/storage.c:129
 #, c-format
 msgid ""
 "Type=%s\n"
@@ -2440,18 +2692,18 @@ msgid ""
 "LUN=%d\n"
 msgstr ""
 
-#: modules/devices/storage.c:167
+#: modules/devices/storage.c:174
 msgid ""
 "\n"
 "[IDE Disks]\n"
 msgstr ""
 
-#: modules/devices/storage.c:250
+#: modules/devices/storage.c:257
 #, c-format
 msgid "Driver=%s\n"
 msgstr ""
 
-#: modules/devices/storage.c:324
+#: modules/devices/storage.c:331
 #, c-format
 msgid ""
 "Device Name=hd%c\n"
@@ -2459,7 +2711,7 @@ msgid ""
 "Cache=%dkb\n"
 msgstr ""
 
-#: modules/devices/storage.c:334
+#: modules/devices/storage.c:341
 #, c-format
 msgid ""
 "[Geometry]\n"
@@ -2467,65 +2719,42 @@ msgid ""
 "Logical=%s\n"
 msgstr ""
 
-#: modules/devices/storage.c:344
+#: modules/devices/storage.c:351
 #, c-format
 msgid ""
 "[Capabilities]\n"
 "%s"
 msgstr ""
 
-#: modules/devices/storage.c:351
+#: modules/devices/storage.c:358
 #, c-format
 msgid ""
 "[Speeds]\n"
 "%s"
 msgstr ""
 
-#: modules/devices/usb.c:44 modules/devices/usb.c:326
-msgid "mA"
-msgstr ""
-
-#. /%.2f is version
-#: modules/devices/usb.c:53 modules/devices/usb.c:190
-#, c-format
-msgid "USB %.2f Hub"
-msgstr ""
-
-#: modules/devices/usb.c:55 modules/devices/usb.c:192
-#, c-format
-msgid "Unknown USB %.2f Device (class %d)"
-msgstr ""
-
-#: modules/devices/usb.c:85 modules/devices/usb.c:232
-msgid "Speed"
-msgstr ""
-
-#: modules/devices/usb.c:85 modules/devices/usb.c:232
-msgid "Mbit/s"
-msgstr ""
-
-#: modules/devices/usb.c:86 modules/devices/usb.c:233 modules/devices/usb.c:350
+#: modules/devices/usb.c:65
 msgid "Max Current"
 msgstr ""
 
-#: modules/devices/usb.c:88 modules/devices/usb.c:235 modules/devices/usb.c:352
+#: modules/devices/usb.c:65
+msgid "mA"
+msgstr ""
+
+#: modules/devices/usb.c:66
 msgid "USB Version"
 msgstr ""
 
-#: modules/devices/usb.c:90 modules/devices/usb.c:238 modules/devices/usb.c:354
-msgid "Vendor ID"
+#: modules/devices/usb.c:68
+msgid "Sub-class"
 msgstr ""
 
-#: modules/devices/usb.c:91 modules/devices/usb.c:239 modules/devices/usb.c:355
-msgid "Product ID"
+#: modules/devices/usb.c:69
+msgid "Device Version"
 msgstr ""
 
-#: modules/devices/usb.c:231
-msgid "Port"
-msgstr ""
-
-#: modules/devices/usb.c:241
-msgid "Level"
+#: modules/devices/usb.c:103
+msgid "No USB devices found."
 msgstr ""
 
 #: modules/devices/x86/processor.c:149
@@ -2555,40 +2784,57 @@ msgctxt "cache-type"
 msgid "Unified"
 msgstr ""
 
-#: modules/devices/x86/processor.c:410
+#: modules/devices/x86/processor.c:367
+msgid "Caches"
+msgstr ""
+
+#: modules/devices/x86/processor.c:418 modules/devices/x86/processor.c:435
+#, c-format
+msgid "Level %d (%s)#%d=%dx %dKB (%dKB), %d-way set-associative, %d sets\n"
+msgstr ""
+
+#: modules/devices/x86/processor.c:645
 msgid "Model Name"
 msgstr ""
 
-#: modules/devices/x86/processor.c:411
+#: modules/devices/x86/processor.c:646
 msgid "Family, model, stepping"
 msgstr ""
 
-#: modules/devices/x86/processor.c:417
+#: modules/devices/x86/processor.c:652
 msgid "Microcode Version"
 msgstr ""
 
-#: modules/devices/x86/processor.c:418
+#: modules/devices/x86/processor.c:653
 msgid "Configuration"
 msgstr ""
 
-#: modules/devices/x86/processor.c:419
+#: modules/devices/x86/processor.c:654
 msgid "Cache Size"
 msgstr ""
 
-#: modules/devices/x86/processor.c:419
+#: modules/devices/x86/processor.c:654
 msgid "kb"
 msgstr ""
 
-#: modules/devices/x86/processor.c:426
+#: modules/devices/x86/processor.c:661
 msgid "Power Management"
 msgstr ""
 
-#: modules/devices/x86/processor.c:427
+#: modules/devices/x86/processor.c:662
 msgid "Bug Workarounds"
 msgstr ""
 
-#: modules/devices/x86/processor.c:454 modules/devices/x86/processor.c:468
+#: modules/devices/x86/processor.c:695 modules/devices/x86/processor.c:715
 msgid "Package Information"
+msgstr ""
+
+#: modules/devices/x86/processor.c:742
+msgid "Socket:Core"
+msgstr ""
+
+#: modules/devices/x86/processor.c:742
+msgid "Thread"
 msgstr ""
 
 #. /flag:fpu
@@ -3902,75 +4148,100 @@ msgctxt "x86-flag"
 msgid "IPI required to wake up remote CPU"
 msgstr ""
 
+#. /bug:cpu_insecure & bug:cpu_meltdown
+#: modules/devices/x86/x86_data.c:281 modules/devices/x86/x86_data.c:282
+msgctxt "x86-flag"
+msgid ""
+"CPU is affected by meltdown attack and needs kernel page table isolation"
+msgstr ""
+
+#. /bug:spectre_v1
+#: modules/devices/x86/x86_data.c:283
+msgctxt "x86-flag"
+msgid "CPU is affected by Spectre variant 1 attack with conditional branches"
+msgstr ""
+
+#. /bug:spectre_v2
+#: modules/devices/x86/x86_data.c:284
+msgctxt "x86-flag"
+msgid "CPU is affected by Spectre variant 2 attack with indirect branches"
+msgstr ""
+
+#. /bug:spec_store_bypass
+#: modules/devices/x86/x86_data.c:285
+msgctxt "x86-flag"
+msgid "CPU is affected by speculative store bypass attack"
+msgstr ""
+
 #. /x86/kernel/cpu/powerflags.h
 #. /flag:pm:ts
-#: modules/devices/x86/x86_data.c:283
+#: modules/devices/x86/x86_data.c:288
 msgctxt "x86-flag"
 msgid "temperature sensor"
 msgstr ""
 
 #. /flag:pm:fid
-#: modules/devices/x86/x86_data.c:284
+#: modules/devices/x86/x86_data.c:289
 msgctxt "x86-flag"
 msgid "frequency id control"
 msgstr ""
 
 #. /flag:pm:vid
-#: modules/devices/x86/x86_data.c:285
+#: modules/devices/x86/x86_data.c:290
 msgctxt "x86-flag"
 msgid "voltage id control"
 msgstr ""
 
 #. /flag:pm:ttp
-#: modules/devices/x86/x86_data.c:286
+#: modules/devices/x86/x86_data.c:291
 msgctxt "x86-flag"
 msgid "thermal trip"
 msgstr ""
 
 #. /flag:pm:tm
-#: modules/devices/x86/x86_data.c:287
+#: modules/devices/x86/x86_data.c:292
 msgctxt "x86-flag"
 msgid "hardware thermal control"
 msgstr ""
 
 #. /flag:pm:stc
-#: modules/devices/x86/x86_data.c:288
+#: modules/devices/x86/x86_data.c:293
 msgctxt "x86-flag"
 msgid "software thermal control"
 msgstr ""
 
 #. /flag:pm:100mhzsteps
-#: modules/devices/x86/x86_data.c:289
+#: modules/devices/x86/x86_data.c:294
 msgctxt "x86-flag"
 msgid "100 MHz multiplier control"
 msgstr ""
 
 #. /flag:pm:hwpstate
-#: modules/devices/x86/x86_data.c:290
+#: modules/devices/x86/x86_data.c:295
 msgctxt "x86-flag"
 msgid "hardware P-state control"
 msgstr ""
 
 #. /flag:pm:cpb
-#: modules/devices/x86/x86_data.c:291
+#: modules/devices/x86/x86_data.c:296
 msgctxt "x86-flag"
 msgid "core performance boost"
 msgstr ""
 
 #. /flag:pm:eff_freq_ro
-#: modules/devices/x86/x86_data.c:292
+#: modules/devices/x86/x86_data.c:297
 msgctxt "x86-flag"
 msgid "Readonly aperf/mperf"
 msgstr ""
 
 #. /flag:pm:proc_feedback
-#: modules/devices/x86/x86_data.c:293
+#: modules/devices/x86/x86_data.c:298
 msgctxt "x86-flag"
 msgid "processor feedback interface"
 msgstr ""
 
 #. /flag:pm:acc_power
-#: modules/devices/x86/x86_data.c:294
+#: modules/devices/x86/x86_data.c:299
 msgctxt "x86-flag"
 msgid "accumulated power mechanism"
 msgstr ""
@@ -4004,7 +4275,7 @@ msgid "Shared Directories"
 msgstr ""
 
 #: modules/network.c:304 modules/network.c:326 modules/network.c:357
-#: modules/network/net.c:477
+#: modules/network/net.c:472
 msgid "IP Address"
 msgstr ""
 
@@ -4068,7 +4339,7 @@ msgstr ""
 msgid "Flags"
 msgstr ""
 
-#: modules/network.c:374 modules/network/net.c:478
+#: modules/network.c:374 modules/network/net.c:473
 msgid "Mask"
 msgstr ""
 
@@ -4238,97 +4509,97 @@ msgctxt "net-if-type"
 msgid "(Unknown)"
 msgstr ""
 
-#: modules/network/net.c:348 modules/network/net.c:358
+#: modules/network/net.c:343 modules/network/net.c:353
 msgid "Network Interfaces"
 msgstr ""
 
-#: modules/network/net.c:348
+#: modules/network/net.c:343
 msgid "None Found"
 msgstr ""
 
-#: modules/network/net.c:400 modules/network/net.c:422
-#: modules/network/net.c:423
+#: modules/network/net.c:395 modules/network/net.c:417
+#: modules/network/net.c:418
 msgid "MiB"
 msgstr ""
 
-#: modules/network/net.c:414
+#: modules/network/net.c:409
 msgid "Network Adapter Properties"
 msgstr ""
 
-#: modules/network/net.c:415
+#: modules/network/net.c:410
 msgid "Interface Type"
 msgstr ""
 
-#: modules/network/net.c:416
+#: modules/network/net.c:411
 msgid "Hardware Address (MAC)"
 msgstr ""
 
-#: modules/network/net.c:420
+#: modules/network/net.c:415
 msgid "MTU"
 msgstr ""
 
-#: modules/network/net.c:421
+#: modules/network/net.c:416
 msgid "Transfer Details"
 msgstr ""
 
-#: modules/network/net.c:422
+#: modules/network/net.c:417
 msgid "Bytes Received"
 msgstr ""
 
-#: modules/network/net.c:423
+#: modules/network/net.c:418
 msgid "Bytes Sent"
 msgstr ""
 
-#: modules/network/net.c:440 modules/network/net.c:462
-#: modules/network/net.c:463
+#: modules/network/net.c:435 modules/network/net.c:457
+#: modules/network/net.c:458
 msgid "dBm"
 msgstr ""
 
-#: modules/network/net.c:440
+#: modules/network/net.c:435
 msgid "mW"
 msgstr ""
 
-#: modules/network/net.c:454
+#: modules/network/net.c:449
 msgid "Wireless Properties"
 msgstr ""
 
-#: modules/network/net.c:455
+#: modules/network/net.c:450
 msgid "Network Name (SSID)"
 msgstr ""
 
-#: modules/network/net.c:456
+#: modules/network/net.c:451
 msgid "Bit Rate"
 msgstr ""
 
-#: modules/network/net.c:456
+#: modules/network/net.c:451
 msgid "Mb/s"
 msgstr ""
 
-#: modules/network/net.c:457
+#: modules/network/net.c:452
 msgid "Transmission Power"
 msgstr ""
 
-#: modules/network/net.c:459
+#: modules/network/net.c:454
 msgid "Status"
 msgstr ""
 
-#: modules/network/net.c:460
+#: modules/network/net.c:455
 msgid "Link Quality"
 msgstr ""
 
-#: modules/network/net.c:461
+#: modules/network/net.c:456
 msgid "Signal / Noise"
 msgstr ""
 
-#: modules/network/net.c:476
+#: modules/network/net.c:471
 msgid "Internet Protocol (IPv4)"
 msgstr ""
 
-#: modules/network/net.c:477 modules/network/net.c:478
-#: modules/network/net.c:480
+#: modules/network/net.c:472 modules/network/net.c:473
+#: modules/network/net.c:475
 msgid "(Not set)"
 msgstr ""
 
-#: modules/network/net.c:479
+#: modules/network/net.c:474
 msgid "Broadcast Address"
 msgstr ""

--- a/po/ru.po
+++ b/po/ru.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: hardinfo\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-06-09 18:08+0300\n"
+"POT-Creation-Date: 2018-06-09 14:09-0500\n"
 "PO-Revision-Date: \n"
 "Last-Translator: Sergey Rodin <rodin.s@rambler.ru>\n"
 "Language-Team: \n"
@@ -4313,8 +4313,7 @@ msgctxt "x86-flag"
 msgid ""
 "CPU is affected by meltdown attack and needs kernel page table isolation"
 msgstr ""
-"Процессор подвержен атаке Meltdown, требуется изоляция таблицы страниц "
-"ядра"
+"Процессор подвержен атаке Meltdown, требуется изоляция таблицы страниц ядра"
 
 #. /bug:spectre_v1
 #: modules/devices/x86/x86_data.c:283
@@ -4327,8 +4326,7 @@ msgstr ""
 #: modules/devices/x86/x86_data.c:284
 msgctxt "x86-flag"
 msgid "CPU is affected by Spectre variant 2 attack with indirect branches"
-msgstr ""
-"Процессор подвержен атаке Spectre variant 2 с непрямыми ветвями"
+msgstr "Процессор подвержен атаке Spectre variant 2 с непрямыми ветвями"
 
 #. /bug:spec_store_bypass
 #: modules/devices/x86/x86_data.c:285


### PR DESCRIPTION
hardinfo.pot now has 908 strings (+57)
- [ ] de.po : (706 / 908 remain untranslated)
- [ ] es.po : (225 / 908 remain untranslated)
- [ ] fr.po : (689 / 908 remain untranslated)
- [ ] ru.po : (222 / 908 remain untranslated)