### PR TITLE
devices/sensors - Sensors.conf parsing fixes

### DIFF
--- a/modules/devices/sensors.c
+++ b/modules/devices/sensors.c
@@ -84,14 +84,13 @@ static void read_sensor_labels(gchar *driver) {
                 p++;
             g_hash_table_insert(sensor_labels, g_strdup_printf("%s/%s", driver, p), "ignore");
         } else if (lock && strstr(line, "compute")) { /* compute lines */
+            strend(line, ',');
             gchar **formulas = g_strsplit(strstr(line, "compute") + 7, " ", 0);
             gchar *key = NULL, *formula = NULL;
 
             for (i = 0; formulas[i]; i++) {
                 if (formulas[i][0] == '\0')
                     continue;
-                if (formulas[i][0] == ',')
-                    break;
 
                 if (!key)
                     key = g_strdup_printf("%s/%s", driver, formulas[i]);


### PR DESCRIPTION
 1. commit - Formulas in a compute statement in sensors.conf are separated with comma. Current implementation worked only when there was space before comma. This commit should fix that.

 2. commit - Driver name was so far used as:
- part of label in "Sensor" column,
- part of the moreinfo key,
- label which was used to search actual hwmon device in sensors.conf (by "chip" statement). This was the issue, because according to the sensors.conf man page: chip statement contains "chip type"; which seems to be whatever is written in "name" file (according to sensors app output). Driver name and device name ("name" file) are not always the same. That's why I replaced driver name with device name.