### PR TITLE
arm/x86: clocks list empty when cpufreq is not available

### DIFF
--- a/modules/devices/arm/processor.c
+++ b/modules/devices/arm/processor.c
@@ -233,7 +233,7 @@ gchar *clocks_summary(GSList * processors)
     /* create list of all clock references */
     for (l = processors; l; l = l->next) {
         p = (Processor*)l->data;
-        if (p->cpufreq) {
+        if (p->cpufreq && p->cpufreq->cpukhz_max > 0) {
             all_clocks = g_slist_prepend(all_clocks, p->cpufreq);
         }
     }

--- a/modules/devices/x86/processor.c
+++ b/modules/devices/x86/processor.c
@@ -275,7 +275,7 @@ gchar *clocks_summary(GSList * processors)
     /* create list of all clock references */
     for (l = processors; l; l = l->next) {
         p = (Processor*)l->data;
-        if (p->cpufreq) {
+        if (p->cpufreq && p->cpufreq->cpukhz_max > 0) {
             all_clocks = g_slist_prepend(all_clocks, p->cpufreq);
         }
     }


### PR DESCRIPTION
Fixes clock list for #282.