### PR TITLE
Devices/storage: Better storage media labels

### DIFF
--- a/includes/udisks2_util.h
+++ b/includes/udisks2_util.h
@@ -12,7 +12,7 @@ typedef struct udiskd {
     gint32 rotation_rate;
     gint64 size;
     gchar *media;
-    gchar *media_compatibility;
+    gchar **media_compatibility;
     gboolean pm_supported;
     gboolean aam_supported;
     gboolean apm_supported;

--- a/shell/callbacks.c
+++ b/shell/callbacks.c
@@ -162,6 +162,7 @@ void cb_about()
         "Agney Lopes Roth Ferraz",
         "Andrey Esin",
         "Burt P.",
+        "Ondrej Čerman",
         "",
         _("Based on work by:"),
         _("MD5 implementation by Colin Plumb (see md5.c for details)"),


### PR DESCRIPTION
The media labels were changed to more familiar style.
For example: "optical_dvd_plus_rw_dl" was changed "DVD+RW DL".

Also I have added myself to contributors list in about dialog.