### PR TITLE
devices/dmi_memory.c: shell viewtype=1 version, other tweaks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -199,6 +199,12 @@ set_source_files_properties(
 	COMPILE_FLAGS "-O0"
 )
 
+set_source_files_properties(
+	modules/devices/dmi_memory.c
+	PROPERTIES
+	COMPILE_FLAGS "-std=c99"
+)
+
 foreach (_module ${HARDINFO_MODULES})
 	add_library(${_module} MODULE ${MODULE_${_module}_SOURCES})
 	set_target_properties(${_module} PROPERTIES PREFIX "")

--- a/includes/hardinfo.h
+++ b/includes/hardinfo.h
@@ -99,11 +99,11 @@ struct _ModuleAbout {
 };
 
 /* String utility functions */
-inline void  remove_quotes(gchar *str);
-inline char *strend(gchar *str, gchar chr);
-inline void  remove_linefeed(gchar *str);
-gchar       *strreplacechr(gchar *string, gchar *replace, gchar new_char);
-gchar       *strreplace(gchar *string, gchar *replace, gchar *replacement);
+void   remove_quotes(gchar *str);
+char  *strend(gchar *str, gchar chr);
+void   remove_linefeed(gchar *str);
+gchar *strreplacechr(gchar *string, gchar *replace, gchar new_char);
+gchar *strreplace(gchar *string, gchar *replace, gchar *replacement);
 
 /* Widget utility functions */
 void widget_set_cursor(GtkWidget *widget, GdkCursorType cursor_type);
@@ -125,7 +125,7 @@ gpointer __idle_free(gpointer ptr, gchar *f, gint l);
 #endif	/* RELEASE == 1 */
 
 gchar	     *find_program(gchar *program_name);
-inline gchar *size_human_readable(gfloat size);
+gchar      *size_human_readable(gfloat size);
 void          nonblock_sleep(guint msec);
 void          open_url(gchar *url);
 GSList	     *modules_get_list(void);

--- a/modules/devices/dmi_memory.c
+++ b/modules/devices/dmi_memory.c
@@ -486,9 +486,10 @@ gchar *dmi_mem_socket_info_view1() {
                             _("Configured Voltage"), UNKIFNULL2(s->voltage_conf_str)
                             );
             moreinfo_add_with_prefix(key_prefix, key, details); /* moreinfo now owns *details */
+            const gchar *mfgr = s->mfgr ? vendor_get_shortest_name(s->mfgr) : NULL;
             ret = h_strdup_cprintf("$!%s$%s=%s|%s|%s\n",
                     ret,
-                    key, s->full_locator, UNKIFNULL2(s->partno), size_str, UNKIFNULL2(s->mfgr)
+                    key, s->full_locator, UNKIFNULL2(s->partno), size_str, UNKIFNULL2(mfgr)
                     );
             g_free(vendor_str);
             g_free(size_str);


### PR DESCRIPTION
ViewType=1 version:
![dmimem](https://user-images.githubusercontent.com/1758090/60146037-9c4d3800-978d-11e9-8e2c-073a9a532f8c.png)

Notes:
* add -std=c99 for dmi_memory.c to use a unicode arrow
* -std=c99 is picky about inline functions
