### PR TITLE
devices/spd: Add initial DDR4 SPD support

### DIFF
--- a/modules/devices.c
+++ b/modules/devices.c
@@ -75,6 +75,7 @@ void scan_dtree(gboolean reload);
 void scan_device_resources(gboolean reload);
 
 gboolean root_required_for_resources(void);
+gboolean spd_decode_show_hinote(const char**);
 
 gchar *hi_more_info(gchar *entry);
 
@@ -831,6 +832,12 @@ const gchar *hi_note_func(gint entry)
     if (entry == ENTRY_RESOURCES) {
         if (root_required_for_resources()) {
             return g_strdup(_("Resource information requires superuser privileges"));
+        }
+    }
+    else if (entry == ENTRY_SPD){
+        const char *msg;
+        if (spd_decode_show_hinote(&msg)) {
+            return msg;
         }
     }
     return NULL;

--- a/modules/devices/spd-decode.c
+++ b/modules/devices/spd-decode.c
@@ -613,6 +613,8 @@ static const char **vendors[VENDORS_BANKS] = { vendors1, vendors2, vendors3, ven
     vendors7
 };
 
+gboolean ddr4_partial_data = FALSE;
+
 /*
  * We consider that no data was written to this area of the SPD EEPROM if
  * all bytes read 0x00 or all bytes read 0xff
@@ -1654,6 +1656,7 @@ static gchar *decode_dimms(GSList * dimm_list, gboolean use_sysfs, int max_size)
 	    detailed_info = decode_ddr4_sdram(bytes, &module_size);
 	    decode_ddr4_part_number(bytes, spd_size, part_number);
 	    decode_ddr4_module_manufacturer(bytes, spd_size, &manufacturer);
+	    ddr4_partial_data = ddr4_partial_data || (spd_size < 512);
 	    break;
 	case DDR_SDRAM:
 	    detailed_info = decode_ddr_sdram(bytes, &module_size);
@@ -1745,4 +1748,13 @@ void scan_spd_do(void)
                    _("SPD"), list,
                    _("Bank"), _("Size"), _("Manufacturer"), _("Model") );
     g_free(list);
+}
+
+gboolean spd_decode_show_hinote(const char **msg){
+    if (ddr4_partial_data){
+        *msg = g_strdup(_("A current driver has provided only partial DDR4 SPD data. Please load and\nconfigure ee1004 driver to obtain additional information about DDR4 SPD."));
+        return TRUE;
+    }
+
+    return FALSE;
 }


### PR DESCRIPTION
![Snímka obrazovky 2019-05-13 23-30-34](https://user-images.githubusercontent.com/10187350/57655823-1e671000-75d7-11e9-96d8-c286cbb99f8b.png)

This PR adds initial support for decoding DDR4 SPD. It is needed to have ee1004 driver loaded and properly configured.

If you are getting hinote _A current driver has provided only partial DDR4 SPD data_:
 - make sure ee1004 driver is loaded
 - unload eeprom driver
 - Follow these instructions how to instantiate ee1004 devices manually  (https://www.spinics.net/lists/linux-i2c/msg32331.html):

> First you must find out the i2c bus number of your motherboard's SMBus,
> using i2cdetect (i2cdetect is part of the i2c-tools package.) Example:
> ```
> # modprobe i2c-dev
> # i2cdetect -l | grep smbus
> i2c-4	smbus     	SMBus I801 adapter at f040      	SMBus adapter
> ```
> So the SMBus is i2c-4. Then you must find the I2C addresses of the
> SPD EEPROMs:
> ```
> # i2cdetect -y 4 0x50 0x57
>      0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f
> 00:                                                 
> 10:                                                 
> 20:                                                 
> 30:                                                 
> 40:                                                 
> 50: -- 51 -- 53 -- -- -- --                         
> 60:                                                 
> 70:                                                 
> ```
> So there are 2 DDR4 SPD EEPROMs, one at I2C address 0x51 and one at
> I2C address 0x53. To instantiate the devices, do:
> ```
> # echo ee1004 0x51 > /sys/bus/i2c/devices/i2c-4/new_device 
> # echo ee1004 0x53 > /sys/bus/i2c/devices/i2c-4/new_device 
> ```