### PR TITLE
add build-* dirs to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ config.h
 *~
 arch/this
 build/
+build-*/
 test/build-*
 po/*.old
 


### PR DESCRIPTION
I have build-gtk3/ and build-dbg/ that are annoying me
in the git status.

...if you don't mind.