### PR TITLE
GTK3/Benchmarks disable guibench only

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -170,7 +170,6 @@ set(MODULE_benchmark_SOURCES_GTKANY
 	modules/benchmark/blowfish.c
 	modules/benchmark/blowfish2.c
 	modules/benchmark/cryptohash.c
-	modules/benchmark/drawing.c
 	modules/benchmark/fbench.c
 	modules/benchmark/fftbench.c
 	modules/benchmark/fft.c
@@ -182,6 +181,7 @@ set(MODULE_benchmark_SOURCES_GTKANY
 	modules/benchmark/zlib.c
 )
 set(MODULE_benchmark_SOURCES_GTK2
+	modules/benchmark/drawing.c
 	modules/benchmark/guibench.c
 )
 if (HARDINFO_GTK3)

--- a/modules/benchmark/benches.c
+++ b/modules/benchmark/benches.c
@@ -54,6 +54,7 @@ BENCH_SCAN_SIMPLE(scan_cryptohash, benchmark_cryptohash, BENCHMARK_CRYPTOHASH);
 BENCH_SCAN_SIMPLE(scan_fib, benchmark_fib, BENCHMARK_FIB);
 BENCH_SCAN_SIMPLE(scan_zlib, benchmark_zlib, BENCHMARK_ZLIB);
 
+#if !GTK_CHECK_VERSION(3,0,0)
 void scan_gui(gboolean reload)
 {
     SCAN_START();
@@ -73,6 +74,7 @@ void scan_gui(gboolean reload)
     }
     SCAN_END();
 }
+#endif
 
 static ModuleEntry entries[] = {
     {N_("CPU Blowfish (Single-thread)"), "blowfish.png", callback_bfsh_single, scan_bfsh_single, MODULE_FLAG_NONE},


### PR DESCRIPTION
GTK3 build inadvertably disabled all benchmarking.
At present, the GTK3 build intentionally avoids building of "guibench"
due to non-trivial changes from GTK2 to GTK3.
However, all other benchmarks were disabled as well.
This was not by design, as non-gui benchmarks have no GTK3
dependencies.
The reason benchmarks were diasbled (did not show up in the menus)
was that the code for "benchark_gui" still referenced the missing "guibench"
routine. This routine was not present in the "benchmark.so", so the library
would not load due to the missing entry point.

This patch addresses the issue. All benchmarks (except guibench)
show/work fine with GTK3.

Signed-off-by: Juro Bystricky <juro.bystricky@intel.com>