### PR TITLE
shell/report: allow "moreinfo" details to appear in reports; sort benchmark results in reports

### DIFF
--- a/hardinfo/util.c
+++ b/hardinfo/util.c
@@ -384,6 +384,7 @@ log_handler(const gchar * log_domain,
 void parameters_init(int *argc, char ***argv, ProgramParameters * param)
 {
     static gboolean create_report = FALSE;
+    static gboolean force_all_details = FALSE;
     static gboolean show_version = FALSE;
     static gboolean list_modules = FALSE;
     static gboolean autoload_deps = FALSE;
@@ -457,6 +458,12 @@ void parameters_init(int *argc, char ***argv, ProgramParameters * param)
 	 .arg = G_OPTION_ARG_NONE,
 	 .arg_data = &skip_benchmarks,
 	 .description = N_("do not run benchmarks")},
+	{
+	 .long_name = "very-verbose",
+	 .short_name = 'w', /* like -vv */
+	 .arg = G_OPTION_ARG_NONE,
+	 .arg_data = &force_all_details,
+	 .description = N_("show all details")},
 	{NULL}
     };
     GOptionContext *ctx;
@@ -486,6 +493,7 @@ void parameters_init(int *argc, char ***argv, ProgramParameters * param)
     param->autoload_deps = autoload_deps;
     param->run_xmlrpc_server = run_xmlrpc_server;
     param->skip_benchmarks = skip_benchmarks;
+    param->force_all_details = force_all_details;
     param->argv0 = *(argv)[0];
 
     if (report_format && g_str_equal(report_format, "html"))

--- a/hardinfo/util.c
+++ b/hardinfo/util.c
@@ -407,7 +407,7 @@ void parameters_init(int *argc, char ***argv, ProgramParameters * param)
 	 .short_name = 'f',
 	 .arg = G_OPTION_ARG_STRING,
 	 .arg_data = &report_format,
-	 .description = N_("chooses a report format (text, html)")},
+	 .description = N_("chooses a report format ([text], html)")},
 	{
 	 .long_name = "run-benchmark",
 	 .short_name = 'b',
@@ -496,8 +496,12 @@ void parameters_init(int *argc, char ***argv, ProgramParameters * param)
     param->force_all_details = force_all_details;
     param->argv0 = *(argv)[0];
 
-    if (report_format && g_str_equal(report_format, "html"))
-	param->report_format = REPORT_FORMAT_HTML;
+    if (report_format) {
+        if (g_str_equal(report_format, "html"))
+            param->report_format = REPORT_FORMAT_HTML;
+        if (g_str_equal(report_format, "shell"))
+            param->report_format = REPORT_FORMAT_SHELL;
+    }
 
     /* html ok?
      * gui: yes

--- a/includes/hardinfo.h
+++ b/includes/hardinfo.h
@@ -46,6 +46,7 @@ typedef struct _ProgramParameters	ProgramParameters;
 
 struct _ProgramParameters {
   gboolean create_report;
+  gboolean force_all_details; /* for create_report, include any "moreinfo" that exists for any item */
   gboolean show_version;
   gboolean gui_running;
   gboolean list_modules;

--- a/includes/report.h
+++ b/includes/report.h
@@ -49,13 +49,19 @@ struct _ReportContext {
   void (*subsubtitle)	(ReportContext *ctx, gchar *text);
   void (*keyvalue)   	(ReportContext *ctx, gchar *key, gchar *value, gboolean highlight);
 
+  void (*details_start)     (ReportContext *ctx, gchar *key, gchar *value, gboolean highlight);
+  void (*details_section)   (ReportContext *ctx, gchar *name);
+  void (*details_keyvalue)  (ReportContext *ctx, gchar *key, gchar *value, gboolean highlight);
+  void (*details_end)       (ReportContext *ctx);
+
   ReportFormat		format;
 
   gboolean		is_image_enabled;
   gboolean		first_table;
+  gboolean		in_details;
 
   gboolean		show_column_headers;
-  guint			columns;
+  guint			columns, parent_columns;
   GHashTable		*column_titles;
 };
 
@@ -83,6 +89,7 @@ void 		 report_subtitle	(ReportContext *ctx, gchar *text);
 void 		 report_subsubtitle	(ReportContext *ctx, gchar *text);
 void		 report_key_value	(ReportContext *ctx, gchar *key, gchar *value, gboolean highlight);
 void		 report_table		(ReportContext *ctx, gchar *text);
+void		 report_details		(ReportContext *ctx, gchar *key, gchar *value, gboolean highlight, gchar *details);
 
 void             report_create_from_module_list(ReportContext *ctx, GSList *modules);
 gchar           *report_create_from_module_list_format(GSList *modules, ReportFormat format);

--- a/includes/report.h
+++ b/includes/report.h
@@ -24,6 +24,7 @@
 typedef enum {
     REPORT_FORMAT_HTML,
     REPORT_FORMAT_TEXT,
+    REPORT_FORMAT_SHELL,
     N_REPORT_FORMAT
 } ReportFormat;
 
@@ -81,6 +82,7 @@ void		 report_dialog_show();
 
 ReportContext	*report_context_html_new();
 ReportContext	*report_context_text_new();
+ReportContext	*report_context_shell_new();
 
 void		 report_header		(ReportContext *ctx);
 void		 report_footer		(ReportContext *ctx);

--- a/includes/shell.h
+++ b/includes/shell.h
@@ -97,10 +97,10 @@ struct _Shell {
 
     ShellViewType	 view_type;
     gboolean		 normalize_percentage;
-    
+
     gint		_pulses;
     ShellOrderType	_order_type;
-    
+
     GKeyFile		*hosts;
     HelpViewer		*help_viewer;
 };
@@ -109,7 +109,7 @@ struct _ShellSummary {
     GtkWidget		*header;
     GtkWidget		*scroll;
     GtkWidget		*view;
-    
+
     GSList		*items;
 };
 
@@ -127,7 +127,7 @@ struct _ShellInfoTree {
     GtkWidget		*view;
     GtkTreeModel        *model;
     GtkTreeSelection	*selection;
-    
+
     GtkTreeViewColumn	 *col_progress, *col_value, *col_extra1, *col_extra2, *col_textvalue;
 };
 
@@ -144,7 +144,7 @@ struct _ShellModule {
     gpointer		(*aboutfunc) ();
     gchar		*(*summaryfunc) ();
     void		(*deinit) ();
-    
+
     guchar		 weight;
 
     GSList		*entries;
@@ -162,7 +162,7 @@ struct _ShellModuleEntry {
     gboolean		 selected;
     gint		 number;
     guint32		 flags;
-    
+
     gchar		*(*func) ();
     void		(*scan_func) ();
 
@@ -219,6 +219,13 @@ void		shell_save_hosts_file(void);
 void		shell_update_remote_menu(void);
 
 void		shell_set_remote_label(Shell *shell, gchar *label);
+
+/* decode special information in keys */
+gboolean    key_is_flagged(gchar *key);       /* has $[<flags>][<tag>]$ at the start of the key */
+gboolean    key_is_highlighted(gchar *key);   /* flag '*' = select/highlight */
+gboolean    key_wants_details(gchar *key);    /* flag '!' = report should include the "moreinfo" */
+gchar       *key_mi_tag(gchar *key);          /* moreinfo lookup tag */
+const gchar *key_get_name(gchar *key);        /* get the key's name, flagged or not */
 
 #endif				/* __SHELL_H__ */
 

--- a/modules/devices/arm/processor.c
+++ b/modules/devices/arm/processor.c
@@ -485,7 +485,7 @@ gchar *processor_get_info(GSList * processors)
     gchar *meta; /* becomes owned by more_info? no need to free? */
     GSList *l;
 
-    tmp = g_strdup_printf("$CPU_META$%s=\n", _("SOC/Package Information") );
+    tmp = g_strdup_printf("$!CPU_META$%s=\n", _("SOC/Package Information") );
 
     meta = processor_meta(processors);
     moreinfo_add_with_prefix("DEV", "CPU_META", meta);

--- a/modules/devices/devicetree.c
+++ b/modules/devices/devicetree.c
@@ -216,13 +216,14 @@ static gchar *get_summary(dtr *dt) {
     return ret;
 }
 
-static void mi_add(const char *key, const char *value) {
+static void mi_add(const char *key, const char *value, int report_details) {
     gchar *ckey, *rkey;
 
     ckey = hardinfo_clean_label(key, 0);
     rkey = g_strdup_printf("%s:%s", "DTREE", ckey);
 
-    dtree_info = h_strdup_cprintf("$%s$%s=\n", dtree_info, rkey, ckey);
+    dtree_info = h_strdup_cprintf("$%s%s$%s=\n", dtree_info,
+        (report_details) ? "!" : "", rkey, ckey);
     moreinfo_add_with_prefix("DEV", rkey, g_strdup(value));
 
     g_free(ckey);
@@ -241,7 +242,7 @@ static void add_keys(dtr *dt, char *np) {
     obj = dtr_obj_read(dt, np);
     dt_path = dtr_obj_path(obj);
     n_info = get_node(dt, dt_path);
-    mi_add(dt_path, n_info);
+    mi_add(dt_path, n_info, 0);
 
     dir_path = g_strdup_printf("%s/%s", dtr_base_path(dt), np);
     dir = g_dir_open(dir_path, 0 , NULL);
@@ -289,13 +290,13 @@ void __scan_dtree()
     gchar *messages = NULL;
 
     dtree_info = g_strdup("[Device Tree]\n");
-    mi_add("Summary", summary);
-    mi_add("Maps", maps);
+    mi_add("Summary", summary, 1);
+    mi_add("Maps", maps, 0);
 
     if(dtr_was_found(dt))
         add_keys(dt, "/");
     messages = msg_section(dt, 0);
-    mi_add("Messages", messages);
+    mi_add("Messages", messages, 0);
 
     g_free(summary);
     g_free(maps);

--- a/modules/devices/x86/processor.c
+++ b/modules/devices/x86/processor.c
@@ -844,7 +844,7 @@ gchar *processor_get_info(GSList * processors)
     gchar *meta; /* becomes owned by more_info? no need to free? */
     GSList *l;
 
-    tmp = g_strdup_printf("$CPU_META$%s=\n", _("Package Information") );
+    tmp = g_strdup_printf("$!CPU_META$%s=\n", _("Package Information") );
 
     meta = processor_meta(processors);
     moreinfo_add_with_prefix("DEV", "CPU_META", meta);

--- a/shell/report.c
+++ b/shell/report.c
@@ -299,12 +299,15 @@ void report_table(ReportContext * ctx, gchar * text)
                     if ( key_is_flagged(key) ) {
                         gchar *mi_tag = key_mi_tag(key);
                         gchar *mi_data = NULL; /*const*/
-                        if (key_wants_details(key)) {
+
+                        if (key_wants_details(key) || params.force_all_details)
                             mi_data = ctx->entry->morefunc(mi_tag);
+
+                        if (mi_data)
                             report_details(ctx, (gchar*)key_get_name(key), value, key_is_highlighted(key), mi_data);
-                        } else {
+                        else
                             report_key_value(ctx, (gchar*)key_get_name(key), value, key_is_highlighted(key) );
-                        }
+
                         g_free(mi_tag);
                     } else {
                         report_key_value(ctx, key, value, FALSE);

--- a/shell/shell.c
+++ b/shell/shell.c
@@ -1242,11 +1242,11 @@ group_handle_normal(GKeyFile * key_file, ShellModuleEntry * entry,
             *(strchr(flags+1, '$')+1) = 0;
 
             gtk_tree_store_set(store, &child, INFO_TREE_COL_NAME,
-                _(name), INFO_TREE_COL_DATA, flags, -1);
+                name, INFO_TREE_COL_DATA, flags, -1);
 
             g_free(flags);
         } else {
-            gtk_tree_store_set(store, &child, INFO_TREE_COL_NAME, _(key),
+            gtk_tree_store_set(store, &child, INFO_TREE_COL_NAME, key,
                 INFO_TREE_COL_DATA, NULL, -1);
         }
 


### PR DESCRIPTION
* Fixes #223
* Used by  Devices/Processors/Package Info
* Used by Devices/Device Tree/Summary
* Can be forced for all items with -w

Somewhat related:
* Report benchmark results are now sorted and limited to the 10 nearest results to avoid clutter.
* A new "shell" report format that is very useful for debugging, is not advertised in --help

