### PR TITLE
 devicetree: get opp-v1/v2 freq range for gpu, if available [v2]

### DIFF
--- a/hardinfo/dt_util.c
+++ b/hardinfo/dt_util.c
@@ -475,8 +475,9 @@ uint32_t dtr_get_prop_u32(dtr *s, dtr_obj *node, const char *name) {
 
     ptmp = g_strdup_printf("%s/%s", (node == NULL) ? "" : node->path, name);
     prop = dtr_obj_read(s, ptmp);
-    if (prop != NULL && prop->data != NULL) {
-        ret = be32toh(*prop->data_int);
+    if (prop != NULL) {
+        if (prop->data != NULL)
+            ret = be32toh(*prop->data_int);
         dtr_obj_free(prop);
     }
     g_free(ptmp);
@@ -490,8 +491,9 @@ uint64_t dtr_get_prop_u64(dtr *s, dtr_obj *node, const char *name) {
 
     ptmp = g_strdup_printf("%s/%s", (node == NULL) ? "" : node->path, name);
     prop = dtr_obj_read(s, ptmp);
-    if (prop != NULL && prop->data != NULL) {
-        ret = be64toh(*prop->data_int64);
+    if (prop != NULL) {
+        if (prop->data != NULL)
+            ret = be64toh(*prop->data_int64);
         dtr_obj_free(prop);
     }
     g_free(ptmp);
@@ -582,7 +584,7 @@ char *dtr_elem_oppv2(dtr_obj* obj) {
         dt_opp_range *opp = dtr_get_opp_range(obj->dt, parent->path);
         if (opp) {
             snprintf(opp_str, 511, "[%d - %d %s]", opp->khz_min, opp->khz_max, _("kHz"));
-            free(opp);
+            g_free(opp);
         }
         dtr_obj_free(parent);
     }
@@ -968,9 +970,8 @@ dt_opp_range *dtr_get_opp_range(dtr *s, const char *name) {
     if (tab_status && strcmp(tab_status, "disabled") == 0)
         goto get_opp_finish;
 
-    ret = malloc(sizeof(dt_opp_range));
+    ret = g_new0(dt_opp_range, 1);
     ret->phandle = opp_ph;
-    ret->khz_min = ret->khz_max = ret->clock_latency_ns = 0;
 
     full_path = dtr_obj_full_path(table_obj);
     dir = g_dir_open(full_path, 0 , NULL);

--- a/hardinfo/dt_util.c
+++ b/hardinfo/dt_util.c
@@ -917,8 +917,8 @@ void _dtr_read_aliases(dtr *s) {
             }
             dtr_obj_free(prop);
         }
+        g_dir_close(dir);
     }
-    g_dir_close(dir);
     g_free(dir_path);
     dtr_obj_free(anode);
     dtr_map_sort(s->aliases, 0);
@@ -946,8 +946,8 @@ void _dtr_read_symbols(dtr *s) {
             }
             dtr_obj_free(prop);
         }
+        g_dir_close(dir);
     }
-    g_dir_close(dir);
     g_free(dir_path);
     dtr_obj_free(anode);
     dtr_map_sort(s->symbols, 0);
@@ -987,8 +987,8 @@ void _dtr_map_phandles(dtr *s, char *np) {
             }
             g_free(ftmp);
         }
+        g_dir_close(dir);
     }
-    g_dir_close(dir);
     dtr_obj_free(prop);
     dtr_map_sort(s->phandles, 1);
 }

--- a/hardinfo/gpu_util.c
+++ b/hardinfo/gpu_util.c
@@ -97,6 +97,7 @@ void gpud_free(gpud *s) {
         free(s->drm_dev);
         free(s->sysfs_drm_path);
         free(s->dt_compat);
+        free(s->dt_opp);
         pcid_free(s->pci_dev);
         nvgpu_free(s->nv_info);
         g_free(s);
@@ -301,6 +302,10 @@ gpud *dt_soc_gpu() {
     gpu->dt_status = dtr_get_string(tmp_path, 1);
     snprintf(tmp_path, 255, "%s/name", dt_gpu_path);
     gpu->dt_name = dtr_get_string(tmp_path, 1);
+    gpu->dt_opp = dtr_get_opp_range(dt, dt_gpu_path);
+    if (gpu->dt_opp) {
+        gpu->khz_max = gpu->dt_opp->khz_max;
+    }
     EMPIFNULL(gpu->dt_name);
     EMPIFNULL(gpu->dt_status);
 

--- a/hardinfo/gpu_util.c
+++ b/hardinfo/gpu_util.c
@@ -305,6 +305,7 @@ gpud *dt_soc_gpu() {
     gpu->dt_opp = dtr_get_opp_range(dt, dt_gpu_path);
     if (gpu->dt_opp) {
         gpu->khz_max = gpu->dt_opp->khz_max;
+        gpu->khz_min = gpu->dt_opp->khz_min;
     }
     EMPIFNULL(gpu->dt_name);
     EMPIFNULL(gpu->dt_status);

--- a/hardinfo/gpu_util.c
+++ b/hardinfo/gpu_util.c
@@ -97,7 +97,7 @@ void gpud_free(gpud *s) {
         free(s->drm_dev);
         free(s->sysfs_drm_path);
         free(s->dt_compat);
-        free(s->dt_opp);
+        g_free(s->dt_opp);
         pcid_free(s->pci_dev);
         nvgpu_free(s->nv_info);
         g_free(s);

--- a/includes/dt_util.h
+++ b/includes/dt_util.h
@@ -99,6 +99,7 @@ typedef struct {
     uint32_t clock_latency_ns;
 } dt_opp_range;
 
+/* free result with g_free() */
 dt_opp_range *dtr_get_opp_range(dtr *, const char *name);
 
 #endif

--- a/includes/dt_util.h
+++ b/includes/dt_util.h
@@ -30,6 +30,7 @@ enum {
     DTP_CLOCKS,  /* <phref, #clock-cells> */
     DTP_GPIOS,   /* <phref, #gpio-cells> */
     DTP_DMAS,    /* dma-specifier list */
+    DTP_PH_REF_OPP2,  /* phandle reference to opp-v2 table */
 };
 
 /* simplest, no aliases, doesn't require an existing dt.
@@ -55,18 +56,20 @@ char *dtr_obj_alias(dtr_obj *);
 char *dtr_obj_symbol(dtr_obj *);
 char *dtr_obj_path(dtr_obj *);        /* device tree path */
 char *dtr_obj_full_path(dtr_obj *);   /* system path */
+dtr_obj *dtr_get_parent_obj(dtr_obj *);
 
 /* find property/node 'name' relative to node
  * if node is NULL, then from root */
 dtr_obj *dtr_get_prop_obj(dtr *, dtr_obj *node, const char *name);
 char *dtr_get_prop_str(dtr *, dtr_obj *node, const char *name);
 uint32_t dtr_get_prop_u32(dtr *, dtr_obj *node, const char *name);
+uint64_t dtr_get_prop_u64(dtr *, dtr_obj *node, const char *name);
 
 /* attempts to render the object as a string */
 char* dtr_str(dtr_obj *obj);
 
 int dtr_guess_type(dtr_obj *obj);
-char *dtr_elem_phref(dtr *, dt_uint e, int show_path);
+char *dtr_elem_phref(dtr *, dt_uint e, int show_path, const char *extra);
 char *dtr_elem_hex(dt_uint e);
 char *dtr_elem_byte(uint8_t e);
 char *dtr_elem_uint(dt_uint e);
@@ -87,5 +90,15 @@ void dtr_msg(dtr *s, char *fmt, ...);
  * the string is not empty.
  * ex: ret = appf(ret, "%s=%s\n", name, value); */
 char *appf(char *src, char *fmt, ...);
+
+/* operating-points-v2 */
+typedef struct {
+    uint32_t phandle;
+    uint32_t khz_min;
+    uint32_t khz_max;
+    uint32_t clock_latency_ns;
+} dt_opp_range;
+
+dt_opp_range *dtr_get_opp_range(dtr *, const char *name);
 
 #endif

--- a/includes/dt_util.h
+++ b/includes/dt_util.h
@@ -30,6 +30,7 @@ enum {
     DTP_CLOCKS,  /* <phref, #clock-cells> */
     DTP_GPIOS,   /* <phref, #gpio-cells> */
     DTP_DMAS,    /* dma-specifier list */
+    DTP_OPP1,    /* list of operating points, pairs of (kHz,uV) */
     DTP_PH_REF_OPP2,  /* phandle reference to opp-v2 table */
 };
 
@@ -91,9 +92,10 @@ void dtr_msg(dtr *s, char *fmt, ...);
  * ex: ret = appf(ret, "%s=%s\n", name, value); */
 char *appf(char *src, char *fmt, ...);
 
-/* operating-points-v2 */
+/* operating-points v0,v1,v2 */
 typedef struct {
-    uint32_t phandle;
+    uint32_t version; /* opp version, 0 = clock-frequency only */
+    uint32_t phandle; /* v2 only */
     uint32_t khz_min;
     uint32_t khz_max;
     uint32_t clock_latency_ns;

--- a/includes/gpu_util.h
+++ b/includes/gpu_util.h
@@ -35,7 +35,7 @@ typedef struct gpud {
     char *vendor_str;
     char *device_str;
     char *location;
-    uint32_t khz_max;
+    uint32_t khz_min, khz_max; /* core */
 
     char *drm_dev;
     char *sysfs_drm_path;

--- a/includes/gpu_util.h
+++ b/includes/gpu_util.h
@@ -35,6 +35,7 @@ typedef struct gpud {
     char *vendor_str;
     char *device_str;
     char *location;
+    uint32_t khz_max;
 
     char *drm_dev;
     char *sysfs_drm_path;
@@ -42,6 +43,7 @@ typedef struct gpud {
 
     char *dt_compat, *dt_status, *dt_name, *dt_path;
     const char *dt_vendor, *dt_device;
+    dt_opp_range *dt_opp;
 
     nvgpu *nv_info;
     /* ... */

--- a/modules/devices/gpu.c
+++ b/modules/devices/gpu.c
@@ -195,14 +195,21 @@ int _dt_soc_gpu(gpud *gpu) {
 
     gchar *opp_str;
     if (gpu->dt_opp) {
-        opp_str = g_strdup_printf("[%s %s]\n"
+        static const char *freq_src[] = {
+            N_("clock-frequency property"),
+            N_("Operating Points (OPPv1)"),
+            N_("Operating Points (OPPv2)"),
+        };
+        opp_str = g_strdup_printf("[%s]\n"
                      /* MinFreq */  "%s=%d %s\n"
                      /* MaxFreq */  "%s=%d %s\n"
-                     /* Latency */  "%s=%d %s\n",
-                    _("Frequency Scaling"), _("(OPPv2)"),
+                     /* Latency */  "%s=%d %s\n"
+                     /* Source */   "%s=%s\n",
+                    _("Frequency Scaling"),
                     _("Minimum"), gpu->dt_opp->khz_min, _("kHz"),
                     _("Maximum"), gpu->dt_opp->khz_max, _("kHz"),
-                    _("Transition Latency"), gpu->dt_opp->clock_latency_ns, _("ns") );
+                    _("Transition Latency"), gpu->dt_opp->clock_latency_ns, _("ns"),
+                    _("Source"), _(freq_src[gpu->dt_opp->version]) );
     } else
         opp_str = strdup("");
 

--- a/modules/devices/gpu.c
+++ b/modules/devices/gpu.c
@@ -129,7 +129,10 @@ static void _gpu_pci_dev(gpud* gpu) {
 
     gchar *freq = g_strdup(_("(Unknown)"));
     if (gpu->khz_max > 0) {
-        freq = g_strdup_printf("%0.2f %s", (double) gpu->khz_max / 1000, _("MHz"));
+        if (gpu->khz_min > 0)
+            freq = g_strdup_printf("%0.2f-%0.2f %s", (double) gpu->khz_min / 1000, (double) gpu->khz_max / 1000, _("MHz"));
+        else
+            freq = g_strdup_printf("%0.2f %s", (double) gpu->khz_max / 1000, _("MHz"));
     }
 
     str = g_strdup_printf("[%s]\n"
@@ -180,7 +183,10 @@ int _dt_soc_gpu(gpud *gpu) {
     if (device == NULL) device = UNKSOC;
     gchar *freq = g_strdup(_("(Unknown)"));
     if (gpu->khz_max > 0) {
-        freq = g_strdup_printf("%0.2f %s", (double) gpu->khz_max / 1000, _("MHz"));
+        if (gpu->khz_min > 0)
+            freq = g_strdup_printf("%0.2f-%0.2f %s", (double) gpu->khz_min / 1000, (double) gpu->khz_max / 1000, _("MHz"));
+        else
+            freq = g_strdup_printf("%0.2f %s", (double) gpu->khz_max / 1000, _("MHz"));
     }
     gchar *key = g_strdup(gpu->id);
     gchar *name = (vendor == UNKSOC && device == UNKSOC)

--- a/modules/devices/gpu.c
+++ b/modules/devices/gpu.c
@@ -195,11 +195,11 @@ int _dt_soc_gpu(gpud *gpu) {
 
     gchar *opp_str;
     if (gpu->dt_opp) {
-        opp_str = g_strdup_printf("[%s]\n"
+        opp_str = g_strdup_printf("[%s %s]\n"
                      /* MinFreq */  "%s=%d %s\n"
                      /* MaxFreq */  "%s=%d %s\n"
                      /* Latency */  "%s=%d %s\n",
-                    _("Frequency Scaling"),
+                    _("Frequency Scaling"), _("(OPPv2)"),
                     _("Minimum"), gpu->dt_opp->khz_min, _("kHz"),
                     _("Maximum"), gpu->dt_opp->khz_max, _("kHz"),
                     _("Transition Latency"), gpu->dt_opp->clock_latency_ns, _("ns") );


### PR DESCRIPTION
* opp = "operating-points", frequency scaling information
  from device tree that can be used for cpu, gpu, etc.
  https://www.kernel.org/doc/Documentation/devicetree/bindings/opp/opp.txt
* adds helper function to get the opp-v1/opp-v2 range of frequencies
  for a node, dtr_get_opp_range() in dt_util.c
* adds a freq range in opp-v2 property for a node in dt
* reports a gpu's max clock frequency if avaiable via opp-v1/v2
