### PR TITLE
move devices/memory to computer/memory usage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,6 +135,7 @@ set(MODULE_computer_SOURCES
 	modules/computer/languages.c
 	modules/computer/loadavg.c
 	modules/computer/memory.c
+	modules/computer/memory_usage.c
 	modules/computer/modules.c
 	modules/computer/os.c
 	modules/computer/uptime.c
@@ -146,7 +147,6 @@ set(MODULE_devices_SOURCES
 	modules/devices/${HARDINFO_ARCH}/processor.c
 	modules/devices/gpu.c
 	modules/devices/battery.c
-	modules/devices/devmemory.c
 	modules/devices/dmi.c
 	modules/devices/devicetree.c
 	modules/devices/inputdevices.c

--- a/includes/computer.h
+++ b/includes/computer.h
@@ -159,4 +159,9 @@ void scan_modules_do(void);
 void scan_filesystems(void);
 void scan_users_do(void);
 
+/* Memory Usage */
+extern GHashTable *memlabels;
+void init_memory_labels(void);
+void scan_memory_do(void);
+
 #endif				/* __COMPUTER_H__ */

--- a/includes/devices.h
+++ b/includes/devices.h
@@ -48,10 +48,6 @@ gchar *processor_describe_default(GSList * processors);
 gchar *processor_describe_by_counting_names(GSList * processors);
 gchar *processor_frequency_desc(GSList *processors);
 
-/* Memory */
-void init_memory_labels(void);
-void scan_memory_do(void);
-
 /* Printers */
 void init_cups(void);
 
@@ -85,7 +81,6 @@ extern gchar *storage_icons;
 extern gchar *storage_list;
 extern gchar *usb_list;
 extern gchar *usb_icons;
-extern GHashTable *memlabels;
 extern GHashTable *_pci_devices;
 extern GHashTable *sensor_compute;
 extern GHashTable *sensor_labels;

--- a/modules/benchmark.c
+++ b/modules/benchmark.c
@@ -652,7 +652,7 @@ static gchar *get_benchmark_results()
 
     gchar *machine = module_call_method("devices::getProcessorName");
     gchar *machineclock = module_call_method("devices::getProcessorFrequency");
-    gchar *machineram = module_call_method("devices::getMemoryTotal");
+    gchar *machineram = module_call_method("computer::getMemoryTotal");
     gchar *result = g_strdup_printf("[param]\n"
 				    "machine=%s\n"
 				    "machineclock=%s\n"

--- a/modules/benchmark/bench_results.c
+++ b/modules/benchmark/bench_results.c
@@ -156,7 +156,7 @@ bench_machine *bench_machine_this() {
         m->cpu_config = module_call_method("devices::getProcessorFrequencyDesc");
         m->gpu_desc = module_call_method("devices::getGPUList");
         m->ogl_renderer = module_call_method("computer::getOGLRenderer");
-        tmp = module_call_method("devices::getMemoryTotal");
+        tmp = module_call_method("computer::getMemoryTotal");
         m->memory_kiB = atoi(tmp);
         free(tmp);
 

--- a/modules/computer/memory_usage.c
+++ b/modules/computer/memory_usage.c
@@ -29,7 +29,12 @@ void scan_memory_do(void)
 
     if (offset == -1) {
         /* gah. linux 2.4 adds three lines of data we don't need in
-           /proc/meminfo */
+         * /proc/meminfo.
+         * The lines look something like this:
+         *  total: used: free: shared: buffers: cached:
+         *  Mem: 3301101568 1523159040 1777942528 0 3514368 1450356736
+         *  Swap: 0 0 0
+         */
         gchar *os_kernel = module_call_method("computer::getOSKernel");
         if (os_kernel) {
             offset = strstr(os_kernel, "Linux 2.4") ? 3 : 0;


### PR DESCRIPTION
As discussed in https://github.com/lpereira/hardinfo/issues/345.

Everything seems to be working, except there is now a message at startup:
> Module "Computer" depends on module "devices.so"

Didn't it always? I'm not sure what I changed that causes this message. This also blocks benchmarks from working, because the spawned process dies with this message.
Maybe @lpereira could fix that?