### PR TITLE
Re-added Desktop Environment field and added MATE version detection

### DIFF
--- a/modules/computer.c
+++ b/modules/computer.c
@@ -509,6 +509,7 @@ gchar *callback_os(void)
         info_field(_("User Name"), computer->os->username),
         info_field(_("Language"), computer->os->language),
         info_field(_("Home Directory"), computer->os->homedir),
+        info_field(_("Desktop Environment"), computer->os->desktop),
         info_field_last());
 
     info_add_group(info, _("Security"),

--- a/modules/computer/os.c
+++ b/modules/computer/os.c
@@ -131,6 +131,28 @@ detect_gnome_version(void)
     return NULL;
 }
 
+
+static gchar *
+detect_mate_version(void)
+{
+    gchar *tmp;
+    gchar *out;
+    gboolean spawned;
+
+    spawned = g_spawn_command_line_sync(
+        "mate-about --version", &out, NULL, NULL, NULL);
+    if (spawned) {
+        tmp = strstr(idle_free(out), _("MATE Desktop Environment "));
+
+        if (tmp) {
+            tmp += strlen(_("MATE Desktop Environment "));
+            return g_strdup_printf("MATE %s", strend(tmp, '\n'));
+        }
+    }
+
+    return NULL;
+}
+
 static gchar *
 detect_window_manager(void)
 {
@@ -191,6 +213,12 @@ detect_xdg_environment(const gchar *env_var)
 
         if (maybe_kde)
             return maybe_kde;
+    }
+    if (g_str_equal(tmp, "MATE") || g_str_equal(tmp, "mate")) {
+        gchar *maybe_mate = detect_mate_version();
+
+        if (maybe_mate)
+            return maybe_mate;
     }
 
     return g_strdup(tmp);


### PR DESCRIPTION
The Desktop Environment field was missing in current git master. I think it was removed by mistake, because the `detect_desktop_environment` function seems to be working just fine. I have also added function for detecting MATE version.