### PR TITLE
devices: Remove product-version from string returned by get_motherboard()

### DIFF
--- a/data/vendor.ids
+++ b/data/vendor.ids
@@ -16,9 +16,15 @@
 # Match strings should be unique.
 #
 
-name ASUS
+name Lenovo Group
+    name_short Lenovo
+    url www.lenovo.com
+    url_support support.lenovo.com
+    match_string lenovo
+
+name ASUSTeK Computer
+    name_short ASUS
     url www.asus.com
-    # "ASUSTek" is common
     match_string ASUSTek
     match_string ASUS
 

--- a/data/vendor.ids
+++ b/data/vendor.ids
@@ -80,7 +80,9 @@ name Realtek
     url www.realtek.com.tw
     match_string Realtek
 
-name Toshiba
+name Toshiba Corporation
+# styled in all-caps
+    name_short TOSHIBA
     url www.toshiba.com
     match_string Toshiba
 

--- a/data/vendor.ids
+++ b/data/vendor.ids
@@ -172,9 +172,18 @@ name D-Link
     match_string D-Link
 
 name Gigabyte Technology
+    name_short Gigabyte
     url www.gigabyte.com.tw
     match_string Giga-byte
     match_string Gigabyte
+
+name Micro-Star International
+    name_short MSI
+    url www.msi.com
+    url_support www.msi.com/support
+    match_string Micro-Star Int'l Co.,Ltd.
+    match_string Micro Star
+    match_string_case MSI
 
 name C-Media Electronics
     url www.cmedia.com.tw
@@ -269,6 +278,12 @@ name SEAGATE
     url www.seagate.com
     match_string_case ST
 
+name Silicon Integrated Systems Corporation
+    name_short SIS
+    url www.sis.com
+    match_string Silicon Integrated Systems
+    match_string_case SIS
+
 #
 # BIOS manufacturers
 #
@@ -278,10 +293,12 @@ name American Megatrends
     match_string American Megatrends
 
 name Award Software International
+    name_short Award
     url www.award-bios.com
     match_string Award
 
 name Phoenix Technologies
+    name_short Phoenix
     url www.phoenix.com
     match_string Phoenix
 
@@ -290,59 +307,53 @@ name Phoenix Technologies
 #
 
 name Advanced Micro Devices
+    name_short AMD
     url www.amd.com
     match_string AMDisbetter!
-
-name Advanced Micro Devices
-    url www.amd.com
     match_string AuthenticAMD
 
-name VIA (formerly Centaur Technology)
-    url www.via.tw
-    match_string CentaurHauls
-
-name Cyrix
-    url
-    match_string CyrixInstead
-
-name Intel
+name Intel Corporation
+    name_short Intel
     url www.intel.com
+    url_support http://ark.intel.com/search.aspx?q=
     match_string GenuineIntel
 
-name Transmeta
-    url
-    match_string TransmetaCPU
-
-name Transmeta
-    url
-    match_string GenuineTMx86
-
-name National Semiconductor
-    url
-    match_string Geode by NSC
-
-name NexGen
-    url
-    match_string NexGenDriven
-
-name Rise Technology
-    url
-    match_string RiseRiseRise
-
-name Silicon Integrated Systems
-    url
-    match_string SiS SiS SiS
-
-name United Microelectronics Corporation
-    url
-    match_string UMC UMC UMC
-
-name VIA
+name VIA Technologies
+    name_short VIA
     url www.via.tw
     match_string VIA VIA VIA
 
+name VIA (formerly Centaur Technology)
+    name_short VIA (Centaur)
+    url www.via.tw
+    match_string CentaurHauls
+
+name VIA (formerly Cyrix)
+    name_short VIA (Cyrix)
+    url www.via.tw
+    match_string CyrixInstead
+
+name Transmeta Corporation
+    name_short Transmeta
+    match_string TransmetaCPU
+    match_string GenuineTMx86
+
+name National Semiconductor
+    match_string Geode by NSC
+
+name NexGen
+    match_string NexGenDriven
+
+name Rise Technology
+    match_string RiseRiseRise
+
+name Silicon Integrated Systems
+    match_string SiS SiS SiS
+
+name United Microelectronics Corporation
+    match_string UMC UMC UMC
+
 name DMP Electronics
-    url
     match_string Vortex86 SoC
 
 #
@@ -350,7 +361,7 @@ name DMP Electronics
 #
 
 name KVM
-    url
+    url www.linux-kvm.org
     match_string KVMKVMKVM
 
 name Microsoft Hyper-V
@@ -358,13 +369,13 @@ name Microsoft Hyper-V
     match_string Microsoft Hv
 
 name Parallels
-    url
+    url www.parallels.com
     match_string lrpepyh vr
 
 name VMware
-    url
+    url www.vmware.com
     match_string VMwareVMware
 
 name Xen HVM
-    url
+    url www.xenproject.org
     match_string XenVMMXenVMM

--- a/data/vendor.ids
+++ b/data/vendor.ids
@@ -185,6 +185,12 @@ name Micro-Star International
     match_string Micro Star
     match_string_case MSI
 
+name ZOTAC International
+    name_short ZOTAC
+    url www.zotac.com
+    url_support www.zotac.com/support/
+    match_string ZOTAC
+
 name C-Media Electronics
     url www.cmedia.com.tw
     match_string C-Media

--- a/hardinfo/dmi_util.c
+++ b/hardinfo/dmi_util.c
@@ -34,6 +34,8 @@ static int ignore_placeholder_strings(char **pstr) {
     DMI_IGNORE("Default String");
     DMI_IGNORE("Rev X.0x"); /* ASUS board version nonsense */
     DMI_IGNORE("x.x");      /* Gigabyte board version nonsense */
+    DMI_IGNORE("XX");       /* Zotac version nonsense */
+    DMI_IGNORE("NA");
     /*... more, I'm sure. */
     return 0;
 }

--- a/hardinfo/dmi_util.c
+++ b/hardinfo/dmi_util.c
@@ -24,9 +24,12 @@
 /* frees the string and sets it NULL if it is to be ignored
  * returns -1 if error, 0 if ok, 1 if ignored */
 static int ignore_placeholder_strings(gchar **pstr) {
+    gchar *chk, *p;
+    chk = g_strdup(*pstr);
+
     if (pstr == NULL || *pstr == NULL)
         return -1;
-#define DMI_IGNORE(m) if (strcasecmp(m, *pstr) == 0) { g_free(*pstr); *pstr = NULL; return 1; }
+#define DMI_IGNORE(m) if (strcasecmp(m, *pstr) == 0) { g_free(chk); g_free(*pstr); *pstr = NULL; return 1; }
     DMI_IGNORE("To be filled by O.E.M.");
     DMI_IGNORE("System Product Name");
     DMI_IGNORE("System Manufacturer");
@@ -34,9 +37,19 @@ static int ignore_placeholder_strings(gchar **pstr) {
     DMI_IGNORE("Default String");
     DMI_IGNORE("Rev X.0x"); /* ASUS board version nonsense */
     DMI_IGNORE("x.x");      /* Gigabyte board version nonsense */
-    DMI_IGNORE("XX");       /* Zotac version nonsense */
     DMI_IGNORE("NA");
+
+    /* Zotac version nonsense */
+    p = chk;
+    while (*p != 0) { *p = 'x'; p++; } /* all X */
+    DMI_IGNORE(chk);
+    p = chk;
+    while (*p != 0) { *p = '0'; p++; } /* all 0 */
+    DMI_IGNORE(chk);
+
     /*... more, I'm sure. */
+
+    g_free(chk);
     return 0;
 }
 

--- a/hardinfo/dmi_util.c
+++ b/hardinfo/dmi_util.c
@@ -32,6 +32,8 @@ static int ignore_placeholder_strings(char **pstr) {
     DMI_IGNORE("System Manufacturer");
     DMI_IGNORE("System Version");
     DMI_IGNORE("Default String");
+    DMI_IGNORE("Rev X.0x"); /* ASUS board version nonsense */
+    DMI_IGNORE("x.x");      /* Gigabyte board version nonsense */
     /*... more, I'm sure. */
     return 0;
 }

--- a/hardinfo/dmi_util.c
+++ b/hardinfo/dmi_util.c
@@ -211,7 +211,7 @@ char *dmi_chassis_type_str(int chassis_type, gboolean with_val) {
             chassis_type = -1;
     }
 
-    if (chassis_type >= 0 && chassis_type < G_N_ELEMENTS(types)) {
+    if (chassis_type >= 0 && chassis_type < (int)G_N_ELEMENTS(types)) {
         if (with_val)
             return g_strdup_printf("[%d] %s", chassis_type, _(types[chassis_type]));
 
@@ -299,7 +299,7 @@ char *dmidecode_match(const char *name, const unsigned long *dmi_type, const uns
         p = full;
         while(next_nl = strchr(p, '\n')) {
             strend(p, '\n');
-            if (!sscanf(p, "Handle 0x%X", &ch) > 0 ) {
+            if (!(sscanf(p, "Handle 0x%X", &ch) > 0) ) {
                 if (!handle || *handle == ch) {
                     while(*p == '\t') p++;
                     if (strncmp(p, name, ln) == 0) {
@@ -335,7 +335,7 @@ dmi_handle_list *dmidecode_match_value(const char *name, const char *value, cons
         p = full;
         while(next_nl = strchr(p, '\n')) {
             strend(p, '\n');
-            if (!sscanf(p, "Handle 0x%X", &ch) > 0 ) {
+            if (!(sscanf(p, "Handle 0x%X", &ch) > 0) ) {
                 while(*p == '\t') p++;
                 if (strncmp(p, name, ln) == 0) {
                     if (*(p + ln) == ':') {

--- a/hardinfo/gpu_util.c
+++ b/hardinfo/gpu_util.c
@@ -154,11 +154,9 @@ static void make_nice_name(gpud *s) {
         device_str = unk_d;
 
     /* try and a get a "short name" for the vendor */
-    const Vendor *v = vendor_match(vendor_str, NULL);
-    if (v && v->name_short && *v->name_short != 0)
-        vendor_str = v->name_short;
+    vendor_str = vendor_get_shortest_name(vendor_str);
 
-    /* These two former special cases are currently handled by the vendor_match()
+    /* These two former special cases are currently handled by the vendor_get_shortest_name()
      * function well enough, but the notes are preserved here. */
         /* nvidia PCI strings are pretty nice already,
          * just shorten the company name */

--- a/hardinfo/vendor.c
+++ b/hardinfo/vendor.c
@@ -340,11 +340,14 @@ static const gchar *vendor_get_name_ex(const gchar * id_str, short shortest) {
             int snl = (v->name_short) ? strlen(v->name_short) : 0;
             if (!nl) nl = 9999;
             if (!snl) snl = 9999;
-            /* if id_str is shortest, then return as if not found (see below) */
-            if (nl <= snl)
-                return (sl <= nl) ? id_str : v->name;
+            /* if id_str is shortest, then return as if
+             *   not found (see below).
+             * if all equal then prefer
+             *   name_short > name > id_str. */
+            if (nl < snl)
+                return (sl < nl) ? id_str : v->name;
             else
-                return (sl <= snl) ? id_str : v->name_short;
+                return (sl < snl) ? id_str : v->name_short;
         } else
             return v->name;
     }

--- a/hardinfo/vendor.c
+++ b/hardinfo/vendor.c
@@ -330,9 +330,10 @@ const Vendor *vendor_match(const gchar *id_str, ...) {
     return ret;
 }
 
-const gchar *vendor_get_name(const gchar * id_str)
+static const gchar *vendor_get_name_ex(const gchar * id_str, short shortest)
 {
     GSList *vendor;
+    int found = 0;
 
     if (!id_str)
         return NULL;
@@ -340,18 +341,43 @@ const gchar *vendor_get_name(const gchar * id_str)
     for (vendor = vendor_list; vendor; vendor = vendor->next) {
         Vendor *v = (Vendor *)vendor->data;
 
-        if (v)
+        if (v) {
             if (v->match_case) {
                 if (v->match_string && strstr(id_str, v->match_string))
-                    return v->name;
+                    found = 1;
             } else {
                 if (v->match_string && strcasestr(id_str, v->match_string))
-                    return v->name;
+                    found = 1;
             }
 
+            if (found) {
+                if (shortest) {
+                    int sl = strlen(id_str);
+                    int nl = (v->name) ? strlen(v->name) : 0;
+                    int snl = (v->name_short) ? strlen(v->name_short) : 0;
+                    if (!nl) nl = 9999;
+                    if (!snl) snl = 9999;
+                    /* if id_str is shortest, then return null as if nothing
+                     * was found */
+                    if (nl <= snl)
+                        return (sl <= nl) ? NULL : v->name;
+                    else
+                        return (sl <= snl) ? NULL : v->name_short;
+                } else
+                    return v->name;
+            }
+        }
     }
 
     return id_str; /* What about const? */
+}
+
+const gchar *vendor_get_name(const gchar * id_str) {
+    return vendor_get_name_ex(id_str, 0);
+}
+
+const gchar *vendor_get_shortest_name(const gchar * id_str) {
+    return vendor_get_name_ex(id_str, 1);
 }
 
 const gchar *vendor_get_url(const gchar * id_str)

--- a/hardinfo/vendor.c
+++ b/hardinfo/vendor.c
@@ -330,46 +330,26 @@ const Vendor *vendor_match(const gchar *id_str, ...) {
     return ret;
 }
 
-static const gchar *vendor_get_name_ex(const gchar * id_str, short shortest)
-{
-    GSList *vendor;
-    int found = 0;
+static const gchar *vendor_get_name_ex(const gchar * id_str, short shortest) {
+    const Vendor *v = vendor_match(id_str, NULL);
 
-    if (!id_str)
-        return NULL;
-
-    for (vendor = vendor_list; vendor; vendor = vendor->next) {
-        Vendor *v = (Vendor *)vendor->data;
-
-        if (v) {
-            if (v->match_case) {
-                if (v->match_string && strstr(id_str, v->match_string))
-                    found = 1;
-            } else {
-                if (v->match_string && strcasestr(id_str, v->match_string))
-                    found = 1;
-            }
-
-            if (found) {
-                if (shortest) {
-                    int sl = strlen(id_str);
-                    int nl = (v->name) ? strlen(v->name) : 0;
-                    int snl = (v->name_short) ? strlen(v->name_short) : 0;
-                    if (!nl) nl = 9999;
-                    if (!snl) snl = 9999;
-                    /* if id_str is shortest, then return null as if nothing
-                     * was found */
-                    if (nl <= snl)
-                        return (sl <= nl) ? NULL : v->name;
-                    else
-                        return (sl <= snl) ? NULL : v->name_short;
-                } else
-                    return v->name;
-            }
-        }
+    if (v) {
+        if (shortest) {
+            int sl = strlen(id_str);
+            int nl = (v->name) ? strlen(v->name) : 0;
+            int snl = (v->name_short) ? strlen(v->name_short) : 0;
+            if (!nl) nl = 9999;
+            if (!snl) snl = 9999;
+            /* if id_str is shortest, then return as if not found (see below) */
+            if (nl <= snl)
+                return (sl <= nl) ? id_str : v->name;
+            else
+                return (sl <= snl) ? id_str : v->name_short;
+        } else
+            return v->name;
     }
 
-    return id_str; /* What about const? */
+    return id_str; /* Preserve an old behavior, but what about const? */
 }
 
 const gchar *vendor_get_name(const gchar * id_str) {
@@ -380,27 +360,11 @@ const gchar *vendor_get_shortest_name(const gchar * id_str) {
     return vendor_get_name_ex(id_str, 1);
 }
 
-const gchar *vendor_get_url(const gchar * id_str)
-{
-    GSList *vendor;
+const gchar *vendor_get_url(const gchar * id_str) {
+    const Vendor *v = vendor_match(id_str, NULL);
 
-    if (!id_str) {
-      return NULL;
-    }
-
-    for (vendor = vendor_list; vendor; vendor = vendor->next) {
-        Vendor *v = (Vendor *)vendor->data;
-
-        if (v)
-            if (v->match_case) {
-                if (v->match_string && strstr(id_str, v->match_string))
-                    return v->url;
-            } else {
-                if (v->match_string && strcasestr(id_str, v->match_string))
-                    return v->url;
-            }
-
-    }
+    if (v)
+        return v->url;
 
     return NULL;
 }

--- a/includes/dmi_util.h
+++ b/includes/dmi_util.h
@@ -21,7 +21,12 @@
 #ifndef __DMI_UTIL_H__
 #define __DMI_UTIL_H__
 
-char *dmi_get_str(const char *id_str);
+/* -1 = yes, but will be ignored
+ *  0 = no
+ *  1 = yes */
+int dmi_str_status(const char *id_str);
+char *dmi_get_str(const char *id_str);     /* ignore nonsense */
+char *dmi_get_str_abs(const char *id_str); /* include nonsense */
 
 /* if chassis_type is <=0 it will be fetched from DMI.
  * with_val = true, will return a string like "[3] Desktop" instead of just

--- a/includes/vendor.h
+++ b/includes/vendor.h
@@ -33,6 +33,7 @@ void vendor_init(void);
 void vendor_cleanup(void);
 const Vendor *vendor_match(const gchar *id_str, ...); /* end list of strings with NULL */
 const gchar *vendor_get_name(const gchar *id_str);
+const gchar *vendor_get_shortest_name(const gchar *id_str);
 const gchar *vendor_get_url(const gchar *id_str);
 void vendor_free(Vendor *v);
 

--- a/modules/devices.c
+++ b/modules/devices.c
@@ -372,7 +372,7 @@ gchar *get_motherboard(void)
     if (board_vendor) {
         /* attempt to shorten */
         tmp = vendor_get_shortest_name(board_vendor);
-        if (tmp) {
+        if (tmp && tmp != board_vendor) {
             g_free(board_vendor);
             board_vendor = g_strdup(tmp);
         }
@@ -384,7 +384,7 @@ gchar *get_motherboard(void)
     if (product_vendor) {
         /* attempt to shorten */
         tmp = vendor_get_shortest_name(product_vendor);
-        if (tmp) {
+        if (tmp && tmp != product_vendor) {
             g_free(product_vendor);
             product_vendor = g_strdup(tmp);
         }

--- a/modules/devices.c
+++ b/modules/devices.c
@@ -358,6 +358,7 @@ gchar *get_motherboard(void)
     gchar *board_name, *board_vendor, *board_version;
     gchar *product_name, *product_vendor, *product_version;
     gchar *board_part = NULL, *product_part = NULL;
+    const gchar *tmp;
     int b = 0, p = 0;
 
     gchar *ret;
@@ -366,12 +367,28 @@ gchar *get_motherboard(void)
     scan_dmi(FALSE);
 
     board_name = dmi_get_str("baseboard-product-name");
-    board_vendor = dmi_get_str("baseboard-manufacturer");
     board_version = dmi_get_str("baseboard-version");
+    board_vendor = dmi_get_str("baseboard-manufacturer");
+    if (board_vendor) {
+        /* attempt to shorten */
+        tmp = vendor_get_shortest_name(board_vendor);
+        if (tmp) {
+            g_free(board_vendor);
+            board_vendor = g_strdup(tmp);
+        }
+    }
 
     product_name = dmi_get_str("system-product-name");
-    product_vendor = dmi_get_str("system-manufacturer");
     product_version = dmi_get_str("system-version");
+    product_vendor = dmi_get_str("system-manufacturer");
+    if (product_vendor) {
+        /* attempt to shorten */
+        tmp = vendor_get_shortest_name(product_vendor);
+        if (tmp) {
+            g_free(product_vendor);
+            product_vendor = g_strdup(tmp);
+        }
+    }
 
     if (board_vendor && product_vendor &&
         strcmp(board_vendor, product_vendor) == 0) {

--- a/modules/devices.c
+++ b/modules/devices.c
@@ -404,6 +404,13 @@ gchar *get_motherboard(void)
             product_name = NULL;
     }
 
+    if (board_version && product_version &&
+        strcmp(board_version, product_version) == 0) {
+            /* ignore duplicate version */
+            g_free(product_version);
+            product_version = NULL;
+    }
+
     if (board_name) b += 1;
     if (board_vendor) b += 2;
     if (board_version) b += 4;

--- a/modules/devices.c
+++ b/modules/devices.c
@@ -355,7 +355,7 @@ gchar *get_memory_total(void)
 
 gchar *get_motherboard(void)
 {
-    char *board_name, *board_vendor, *system_version;
+    char *board_name, *board_vendor;
     char *ret;
 
 #if defined(ARCH_x86) || defined(ARCH_x86_64)
@@ -369,11 +369,7 @@ gchar *get_motherboard(void)
     if (board_vendor == NULL)
         board_vendor = dmi_get_str("system-manufacturer");
 
-    system_version = dmi_get_str("system-version");
-
-    if (board_name && board_vendor && system_version)
-        ret = g_strdup_printf("%s / %s (%s)", system_version, board_name, board_vendor);
-    else if (board_name && board_vendor)
+    if (board_name && board_vendor)
         ret = g_strconcat(board_vendor, " ", board_name, NULL);
     else if (board_name)
         ret = g_strdup(board_name);
@@ -384,7 +380,6 @@ gchar *get_motherboard(void)
 
     free(board_name);
     free(board_vendor);
-    free(system_version);
     return ret;
 #endif
 


### PR DESCRIPTION
This reverts a change 2db563687071c099851c59396bdde29a00dba156.

It seems to me that using product version in this way gives
inconsistent values.
The recent benchmark result submitted demonstrates the problem:
`2.0 / X370 SLI PLUS (MS-7A33) (Micro-Star International Co., Ltd.)`

The product version `2.0` is put in front, but without the product
name or product vendor for context, it doesn't really add anything.
The board vendor, which otherwise would be in front, is now in () at
the end.

When the product version is not defined, then the motherboard is
reported as `<board vendor> <board name>`. The only time it is
`<board name> (<board vendor>)` is when product version is defined.

If this change is applied, that same motherboard would be reported
`Micro-Star International Co., Ltd. X370 SLI PLUS (MS-7A33)`
which, to me, makes more sense for get_motherboard(). I have no idea
what "product" this is version 2.0 of.
