### PR TITLE
params: html_ok -> markup_ok

### DIFF
--- a/hardinfo/hardinfo.c
+++ b/hardinfo/hardinfo.c
@@ -92,13 +92,17 @@ int main(int argc, char **argv)
     }
 
     if (!params.create_report && !params.run_benchmark) {
-	/* we only try to open the UI if the user didn't ask for a report. */
-	params.gui_running = ui_init(&argc, &argv);
+        /* we only try to open the UI if the user didn't ask for a report. */
+        params.gui_running = ui_init(&argc, &argv);
 
-	/* as a fallback, if GTK+ initialization failed, run in report
-	   generation mode. */
-	if (!params.gui_running)
-	    params.create_report = TRUE;
+        /* as a fallback, if GTK+ initialization failed, run in report
+           generation mode. */
+        if (!params.gui_running) {
+            params.create_report = TRUE;
+            /* ... it is possible to -f html without -r */
+            if (params.report_format != REPORT_FORMAT_HTML)
+                params.markup_ok = FALSE;
+        }
     }
 
     if (params.use_modules) {

--- a/hardinfo/util.c
+++ b/hardinfo/util.c
@@ -496,9 +496,9 @@ void parameters_init(int *argc, char ***argv, ProgramParameters * param)
      * report html: yes
      * report text: no
      * anything else? */
-    param->html_ok = TRUE;
+    param->markup_ok = TRUE;
     if (param->create_report && param->report_format != REPORT_FORMAT_HTML)
-        param->html_ok = FALSE;
+        param->markup_ok = FALSE;
 
     gchar *confdir = g_build_filename(g_get_user_config_dir(), "hardinfo", NULL);
     if (!g_file_test(confdir, G_FILE_TEST_EXISTS)) {

--- a/includes/hardinfo.h
+++ b/includes/hardinfo.h
@@ -52,7 +52,14 @@ struct _ProgramParameters {
   gboolean autoload_deps;
   gboolean run_xmlrpc_server;
   gboolean skip_benchmarks;
-  gboolean html_ok; /* ok to use html in the value part of a key/value */
+
+  /*
+   * OK to use the common parts of HTML(4.0) and Pango Markup
+   * in the value part of a key/value.
+   * Including the (b,big,i,s,sub,sup,small,tt,u) tags.
+   * https://developer.gnome.org/pango/stable/PangoMarkupFormat.html
+   */
+  gboolean markup_ok;
 
   gint     report_format;
 

--- a/modules/devices/printers.c
+++ b/modules/devices/printers.c
@@ -216,7 +216,7 @@ scan_printers_do(void)
 					    printer_list,
 					    prn_id,
 					    dests[i].name,
-					    dests[i].is_default ? ((params.html_ok) ? "<i>Default</i>" : "(Default)") : "");
+					    dests[i].is_default ? ((params.markup_ok) ? "<i>Default</i>" : "(Default)") : "");
             printer_icons = h_strdup_cprintf("\nIcon$%s$%s=printer.png",
                                              printer_icons,
                                              prn_id,

--- a/modules/devices/resources.c
+++ b/modules/devices/resources.c
@@ -43,7 +43,7 @@ static gchar *_resource_obtain_name(gchar *name)
     if (g_regex_match(_regex_pci, name, 0, NULL)) {
       temp = module_call_method_param("devices::getPCIDeviceDescription", name);
       if (temp) {
-        if (params.html_ok)
+        if (params.markup_ok)
           return g_strdup_printf("<b><small>PCI</small></b> %s", (gchar *)idle_free(temp));
         else
           return g_strdup_printf("PCI %s", (gchar *)idle_free(temp));
@@ -51,7 +51,7 @@ static gchar *_resource_obtain_name(gchar *name)
     } else if (g_regex_match(_regex_module, name, 0, NULL)) {
       temp = module_call_method_param("computer::getKernelModuleDescription", name);
       if (temp) {
-        if (params.html_ok)
+        if (params.markup_ok)
           return g_strdup_printf("<b><small>Module</small></b> %s", (gchar *)idle_free(temp));
         else
           return g_strdup_printf("Module %s", (gchar *)idle_free(temp));
@@ -98,7 +98,7 @@ void scan_device_resources(gboolean reload)
           if (strstr(temp[0], "0000-0000"))
             zero_to_zero_addr++;
 
-          if (params.html_ok)
+          if (params.markup_ok)
             _resources = h_strdup_cprintf("<tt>%s</tt>=%s\n", _resources,
                                           temp[0], name);
           else

--- a/modules/network.c
+++ b/modules/network.c
@@ -107,7 +107,7 @@ void scan_statistics(gboolean reload)
 
             while (*tmp && isspace(*tmp)) tmp++;
                 /* the bolded-space/dot used here is a hardinfo shell hack */
-                if (params.html_ok)
+                if (params.markup_ok)
                     __statistics = h_strdup_cprintf("<b> </b>#%d=%s\n",
                                             __statistics,
                                             line++, tmp);


### PR DESCRIPTION
The html_ok param added in 970174b0897d40b804808632784ffa1544d9da93
is misleading. It turns out that it is not HTML,
but Pango Markup that is used by GTK, and a subset of that
happens to also work as HTML4 for the HTML report generation.

This change renames html_ok to markup_ok in ProgramParameters
and adds a comment explaining what common set of tags may be
used.

Also, if report generation happens as a fallback after GUI
initialization failed, then also disable markup, unless report
will be generated as HTML.

Pango markup info at:
https://developer.gnome.org/pango/stable/PangoMarkupFormat.html
