### PR TITLE
devicetree: get opp-v2 freq range for gpu, if available

### DIFF
--- a/hardinfo/gpu_util.c
+++ b/hardinfo/gpu_util.c
@@ -97,6 +97,7 @@ void gpud_free(gpud *s) {
         free(s->drm_dev);
         free(s->sysfs_drm_path);
         free(s->dt_compat);
+        free(s->dt_opp);
         pcid_free(s->pci_dev);
         nvgpu_free(s->nv_info);
         g_free(s);
@@ -301,6 +302,10 @@ gpud *dt_soc_gpu() {
     gpu->dt_status = dtr_get_string(tmp_path, 1);
     snprintf(tmp_path, 255, "%s/name", dt_gpu_path);
     gpu->dt_name = dtr_get_string(tmp_path, 1);
+    gpu->dt_opp = dtr_get_opp_range(dt, dt_gpu_path);
+    if (gpu->dt_opp) {
+        gpu->khz_max = gpu->dt_opp->khz_max;
+    }
     EMPIFNULL(gpu->dt_name);
     EMPIFNULL(gpu->dt_status);
 

--- a/includes/dt_util.h
+++ b/includes/dt_util.h
@@ -61,6 +61,7 @@ char *dtr_obj_full_path(dtr_obj *);   /* system path */
 dtr_obj *dtr_get_prop_obj(dtr *, dtr_obj *node, const char *name);
 char *dtr_get_prop_str(dtr *, dtr_obj *node, const char *name);
 uint32_t dtr_get_prop_u32(dtr *, dtr_obj *node, const char *name);
+uint64_t dtr_get_prop_u64(dtr *, dtr_obj *node, const char *name);
 
 /* attempts to render the object as a string */
 char* dtr_str(dtr_obj *obj);
@@ -87,5 +88,15 @@ void dtr_msg(dtr *s, char *fmt, ...);
  * the string is not empty.
  * ex: ret = appf(ret, "%s=%s\n", name, value); */
 char *appf(char *src, char *fmt, ...);
+
+/* operating-points-v2 */
+typedef struct {
+    uint32_t phandle;
+    uint32_t khz_min;
+    uint32_t khz_max;
+    uint32_t clock_latency_ns;
+} dt_opp_range;
+
+dt_opp_range *dtr_get_opp_range(dtr *, const char *name);
 
 #endif

--- a/includes/gpu_util.h
+++ b/includes/gpu_util.h
@@ -35,6 +35,7 @@ typedef struct gpud {
     char *vendor_str;
     char *device_str;
     char *location;
+    uint32_t khz_max;
 
     char *drm_dev;
     char *sysfs_drm_path;
@@ -42,6 +43,7 @@ typedef struct gpud {
 
     char *dt_compat, *dt_status, *dt_name, *dt_path;
     const char *dt_vendor, *dt_device;
+    dt_opp_range *dt_opp;
 
     nvgpu *nv_info;
     /* ... */


### PR DESCRIPTION
* opp-v2 = operating-points-v2, frequency scaling information
  from device tree that can be used for cpu, gpu, etc.
  https://www.kernel.org/doc/Documentation/devicetree/bindings/opp/opp.txt
* adds helper function to get the opp-v2 range of frequencies
  for a node, dtr_get_opp_range() in dt_util.c
* reports a gpu's max clock frequency if avaiable via opp-v2