### PR TITLE
don't use html in text-only output

### DIFF
--- a/hardinfo/util.c
+++ b/hardinfo/util.c
@@ -491,6 +491,15 @@ void parameters_init(int *argc, char ***argv, ProgramParameters * param)
     if (report_format && g_str_equal(report_format, "html"))
 	param->report_format = REPORT_FORMAT_HTML;
 
+    /* html ok?
+     * gui: yes
+     * report html: yes
+     * report text: no
+     * anything else? */
+    param->html_ok = TRUE;
+    if (param->create_report && param->report_format != REPORT_FORMAT_HTML)
+        param->html_ok = FALSE;
+
     gchar *confdir = g_build_filename(g_get_user_config_dir(), "hardinfo", NULL);
     if (!g_file_test(confdir, G_FILE_TEST_EXISTS)) {
 	mkdir(confdir, 0744);

--- a/includes/hardinfo.h
+++ b/includes/hardinfo.h
@@ -52,6 +52,7 @@ struct _ProgramParameters {
   gboolean autoload_deps;
   gboolean run_xmlrpc_server;
   gboolean skip_benchmarks;
+  gboolean html_ok; /* ok to use html in the value part of a key/value */
 
   gint     report_format;
 

--- a/modules/devices/printers.c
+++ b/modules/devices/printers.c
@@ -33,7 +33,7 @@ struct _CUPSDest {
     char *name, *instance;
     int is_default;
     int num_options;
-    CUPSOption *options;  
+    CUPSOption *options;
 };
 
 static int (*cups_dests_get) (CUPSDest **dests) = NULL;
@@ -49,13 +49,13 @@ init_cups(void)
 
     if (!(cups_dests_get && cups_dests_free)) {
         int i;
-        
+
         for (i = 0; libcups[i] != NULL; i++) {
             cups = g_module_open(libcups[i], G_MODULE_BIND_LAZY);
             if (cups)
-                break; 
+                break;
         }
-        
+
         if (!cups) {
 	    cups_init = FALSE;
 	    return;
@@ -67,7 +67,7 @@ init_cups(void)
 	    cups_init = FALSE;
 	}
     }
-    
+
     cups_init = TRUE;
 }
 
@@ -76,7 +76,7 @@ gchar *__cups_callback_ptype(gchar *strvalue)
   if (strvalue) {
     unsigned value = atoi(strvalue);
     gchar *output = g_strdup("\n");
-    
+
     if (value & 0x0004)
       output = h_strdup_cprintf(_("\342\232\254 Can do black and white printing=\n"), output);
     if (value & 0x0008)
@@ -121,7 +121,7 @@ gchar *__cups_callback_state_change_time(gchar *value)
 {
   struct tm tm;
   char buf[255];
-  
+
   if (value) {
     strptime(value, "%s", &tm);
     strftime(buf, sizeof(buf), "%c", &tm);
@@ -148,25 +148,25 @@ const struct {
   { "Printer Information", NULL, NULL },
   { "printer-info", "Destination Name", NULL },
   { "printer-make-and-model", "Make and Model", NULL },
-  
+
   { "Capabilities", NULL, NULL },
   { "printer-type", "#", __cups_callback_ptype },
-  
+
   { "Printer State", NULL, NULL },
   { "printer-state", "State", __cups_callback_state },
   { "printer-state-change-time", "Change Time", __cups_callback_state_change_time },
   { "printer-state-reasons", "State Reasons" },
-  
+
   { "Sharing Information", NULL, NULL },
   { "printer-is-shared", "Shared?", __cups_callback_boolean },
   { "printer-location", "Physical Location" },
   { "auth-info-required", "Authentication Required", __cups_callback_boolean },
-  
+
   { "Jobs", NULL, NULL },
   { "job-hold-until", "Hold Until", NULL },
   { "job-priority", "Priority", NULL },
   { "printer-is-accepting-jobs", "Accepting Jobs", __cups_callback_boolean },
-  
+
   { "Media", NULL, NULL },
   { "media", "Media", NULL },
   { "finishings", "Finishings", NULL },
@@ -185,7 +185,7 @@ scan_printers_do(void)
 
     if (!cups_init) {
         init_cups();
-        
+
         printer_icons = g_strdup("");
         printer_list = g_strdup(_("[Printers]\n"
                                 "No suitable CUPS library found="));
@@ -201,22 +201,22 @@ scan_printers_do(void)
         printer_icons = g_strdup("");
 	for (i = 0; i < num_dests; i++) {
 	    GHashTable *options;
-	    
+
 	    options = g_hash_table_new(g_str_hash, g_str_equal);
-	    
+
 	    for (j = 0; j < dests[i].num_options; j++) {
 	      g_hash_table_insert(options,
 	                          g_strdup(dests[i].options[j].name),
 	                          g_strdup(dests[i].options[j].value));
 	    }
-	
+
             prn_id = g_strdup_printf("PRN%d", i);
-	
+
 	    printer_list = h_strdup_cprintf("\n$%s$%s=%s\n",
 					    printer_list,
-					    prn_id,						
+					    prn_id,
 					    dests[i].name,
-					    dests[i].is_default ? "<i>Default</i>" : "");
+					    dests[i].is_default ? ((params.html_ok) ? "<i>Default</i>" : "(Default)") : "");
             printer_icons = h_strdup_cprintf("\nIcon$%s$%s=printer.png",
                                              printer_icons,
                                              prn_id,
@@ -230,9 +230,9 @@ scan_printers_do(void)
                                                 cups_fields[j].key);
               } else {
                 gchar *temp;
-                
+
                 temp = g_hash_table_lookup(options, cups_fields[j].key);
-                
+
                 if (cups_fields[j].callback) {
                   temp = cups_fields[j].callback(temp);
                 } else {
@@ -243,21 +243,21 @@ scan_printers_do(void)
                     temp = g_strdup(_("Unknown"));
                   }
                 }
-                
+
                 prn_moreinfo = h_strdup_cprintf("%s=%s\n",
                                                 prn_moreinfo,
                                                 cups_fields[j].name,
                                                 temp);
-                
+
                 g_free(temp);
               }
             }
-            
+
             moreinfo_add_with_prefix("DEV", prn_id, prn_moreinfo);
             g_free(prn_id);
             g_hash_table_destroy(options);
 	}
-	
+
 	cups_dests_free(num_dests, dests);
     } else {
 	printer_list = g_strdup(_("[Printers]\n"

--- a/modules/devices/resources.c
+++ b/modules/devices/resources.c
@@ -37,21 +37,27 @@ static gchar *_resource_obtain_name(gchar *name)
                                0, 0, NULL);
       _regex_module = g_regex_new("^[0-9a-zA-Z\\_\\-]+$", 0, 0, NULL);
     }
-    
+
     name = g_strstrip(name);
-    
+
     if (g_regex_match(_regex_pci, name, 0, NULL)) {
       temp = module_call_method_param("devices::getPCIDeviceDescription", name);
       if (temp) {
+        if (params.html_ok)
           return g_strdup_printf("<b><small>PCI</small></b> %s", (gchar *)idle_free(temp));
+        else
+          return g_strdup_printf("PCI %s", (gchar *)idle_free(temp));
       }
     } else if (g_regex_match(_regex_module, name, 0, NULL)) {
       temp = module_call_method_param("computer::getKernelModuleDescription", name);
       if (temp) {
+        if (params.html_ok)
           return g_strdup_printf("<b><small>Module</small></b> %s", (gchar *)idle_free(temp));
+        else
+          return g_strdup_printf("Module %s", (gchar *)idle_free(temp));
       }
     }
-    
+
     return g_strdup(name);
 }
 #else
@@ -77,10 +83,10 @@ void scan_device_resources(gboolean reload)
       { "/proc/iomem", "[Memory]\n" },
       { "/proc/dma", "[DMA]\n" }
     };
-    
+
     g_free(_resources);
     _resources = g_strdup("");
-    
+
     for (i = 0; i < G_N_ELEMENTS(resources); i++) {
       if ((io = fopen(resources[i].file, "r"))) {
         _resources = h_strconcat(_resources, resources[i].description, NULL);
@@ -92,8 +98,12 @@ void scan_device_resources(gboolean reload)
           if (strstr(temp[0], "0000-0000"))
             zero_to_zero_addr++;
 
-          _resources = h_strdup_cprintf("<tt>%s</tt>=%s\n", _resources,
-                                        temp[0], name);
+          if (params.html_ok)
+            _resources = h_strdup_cprintf("<tt>%s</tt>=%s\n", _resources,
+                                          temp[0], name);
+          else
+            _resources = h_strdup_cprintf(">%s=%s\n", _resources,
+                                          temp[0], name);
 
           g_strfreev(temp);
           g_free(name);

--- a/modules/network.c
+++ b/modules/network.c
@@ -106,8 +106,13 @@ void scan_statistics(gboolean reload)
             gchar *tmp = buffer;
 
             while (*tmp && isspace(*tmp)) tmp++;
-
-            __statistics = h_strdup_cprintf("<b> </b>#%d=%s\n",
+                /* the bolded-space/dot used here is a hardinfo shell hack */
+                if (params.html_ok)
+                    __statistics = h_strdup_cprintf("<b> </b>#%d=%s\n",
+                                            __statistics,
+                                            line++, tmp);
+                else
+                    __statistics = h_strdup_cprintf(">#%d=%s\n",
                                             __statistics,
                                             line++, tmp);
           }


### PR DESCRIPTION
Fixes https://github.com/lpereira/hardinfo/issues/266

This is also needed so that vendor urls can be links where
appropriate.
