### PR TITLE
DMI socket/module information moved from Processor to Memory DMI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -148,6 +148,7 @@ set(MODULE_devices_SOURCES
 	modules/devices/gpu.c
 	modules/devices/battery.c
 	modules/devices/dmi.c
+	modules/devices/dmi_memory.c
 	modules/devices/devicetree.c
 	modules/devices/inputdevices.c
 	modules/devices/pci.c

--- a/modules/devices.c
+++ b/modules/devices.c
@@ -50,6 +50,7 @@ gchar *callback_storage();
 gchar *callback_input();
 gchar *callback_usb();
 gchar *callback_dmi();
+gchar *callback_dmi_mem();
 gchar *callback_spd();
 gchar *callback_dtree();
 gchar *callback_device_resources();
@@ -64,6 +65,7 @@ void scan_storage(gboolean reload);
 void scan_input(gboolean reload);
 void scan_usb(gboolean reload);
 void scan_dmi(gboolean reload);
+void scan_dmi_mem(gboolean reload);
 void scan_spd(gboolean reload);
 void scan_dtree(gboolean reload);
 void scan_device_resources(gboolean reload);
@@ -75,8 +77,11 @@ gchar *hi_more_info(gchar *entry);
 
 enum {
     ENTRY_DTREE,
+    ENTRY_DMI,
     ENTRY_PROCESSOR,
     ENTRY_GPU,
+    ENTRY_SPD,
+    ENTRY_DMI_MEM,
     ENTRY_PCI,
     ENTRY_USB,
     ENTRY_PRINTERS,
@@ -84,8 +89,6 @@ enum {
     ENTRY_SENSORS,
     ENTRY_INPUT,
     ENTRY_STORAGE,
-    ENTRY_DMI,
-    ENTRY_SPD,
     ENTRY_RESOURCES
 };
 
@@ -99,8 +102,9 @@ static ModuleEntry entries[] = {
     [ENTRY_SENSORS] = {N_("Sensors"), "therm.png", callback_sensors, scan_sensors, MODULE_FLAG_NONE},
     [ENTRY_INPUT] = {N_("Input Devices"), "inputdevices.png", callback_input, scan_input, MODULE_FLAG_NONE},
     [ENTRY_STORAGE] = {N_("Storage"), "hdd.png", callback_storage, scan_storage, MODULE_FLAG_NONE},
-    [ENTRY_DMI] = {N_("DMI"), "computer.png", callback_dmi, scan_dmi, MODULE_FLAG_NONE},
+    [ENTRY_DMI] = {N_("System DMI"), "computer.png", callback_dmi, scan_dmi, MODULE_FLAG_NONE},
     [ENTRY_SPD] = {N_("Memory SPD"), "memory.png", callback_spd, scan_spd, MODULE_FLAG_NONE},
+    [ENTRY_DMI_MEM] = {N_("Memory DMI"), "memory.png", callback_dmi_mem, scan_dmi_mem, MODULE_FLAG_NONE},
 #if defined(ARCH_x86) || defined(ARCH_x86_64)
     [ENTRY_DTREE] = {"#"},
 #else
@@ -118,6 +122,11 @@ gchar *input_list = NULL;
 gchar *storage_list = NULL;
 gchar *battery_list = NULL;
 gchar *lginterval = NULL;
+
+/* in dmi_memory.c */
+gchar *dmi_mem_socket_info();
+gboolean dmi_mem_show_hinote(const char **msg);
+gchar *dmi_mem_info = NULL;
 
 #include <vendor.h>
 
@@ -523,6 +532,15 @@ void scan_dmi(gboolean reload)
     SCAN_END();
 }
 
+void scan_dmi_mem(gboolean reload)
+{
+    SCAN_START();
+    if (dmi_mem_info)
+        g_free(dmi_mem_info);
+    dmi_mem_info = dmi_mem_socket_info();
+    SCAN_END();
+}
+
 void scan_spd(gboolean reload)
 {
     SCAN_START();
@@ -615,6 +633,11 @@ gchar *callback_processors()
 gchar *callback_dmi()
 {
     return g_strdup(dmi_info);
+}
+
+gchar *callback_dmi_mem()
+{
+    return g_strdup(dmi_mem_info);
 }
 
 gchar *callback_spd()
@@ -784,6 +807,12 @@ const gchar *hi_note_func(gint entry)
     else if (entry == ENTRY_SPD){
         const char *msg;
         if (spd_decode_show_hinote(&msg)) {
+            return msg;
+        }
+    }
+    else if (entry == ENTRY_DMI_MEM){
+        const char *msg;
+        if (dmi_mem_show_hinote(&msg)) {
             return msg;
         }
     }

--- a/modules/devices/dmi_memory.c
+++ b/modules/devices/dmi_memory.c
@@ -1,0 +1,138 @@
+/*
+ *    HardInfo - Displays System Information
+ *    Copyright (C) 2003-2019 Leandro A. F. Pereira <leandro@hardinfo.org>
+ *    Copyright (C) 2019 Burt P. <pburt0@gmail.com>
+ *
+ *    This program is free software; you can redistribute it and/or modify
+ *    it under the terms of the GNU General Public License as published by
+ *    the Free Software Foundation, version 2.
+ *
+ *    This program is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU General Public License for more details.
+ *
+ *    You should have received a copy of the GNU General Public License
+ *    along with this program; if not, write to the Free Software
+ *    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+ */
+
+#include "hardinfo.h"
+#include "devices.h"
+
+gboolean no_handles = FALSE;
+
+gchar *dmi_mem_socket_info() {
+    static const char empty_mem_str[] = "No Module Installed";
+    gchar *ret = strdup("");
+    unsigned long dtm = 17, i;
+    dmi_handle_list *hlm = dmidecode_handles(&dtm);
+    if (!hlm) {
+        no_handles = TRUE;
+        ret = g_strdup_printf("[%s]\n%s=%s\n",
+                _("Socket Information"), _("Result"),
+                (getuid() == 0)
+                ? _("(Not available)")
+                : _("(Not available; Perhaps try running HardInfo as root.)") );
+    } else {
+        no_handles = FALSE;
+        if (hlm) {
+            for(i = 0; i < hlm->count; i++) {
+                unsigned long h = hlm->handles[i];
+                gchar *locator = dmidecode_match("Locator", &dtm, &h);
+                gchar *size_str = dmidecode_match("Size", &dtm, &h);
+
+                if (strcmp(size_str, empty_mem_str) == 0) {
+                    ret = h_strdup_cprintf("[%s (%lu) %s]\n"
+                                    "%s=0x%x\n"
+                                    "%s=%s\n",
+                                    ret,
+                                    _("Memory Socket"), i, locator,
+                                    _("DMI Handle"), h,
+                                    _("Size"), _("(Empty)") );
+                } else {
+                    gchar *form_factor = dmidecode_match("Form Factor", &dtm, &h);
+                    gchar *type = dmidecode_match("Type", &dtm, &h);
+                    gchar *type_detail = dmidecode_match("Type Detail", &dtm, &h);
+                    gchar *speed_str = dmidecode_match("Speed", &dtm, &h);
+                    gchar *configured_clock_str = dmidecode_match("Configured Clock Speed", &dtm, &h);
+                    gchar *voltage_min_str = dmidecode_match("Minimum Voltage", &dtm, &h);
+                    gchar *voltage_max_str = dmidecode_match("Maximum Voltage", &dtm, &h);
+                    gchar *voltage_conf_str = dmidecode_match("Configured Voltage", &dtm, &h);
+                    gchar *mfgr = dmidecode_match("Manufacturer", &dtm, &h);
+                    gchar *partno = dmidecode_match("Part Number", &dtm, &h);
+
+                    gchar *vendor_str = NULL;
+                    if (mfgr) {
+                        const gchar *v_url = vendor_get_url(mfgr);
+                        if (v_url)
+                            vendor_str = g_strdup_printf(" (%s, %s)",
+                                vendor_get_name(mfgr), v_url );
+                        else
+                            vendor_str = g_strdup("");
+                    }
+
+#define UNKIFNULL2(f) ((f) ? f : _("(Unknown)"))
+
+                    ret = h_strdup_cprintf("[%s (%lu) %s]\n"
+                                    "%s=0x%x\n"
+                                    "%s=%s\n"
+                                    "%s=%s%s\n"
+                                    "%s=%s\n"
+                                    "%s=%s / %s\n"
+                                    "%s=%s\n"
+                                    "%s=%s\n"
+                                    "%s=%s\n"
+                                    "%s=%s\n"
+                                    "%s=%s\n"
+                                    "%s=%s\n",
+                                    ret,
+                                    _("Memory Socket"), i, locator,
+                                    _("DMI Handle"), h,
+                                    _("Form Factor"), UNKIFNULL2(form_factor),
+                                    _("Manufacturer"), UNKIFNULL2(mfgr), vendor_str,
+                                    _("Part Number"), UNKIFNULL2(partno),
+                                    _("Type"), UNKIFNULL2(type), UNKIFNULL2(type_detail),
+                                    _("Size"), UNKIFNULL2(size_str),
+                                    _("Speed"), UNKIFNULL2(speed_str),
+                                    _("Configured Clock Frequency"), UNKIFNULL2(configured_clock_str),
+                                    _("Minimum Voltage"), UNKIFNULL2(voltage_min_str),
+                                    _("Maximum Voltage"), UNKIFNULL2(voltage_max_str),
+                                    _("Configured Voltage"), UNKIFNULL2(voltage_conf_str)
+                                    );
+                    g_free(type);
+                    g_free(form_factor);
+                    g_free(speed_str);
+                    g_free(configured_clock_str);
+                    g_free(voltage_min_str);
+                    g_free(voltage_max_str);
+                    g_free(voltage_conf_str);
+                    g_free(mfgr);
+                    g_free(partno);
+                    g_free(vendor_str);
+                }
+                g_free(size_str);
+                g_free(locator);
+            }
+            dmi_handle_list_free(hlm);
+        }
+    }
+
+    return ret;
+}
+
+gboolean dmi_mem_show_hinote(const char **msg) {
+    if (no_handles) {
+        if (getuid() == 0) {
+            *msg = g_strdup(
+                _("To view DMI memory information the <b><i>dmidecode</i></b> utility must be\n"
+                  "available."));
+        } else {
+            *msg = g_strdup(
+                _("To view DMI memory information the <b><i>dmidecode</i></b> utility must be\n"
+                  "available, and HardInfo must be run with superuser privileges."));
+        }
+        return TRUE;
+    }
+    return FALSE;
+}

--- a/modules/devices/x86/processor.c
+++ b/modules/devices/x86/processor.c
@@ -679,11 +679,9 @@ gchar *processor_describe(GSList * processors) {
 }
 
 gchar *dmi_socket_info() {
-    static const char empty_mem_str[] = "No Module Installed";
     gchar *ret = strdup("");
-    unsigned long dt = 4, dtm = 17, i;
+    unsigned long dt = 4, i;
     dmi_handle_list *hl = dmidecode_handles(&dt);
-    dmi_handle_list *hlm = dmidecode_handles(&dtm);
     if (!hl) {
         ret = g_strdup_printf("[%s]\n%s=%s\n",
                 _("Socket Information"), _("Result"),
@@ -721,87 +719,6 @@ gchar *dmi_socket_info() {
         }
 
         dmi_handle_list_free(hl);
-
-        if (hlm) {
-            for(i = 0; i < hlm->count; i++) {
-                unsigned long h = hlm->handles[i];
-                gchar *locator = dmidecode_match("Locator", &dtm, &h);
-                gchar *size_str = dmidecode_match("Size", &dtm, &h);
-
-                if (strcmp(size_str, empty_mem_str) == 0) {
-                    ret = h_strdup_cprintf("[%s (%lu) %s]\n"
-                                    "%s=0x%x\n"
-                                    "%s=%s\n",
-                                    ret,
-                                    _("Memory Socket"), i, locator,
-                                    _("DMI Handle"), h,
-                                    _("Size"), _("(Empty)") );
-                } else {
-                    gchar *form_factor = dmidecode_match("Form Factor", &dtm, &h);
-                    gchar *type = dmidecode_match("Type", &dtm, &h);
-                    gchar *type_detail = dmidecode_match("Type Detail", &dtm, &h);
-                    gchar *speed_str = dmidecode_match("Speed", &dtm, &h);
-                    gchar *configured_clock_str = dmidecode_match("Configured Clock Speed", &dtm, &h);
-                    gchar *voltage_min_str = dmidecode_match("Minimum Voltage", &dtm, &h);
-                    gchar *voltage_max_str = dmidecode_match("Maximum Voltage", &dtm, &h);
-                    gchar *voltage_conf_str = dmidecode_match("Configured Voltage", &dtm, &h);
-                    gchar *mfgr = dmidecode_match("Manufacturer", &dtm, &h);
-                    gchar *partno = dmidecode_match("Part Number", &dtm, &h);
-
-                    gchar *vendor_str = NULL;
-                    if (mfgr) {
-                        const gchar *v_url = vendor_get_url(mfgr);
-                        if (v_url)
-                            vendor_str = g_strdup_printf(" (%s, %s)",
-                                vendor_get_name(mfgr), v_url );
-                        else
-                            vendor_str = g_strdup("");
-                    }
-
-#define UNKIFNULL2(f) ((f) ? f : _("(Unknown)"))
-
-                    ret = h_strdup_cprintf("[%s (%lu) %s]\n"
-                                    "%s=0x%x\n"
-                                    "%s=%s\n"
-                                    "%s=%s%s\n"
-                                    "%s=%s\n"
-                                    "%s=%s / %s\n"
-                                    "%s=%s\n"
-                                    "%s=%s\n"
-                                    "%s=%s\n"
-                                    "%s=%s\n"
-                                    "%s=%s\n"
-                                    "%s=%s\n",
-                                    ret,
-                                    _("Memory Socket"), i, locator,
-                                    _("DMI Handle"), h,
-                                    _("Form Factor"), UNKIFNULL2(form_factor),
-                                    _("Manufacturer"), UNKIFNULL2(mfgr), vendor_str,
-                                    _("Part Number"), UNKIFNULL2(partno),
-                                    _("Type"), UNKIFNULL2(type), UNKIFNULL2(type_detail),
-                                    _("Size"), UNKIFNULL2(size_str),
-                                    _("Speed"), UNKIFNULL2(speed_str),
-                                    _("Configured Clock Frequency"), UNKIFNULL2(configured_clock_str),
-                                    _("Minimum Voltage"), UNKIFNULL2(voltage_min_str),
-                                    _("Maximum Voltage"), UNKIFNULL2(voltage_max_str),
-                                    _("Configured Voltage"), UNKIFNULL2(voltage_conf_str)
-                                    );
-                    g_free(type);
-                    g_free(form_factor);
-                    g_free(speed_str);
-                    g_free(configured_clock_str);
-                    g_free(voltage_min_str);
-                    g_free(voltage_max_str);
-                    g_free(voltage_conf_str);
-                    g_free(mfgr);
-                    g_free(partno);
-                    g_free(vendor_str);
-                }
-                g_free(size_str);
-                g_free(locator);
-            }
-            dmi_handle_list_free(hlm);
-        }
     }
 
     return ret;


### PR DESCRIPTION
As discussed #345. Following #354.

SPD is still preferable because Hardinfo doesn't need to run as root, only the user has to add the required module. I would still like to merge Memory DMI and Memory SPD in the future, if a way can be found to match the information from DMI and SPD and create an abstract Memory Slot/Module structure to display.