### PR TITLE
Fixes for #298

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -219,6 +219,16 @@ add_library(uber-graph STATIC
 )
 endif()
 
+set_source_files_properties(
+	hardinfo/usb_util.c
+	hardinfo/pci_util.c
+	hardinfo/gpu_util.c
+	hardinfo/cpu_util.c
+	hardinfo/x_util.c
+	PROPERTIES
+	COMPILE_FLAGS "-Wall -Wextra -Wno-parentheses -Wno-unused-function"
+)
+
 if (HARDINFO_GTK3)
 add_executable(hardinfo
 	hardinfo/usb_util.c

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -225,6 +225,7 @@ set_source_files_properties(
 	hardinfo/gpu_util.c
 	hardinfo/cpu_util.c
 	hardinfo/x_util.c
+	hardinfo/dt_util.c
 	PROPERTIES
 	COMPILE_FLAGS "-Wall -Wextra -Wno-parentheses -Wno-unused-function"
 )

--- a/hardinfo/gpu_util.c
+++ b/hardinfo/gpu_util.c
@@ -28,7 +28,7 @@ nvgpu *nvgpu_new() {
     return g_new0(nvgpu, 1);
 }
 
-void *nvgpu_free(nvgpu *s) {
+void nvgpu_free(nvgpu *s) {
     if (s) {
         free(s->model);
         free(s->bios_version);

--- a/hardinfo/gpu_util.c
+++ b/hardinfo/gpu_util.c
@@ -255,7 +255,7 @@ gpud *dt_soc_gpu() {
         { "brcm,bcm2835-vc4", "Broadcom", "VideoCore IV" },
         { "arm,mali-450", "ARM", "Mali 450" },
         { "arm,mali", "ARM", "Mali family" },
-        { NULL, NULL }
+        { NULL, NULL, NULL }
     };
     char tmp_path[256] = "";
     char *dt_gpu_path = NULL;
@@ -399,7 +399,7 @@ gpud *gpu_get_device_list() {
 
 /* Try other things ... */
 
-
+    return list;
 }
 
 

--- a/hardinfo/pci_util.c
+++ b/hardinfo/pci_util.c
@@ -80,9 +80,7 @@ static char *lspci_line_value(char *line, const char *prefix) {
 /* read output line of lspci -vmmnn */
 static int lspci_line_string_and_code(char *line, char *prefix, char **str, uint32_t *code) {
     char *l = lspci_line_value(line, prefix);
-    char buff[512] = "";
     char *e;
-    int ec;
 
     if (l) {
         e = strchr(l, 0);
@@ -97,7 +95,7 @@ static int lspci_line_string_and_code(char *line, char *prefix, char **str, uint
 
 static gboolean pci_fill_details(pcid *s) {
     gboolean spawned;
-    gchar *out, *err, *p, *l, *t, *next_nl;
+    gchar *out, *err, *p, *l, *next_nl;
     gchar *pci_loc = pci_address_str(s->domain, s->bus, s->device, s->function);
     gchar *lspci_cmd = g_strdup_printf("lspci -D -s %s -vvv", pci_loc);
 
@@ -154,9 +152,9 @@ gboolean _sysfs_bus_pci_read_hex(uint32_t dom, uint32_t bus, uint32_t dev, uint3
         if (ec) {
             *val = tval;
             return TRUE;
-        } else
-            return FALSE;
+        }
     }
+    return FALSE;
 }
 
 /* https://www.kernel.org/doc/Documentation/ABI/testing/sysfs-bus-pci */
@@ -204,7 +202,7 @@ static gboolean pci_get_device_sysfs(uint32_t dom, uint32_t bus, uint32_t dev, u
 
 static gboolean pci_get_device_lspci(uint32_t dom, uint32_t bus, uint32_t dev, uint32_t func, pcid *s) {
     gboolean spawned;
-    gchar *out, *err, *p, *l, *t, *next_nl;
+    gchar *out, *err, *p, *l, *next_nl;
     gchar *pci_loc = pci_address_str(dom, bus, dev, func);
     gchar *lspci_cmd = g_strdup_printf("lspci -D -s %s -vmmnn", pci_loc);
 

--- a/hardinfo/pci_util.c
+++ b/hardinfo/pci_util.c
@@ -168,7 +168,8 @@ static gboolean pci_get_device_sysfs(uint32_t dom, uint32_t bus, uint32_t dev, u
     s->bus = bus;
     s->device = dev;
     s->function = func;
-    _sysfs_bus_pci_read_hex(dom, bus, dev, func, "class", &s->class);
+    if (! _sysfs_bus_pci_read_hex(dom, bus, dev, func, "class", &s->class) )
+        return FALSE;
     s->class >>= 8; /* TODO: find out why */
     _sysfs_bus_pci_read_hex(dom, bus, dev, func, "device", &s->device_id);
     _sysfs_bus_pci_read_hex(dom, bus, dev, func, "vendor", &s->vendor_id);
@@ -198,7 +199,7 @@ static gboolean pci_get_device_sysfs(uint32_t dom, uint32_t bus, uint32_t dev, u
         s->pcie_width_curr = strtoul(tmp, NULL, 0);
         free(tmp);
     }
-
+    return TRUE;
 }
 
 static gboolean pci_get_device_lspci(uint32_t dom, uint32_t bus, uint32_t dev, uint32_t func, pcid *s) {
@@ -248,7 +249,7 @@ static gboolean pci_get_device_lspci(uint32_t dom, uint32_t bus, uint32_t dev, u
 
 pcid *pci_get_device(uint32_t dom, uint32_t bus, uint32_t dev, uint32_t func) {
     pcid *s = pcid_new();
-    int ok = 0;
+    gboolean ok = FALSE;
     if (s) {
         ok = pci_get_device_sysfs(dom, bus, dev, func, s);
         ok |= pci_get_device_lspci(dom, bus, dev, func, s);

--- a/hardinfo/x_util.c
+++ b/hardinfo/x_util.c
@@ -54,10 +54,8 @@ static char *simple_line_value(char *line, const char *prefix) {
 
 gboolean fill_glx_info(glx_info *glx) {
     gboolean spawned;
-    gchar *out, *err, *p, *l, *t, *next_nl;
+    gchar *out, *err, *p, *l, *next_nl;
     gchar *glx_cmd = g_strdup("glxinfo");
-
-    int ec;
 
 #define GLX_MATCH_LINE(prefix_str, struct_member) \
     if (l = simple_line_value(p, prefix_str)) { glx->struct_member = g_strdup(l); goto glx_next_line; }
@@ -120,10 +118,8 @@ void glx_free(glx_info *s) {
 
 gboolean fill_xinfo(xinfo *xi) {
     gboolean spawned;
-    gchar *out, *err, *p, *l, *t, *next_nl;
+    gchar *out, *err, *p, *l, *next_nl;
     gchar *xi_cmd = g_strdup("xdpyinfo");
-
-    int ec;
 
 #define XI_MATCH_LINE(prefix_str, struct_member) \
     if (l = simple_line_value(p, prefix_str)) { xi->struct_member = g_strdup(l); goto xi_next_line; }
@@ -154,10 +150,10 @@ gboolean fill_xinfo(xinfo *xi) {
 
 gboolean fill_xrr_info(xrr_info *xrr) {
     gboolean spawned;
-    gchar *out, *err, *p, *l, *t, *next_nl;
+    gchar *out, *err, *p, *next_nl;
     gchar *xrr_cmd = g_strdup("xrandr");
-
     int ec;
+
     x_screen ts;
     x_output to;
     char output_id[128];

--- a/includes/hardinfo.h
+++ b/includes/hardinfo.h
@@ -19,6 +19,9 @@
 #ifndef __HARDINFO_H__
 #define __HARDINFO_H__
 
+#include <stdio.h>
+#include <string.h>
+#include <ctype.h>
 #include <unistd.h>
 #include <gtk/gtk.h>
 #include "config.h"

--- a/modules/benchmark/bench_results.c
+++ b/modules/benchmark/bench_results.c
@@ -113,7 +113,7 @@ static int cpu_config_is_close(char *str0, char *str1) {
     return 0;
 }
 
-static gen_machine_id(bench_machine *m) {
+static void gen_machine_id(bench_machine *m) {
     char *s;
     if (m) {
         if (m->mid != NULL)

--- a/modules/benchmark/zlib.c
+++ b/modules/benchmark/zlib.c
@@ -22,10 +22,17 @@
 
 #include "benchmark.h"
 
+/* must be less than or equal to
+ * file size of ( params.path_data + "benchmark.data" ) */
+#define BENCH_DATA_SIZE 65536
+
+#define BENCH_EVENTS 50000
+#define BENCH_WTF_NUMBER 840205128
+
 static gpointer zlib_for(unsigned int start, unsigned int end, void *data, gint thread_number)
 {
     char *compressed;
-    uLong bound = compressBound(bound);
+    uLong bound = compressBound(BENCH_DATA_SIZE);
     unsigned int i;
 
     compressed = malloc(bound);
@@ -33,11 +40,11 @@ static gpointer zlib_for(unsigned int start, unsigned int end, void *data, gint 
         return NULL;
 
     for (i = start; i <= end; i++) {
-        char uncompressed[65536];
+        char uncompressed[BENCH_DATA_SIZE];
         uLong compressedBound = bound;
         uLong destBound = sizeof(uncompressed);
 
-        compress(compressed, &compressedBound, data, 65536);
+        compress(compressed, &compressedBound, data, BENCH_DATA_SIZE);
         uncompress(uncompressed, &destBound, compressed, compressedBound);
     }
 
@@ -61,13 +68,13 @@ benchmark_zlib(void)
     shell_view_set_enabled(FALSE);
     shell_status_update("Running Zlib benchmark...");
 
-    r = benchmark_parallel_for(0, 0, 50000, zlib_for, tmpsrc);
+    r = benchmark_parallel_for(0, 0, BENCH_EVENTS, zlib_for, tmpsrc);
 
     g_free(bdata_path);
     g_free(tmpsrc);
 
-    //TODO: explain in code comments
-    gdouble marks = (50000. * 65536.) / (r.elapsed_time * 840205128.);
+    //TODO: explain in code comments!
+    gdouble marks = ((double)BENCH_EVENTS * (double)BENCH_DATA_SIZE) / (r.elapsed_time * (double)BENCH_WTF_NUMBER);
     r.result = marks;
     bench_results[BENCHMARK_ZLIB] = r;
 }

--- a/modules/devices/spd-decode.c
+++ b/modules/devices/spd-decode.c
@@ -947,7 +947,7 @@ static void decode_ddr_module_size(unsigned char *bytes, int *size)
     }
 }
 
-static void *decode_ddr_module_timings(unsigned char *bytes, float *tcl, float *trcd, float *trp, float *tras)
+static void decode_ddr_module_timings(unsigned char *bytes, float *tcl, float *trcd, float *trp, float *tras)
 {
     float ctime;
     float highest_cas = 0;

--- a/modules/network.c
+++ b/modules/network.c
@@ -27,6 +27,8 @@
 #include <sys/stat.h>
 
 #include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
 #include <netdb.h>
 
 #include <hardinfo.h>


### PR DESCRIPTION
For #298:

* [x] W: hardinfo implicit-pointer-decl /home/abuild/rpmbuild/BUILD/hardinfo-20181022T194523/hardinfo/dt_util.c:540
* [x] W: hardinfo implicit-pointer-decl /home/abuild/rpmbuild/BUILD/hardinfo-20181022T194523/hardinfo/vendor.c:119
* [x] W: hardinfo implicit-pointer-decl /home/abuild/rpmbuild/BUILD/hardinfo-20181022T194523/modules/benchmark/bench_results.c:127, 208
* [x] W: hardinfo implicit-pointer-decl /home/abuild/rpmbuild/BUILD/hardinfo-20181022T194523/modules/computer/os.c:396
* [x] W: hardinfo implicit-pointer-decl /home/abuild/rpmbuild/BUILD/hardinfo-20181022T194523/modules/network.c:152

I: Program is using uninitialized variables. Note the difference between "is used" and "may be used"
* [x] W: hardinfo uninitialized-variable /home/abuild/rpmbuild/BUILD/hardinfo-20181022T194523/modules/benchmark/zlib.c:28

I: Program returns random data in a function
* [x] E: hardinfo no-return-in-nonvoid-function /home/abuild/rpmbuild/BUILD/hardinfo-20181022T194523/hardinfo/gpu_util.c:37, 405
* [x] E: hardinfo no-return-in-nonvoid-function /home/abuild/rpmbuild/BUILD/hardinfo-20181022T194523/hardinfo/pci_util.c:202, 160
* [x] E: hardinfo no-return-in-nonvoid-function /home/abuild/rpmbuild/BUILD/hardinfo-20181022T194523/modules/benchmark/bench_results.c:137
* [x] E: hardinfo no-return-in-nonvoid-function /home/abuild/rpmbuild/BUILD/hardinfo-20181022T194523/modules/devices/spd-decode.c:982

----

* [x] E: hardinfo no-return-in-nonvoid-function /home/abuild/rpmbuild/BUILD/hardinfo-20181022T194523/hardinfo/gpu_util.c:405
* [x] E: hardinfo no-return-in-nonvoid-function /home/abuild/rpmbuild/BUILD/hardinfo-20181022T194523/hardinfo/pci_util.c:160