### PR TITLE
Allow DMI on non-x86

### DIFF
--- a/includes/devices.h
+++ b/includes/devices.h
@@ -69,10 +69,8 @@ void scan_sensors_do(void);
 void sensors_init(void);
 void sensors_shutdown(void);
 
-#if defined(ARCH_x86) || defined(ARCH_x86_64)
 /* SPD */
 void scan_spd_do(void);
-#endif /* ARCH_x86 */
 
 extern gchar *battery_list;
 extern gchar *input_icons;
@@ -92,10 +90,8 @@ extern GHashTable *sensor_compute;
 extern GHashTable *sensor_labels;
 extern GModule *cups;
 
-#if defined(ARCH_x86) || defined(ARCH_x86_64)
 extern gchar *spd_info;
 extern gchar *dmi_info;
-#endif
 
 extern gchar *dtree_info;
 extern gchar *gpu_list;

--- a/modules/devices.c
+++ b/modules/devices.c
@@ -49,10 +49,8 @@ gchar *callback_printers();
 gchar *callback_storage();
 gchar *callback_input();
 gchar *callback_usb();
-#if defined(ARCH_x86) || defined(ARCH_x86_64)
 gchar *callback_dmi();
 gchar *callback_spd();
-#endif
 gchar *callback_dtree();
 gchar *callback_device_resources();
 
@@ -66,10 +64,8 @@ void scan_printers(gboolean reload);
 void scan_storage(gboolean reload);
 void scan_input(gboolean reload);
 void scan_usb(gboolean reload);
-#if defined(ARCH_x86) || defined(ARCH_x86_64)
 void scan_dmi(gboolean reload);
 void scan_spd(gboolean reload);
-#endif
 void scan_dtree(gboolean reload);
 void scan_device_resources(gboolean reload);
 
@@ -105,13 +101,11 @@ static ModuleEntry entries[] = {
     [ENTRY_SENSORS] = {N_("Sensors"), "therm.png", callback_sensors, scan_sensors, MODULE_FLAG_NONE},
     [ENTRY_INPUT] = {N_("Input Devices"), "inputdevices.png", callback_input, scan_input, MODULE_FLAG_NONE},
     [ENTRY_STORAGE] = {N_("Storage"), "hdd.png", callback_storage, scan_storage, MODULE_FLAG_NONE},
-#if defined(ARCH_x86) || defined(ARCH_x86_64)
     [ENTRY_DMI] = {N_("DMI"), "computer.png", callback_dmi, scan_dmi, MODULE_FLAG_NONE},
     [ENTRY_SPD] = {N_("Memory SPD"), "memory.png", callback_spd, scan_spd, MODULE_FLAG_NONE},
+#if defined(ARCH_x86) || defined(ARCH_x86_64)
     [ENTRY_DTREE] = {"#"},
 #else
-    [ENTRY_DMI] = {"#"},
-    [ENTRY_SPD] = {"#"},
     [ENTRY_DTREE] = {N_("Device Tree"), "devices.png", callback_dtree, scan_dtree, MODULE_FLAG_NONE},
 #endif	/* x86 or x86_64 */
     [ENTRY_RESOURCES] = {N_("Resources"), "resources.png", callback_device_resources, scan_device_resources, MODULE_FLAG_NONE},
@@ -537,7 +531,6 @@ gchar *hi_get_field(gchar * field)
     return g_strdup(field);
 }
 
-#if defined(ARCH_x86) || defined(ARCH_x86_64)
 void scan_dmi(gboolean reload)
 {
     SCAN_START();
@@ -551,7 +544,6 @@ void scan_spd(gboolean reload)
     scan_spd_do();
     SCAN_END();
 }
-#endif
 
 void scan_dtree(gboolean reload)
 {
@@ -640,7 +632,6 @@ gchar *callback_processors()
     return processor_get_info(processors);
 }
 
-#if defined(ARCH_x86) || defined(ARCH_x86_64)
 gchar *callback_dmi()
 {
     return g_strdup(dmi_info);
@@ -650,7 +641,6 @@ gchar *callback_spd()
 {
     return g_strdup(spd_info);
 }
-#endif
 
 gchar *callback_dtree()
 {

--- a/modules/devices/dmi.c
+++ b/modules/devices/dmi.c
@@ -151,8 +151,11 @@ void __scan_dmi()
   dmi_ok = dmi_get_info();
 
   if (!dmi_ok) {
-    dmi_info = g_strdup("[No DMI information]\n"
-                        "There was an error retrieving the information.=\n"
-                        "Please try running HardInfo as root.=\n");
+    dmi_info = g_strdup_printf("[%s]\n%s=\n",
+                        _("DMI Unavailable"),
+                        (getuid() == 0)
+                            ? _("DMI is not avaliable. Perhaps this platform does not provide DMI.")
+                            : _("DMI is not available; Perhaps try running HardInfo as root.") );
+
   }
 }


### PR DESCRIPTION
There's nothing preventing this from running on non-x86. If it is not available it will just say so, like PCI.
