### PR TITLE
benchmark/zlib: new version of zlib benchmark

### DIFF
--- a/data/benchmark.conf
+++ b/data/benchmark.conf
@@ -317,9 +317,11 @@ AMD Athlon(tm) X2 Dual Core Processor BE-2300=4.373|2x 1899 MHz|Unknown
 Intel(R) Core(TM)2 Duo CPU E6750@ 2.66GHz=4.096|2x 2671 MHz|Unknown
 PowerPC 740/750=58.07682|280.00 MHz|Unknown
 2_0___X370_SLI_PLUS_(MS_7A33)_(Micro_Star_International_Co___Ltd_);AMD_Ryzen_5_1600_Six_Core_Processor;38400_00 = 1.209032; 1.209032; 1|1|2.0 / X370 SLI PLUS (MS-7A33) (Micro-Star International Co., Ltd.)|AMD Ryzen 5 1600 Six-Core Processor|1 physical processor; 6 cores; 12 threads|12x 3200.00 MHz|16377260|1|6|12|AMD Radeon (TM) R9 390 Series (HAWAII, DRM 3.26.0, 4.18.0, LLVM 6.0.1)|AMD/ATI Hawaii PRO + NVIDIA GeForce GTX 750
+
 [CPU Zlib]
-PowerPC 740/750=2150.597408|280.00 MHz|Unknown
-2_0___X370_SLI_PLUS_(MS_7A33)_(Micro_Star_International_Co___Ltd_);AMD_Ryzen_5_1600_Six_Core_Processor;38400_00 = 1.904608; 2.047665; 12|12|2.0 / X370 SLI PLUS (MS-7A33) (Micro-Star International Co., Ltd.)|AMD Ryzen 5 1600 Six-Core Processor|1 physical processor; 6 cores; 12 threads|12x 3200.00 MHz|16377260|1|6|12|AMD Radeon (TM) R9 390 Series (HAWAII, DRM 3.26.0, 4.18.0, LLVM 6.0.1)|AMD/ATI Hawaii PRO + NVIDIA GeForce GTX 750
+Raspberry_Pi_Model_B_Rev_1;Broadcom_BCM2835;900_00=0.550000; 7.000921; 1|1|Raspberry Pi Model B Rev 1|Broadcom BCM2835|1x ARM ARM1176 r0p7 (AArch32)|1x 900.00 MHz|233612|1|1|1||Broadcom VideoCore IV
+ASUS_PRIME_B350_PLUS;AMD_Ryzen_5_1600_Six_Core_Processor;38400_00=97.400000; 7.000335; 12|12|ASUS PRIME B350-PLUS|AMD Ryzen 5 1600 Six-Core Processor|1 physical processor; 6 cores; 12 threads|12x 3200.00 MHz|16423392|1|6|12|Radeon RX 560 Series (POLARIS11, DRM 3.26.0, 4.18.0-10-generic, LLVM 7.0.0)|AMD/ATI Baffin
+
 [GPU Drawing]
 
 [CPU Blowfish (Single-thread)]

--- a/modules/benchmark/zlib.c
+++ b/modules/benchmark/zlib.c
@@ -22,15 +22,12 @@
 
 #include "benchmark.h"
 
-/* must be less than or equal to
- * file size of ( params.path_data + "benchmark.data" ) */
-#define BENCH_DATA_SIZE 65536
+/* zip/unzip 256KB blocks for 7 seconds
+ * result is number of full completions / 100 */
+#define BENCH_DATA_SIZE 262144
+#define CRUNCH_TIME 7
 
-#define BENCH_EVENTS 50000
-#define BENCH_WTF_NUMBER 840205128
-
-static gpointer zlib_for(unsigned int start, unsigned int end, void *data, gint thread_number)
-{
+static gpointer zlib_for(void *in_data, gint thread_number) {
     char *compressed;
     uLong bound = compressBound(BENCH_DATA_SIZE);
     unsigned int i;
@@ -39,42 +36,64 @@ static gpointer zlib_for(unsigned int start, unsigned int end, void *data, gint 
     if (!compressed)
         return NULL;
 
-    for (i = start; i <= end; i++) {
-        char uncompressed[BENCH_DATA_SIZE];
-        uLong compressedBound = bound;
-        uLong destBound = sizeof(uncompressed);
+    char uncompressed[BENCH_DATA_SIZE];
+    uLong compressedBound = bound;
+    uLong destBound = sizeof(uncompressed);
 
-        compress(compressed, &compressedBound, data, BENCH_DATA_SIZE);
-        uncompress(uncompressed, &destBound, compressed, compressedBound);
-    }
+    compress(compressed, &compressedBound, in_data, BENCH_DATA_SIZE);
+    uncompress(uncompressed, &destBound, compressed, compressedBound);
 
     free(compressed);
 
     return NULL;
 }
 
+static gchar *get_test_data(gsize min_size) {
+    gchar *bdata_path, *data;
+    gsize data_size;
+
+    gchar *exp_data, *p;
+    gsize sz;
+
+    bdata_path = g_build_filename(params.path_data, "benchmark.data", NULL);
+    if (!g_file_get_contents(bdata_path, &data, &data_size, NULL)) {
+        g_free(bdata_path);
+        return NULL;
+    }
+
+    if (data_size < min_size) {
+        DEBUG("expanding %lu bytes of test data to %lu bytes", data_size, min_size);
+        exp_data = g_malloc(min_size + 1);
+        memcpy(exp_data, data, data_size);
+        p = exp_data + data_size;
+        sz = data_size;
+        while (sz < (min_size - data_size) ) {
+            memcpy(p, data, data_size);
+            p += data_size;
+            sz += data_size;
+        }
+        strncpy(p, data, min_size - sz);
+        g_free(data);
+        data = exp_data;
+    }
+    g_free(bdata_path);
+    return data;
+}
+
 void
 benchmark_zlib(void)
 {
     bench_value r = EMPTY_BENCH_VALUE;
-    gchar *tmpsrc, *bdata_path;
-
-    bdata_path = g_build_filename(params.path_data, "benchmark.data", NULL);
-    if (!g_file_get_contents(bdata_path, &tmpsrc, NULL, NULL)) {
-        g_free(bdata_path);
+    gchar *data = get_test_data(BENCH_DATA_SIZE);
+    if (!data)
         return;
-    }
 
     shell_view_set_enabled(FALSE);
     shell_status_update("Running Zlib benchmark...");
 
-    r = benchmark_parallel_for(0, 0, BENCH_EVENTS, zlib_for, tmpsrc);
-
-    g_free(bdata_path);
-    g_free(tmpsrc);
-
-    //TODO: explain in code comments!
-    gdouble marks = ((double)BENCH_EVENTS * (double)BENCH_DATA_SIZE) / (r.elapsed_time * (double)BENCH_WTF_NUMBER);
-    r.result = marks;
+    r = benchmark_crunch_for(CRUNCH_TIME, 0, zlib_for, data);
+    r.result /= 100;
     bench_results[BENCHMARK_ZLIB] = r;
+
+    g_free(data);
 }


### PR DESCRIPTION
The new version uses a fixed time (7s) and the results are much
more consistent than the previous version.

A couple results for the new version, one "low" and one "high",
replace the old results, which were quite strange.

This will probably conflict with #299.
