### PR TITLE
Fix missing icons

### DIFF
--- a/shell/shell.c
+++ b/shell/shell.c
@@ -1152,7 +1152,7 @@ group_handle_special(GKeyFile * key_file, ShellModuleEntry * entry,
 	    } else if (g_str_has_prefix(key, "Icon")) {
 		GtkTreeIter *iter = g_hash_table_lookup(update_tbl,
 							g_utf8_strchr(key,
-							       -1, '$') + 1);
+							       -1, '$') );
 
 		if (iter) {
 		    gchar *file =


### PR DESCRIPTION
Fixes https://github.com/lpereira/hardinfo/issues/304

After 9eaf1a7a96aabc021594bcc6f5fe2ef60da8fb0c, the
whole key part, including the opening and closing '$',
is stored in INFO_TREE_COL_DATA so that the
key_*() functions can be used against it anywhere.

The first '$' no longer needs to be skipped.