### PR TITLE
devices/sensors: hwmon improvements

### DIFF
--- a/modules/devices/sensors.c
+++ b/modules/devices/sensors.c
@@ -71,7 +71,7 @@ static void read_sensor_labels(gchar *driver) {
             }
 
             remove_quotes(value);
-            g_hash_table_insert(sensor_labels, key, value);
+            g_hash_table_insert(sensor_labels, key, g_strstrip(value));
 
             g_strfreev(names);
         } else if (lock && strstr(line, "ignore")) { /* ignore lines */

--- a/modules/devices/sensors.c
+++ b/modules/devices/sensors.c
@@ -236,6 +236,24 @@ static const struct HwmonSensor hwmon_sensors[] = {
         1000.0
     },
     {
+        "Current",
+        "^curr([0-9]+)_input$",
+        "%s/curr%d_input",
+        "%s/curr%d_label",
+        "curr%d",
+        "A",
+        1000.0
+    },
+    {
+        "Power",
+        "^power([0-9]+)_input$",
+        "%s/power%d_input",
+        "%s/power%d_label",
+        "power%d",
+        "W",
+        1000000.0
+    },
+    {
         "Voltage",
         "^cpu([0-9]+)_vid$",
         "%s/cpu%d_vid",


### PR DESCRIPTION
 - Performance improvement: instead of blindly trying to read sensor files 256 times, the sensor file names are determined based on directory listing. Because `g_dir_read_name` do not sort filenames, it is first determined which files exists and then read in for-loop. This also fixes my problems described in issue #312 
 - Added support for Current and Power sensors
 - Removed unwanted whitespace from sensor labels