### PR TITLE
devices/spd-decode.c: show spd details in reports

### DIFF
--- a/modules/devices/spd-decode.c
+++ b/modules/devices/spd-decode.c
@@ -1770,7 +1770,7 @@ static gchar *decode_dimms(GSList *dimm_list, gboolean use_sysfs, int max_size) 
         if (!output)
             output = g_string_new("");
 
-        g_string_append_printf(output, "$MEM%d$%d=%s|%d MB|%s\n", count, count, part_number,
+        g_string_append_printf(output, "$!MEM%d$%d=%s|%d MB|%s\n", count, count, part_number,
                                module_size, manufacturer);
 
         g_free(spd_path);


### PR DESCRIPTION
Adding ! in front of the key causes the "moreinfo" details to be included in a `hardinfo -r` report.