### PR TITLE
Memory devices: show bank in locator if needed 

### DIFF
--- a/hardinfo/dmi_util.c
+++ b/hardinfo/dmi_util.c
@@ -239,7 +239,7 @@ static char *dd_cache[128] = {};
 void dmidecode_cache_free()
 { int i; for(i = 0; i < 128; i++) g_free(dd_cache[i]); }
 
-char *dmidecode_read(const unsigned long *dmi_type) {
+char *dmidecode_read(const dmi_type *type) {
     gchar *ret = NULL;
     gchar full_path[PATH_MAX];
     gboolean spawned;
@@ -247,10 +247,10 @@ char *dmidecode_read(const unsigned long *dmi_type) {
 
     int i = 0;
 
-    if (dmi_type) {
-        if (dd_cache[*dmi_type])
-            return g_strdup(dd_cache[*dmi_type]);
-        snprintf(full_path, PATH_MAX, "dmidecode -t %lu", *dmi_type);
+    if (type) {
+        if (dd_cache[*type])
+            return g_strdup(dd_cache[*type]);
+        snprintf(full_path, PATH_MAX, "dmidecode -t %"PRId32, *type);
     } else {
         if (dd_cache[127])
             return g_strdup(dd_cache[127]);
@@ -269,8 +269,8 @@ char *dmidecode_read(const unsigned long *dmi_type) {
     }
 
     if (ret) {
-        if (*dmi_type)
-            dd_cache[*dmi_type] = g_strdup(ret);
+        if (*type)
+            dd_cache[*type] = g_strdup(ret);
         else
             dd_cache[127] = g_strdup(ret);
     }
@@ -278,25 +278,25 @@ char *dmidecode_read(const unsigned long *dmi_type) {
     return ret;
 }
 
-dmi_handle_list *dmi_handle_list_add(dmi_handle_list *hl, unsigned int new_handle) {
+dmi_handle_list *dmi_handle_list_add(dmi_handle_list *hl, dmi_handle new_handle) {
     if (!hl) {
         hl = malloc(sizeof(dmi_handle_list));
         hl->count = 1;
-        hl->handles = malloc(sizeof(unsigned long) * hl->count);
+        hl->handles = malloc(sizeof(dmi_handle) * hl->count);
     } else {
         hl->count++;
-        hl->handles = realloc(hl->handles, sizeof(unsigned long) * hl->count);
+        hl->handles = realloc(hl->handles, sizeof(dmi_handle) * hl->count);
     }
     hl->handles[hl->count - 1] = new_handle;
     return hl;
 }
 
-dmi_handle_list *dmidecode_handles(const unsigned long *dmi_type) {
+dmi_handle_list *dmidecode_handles(const dmi_type *type) {
     gchar *full = NULL, *p = NULL, *next_nl = NULL;
     dmi_handle_list *hl = NULL;
     unsigned int ch = 0;
 
-    full = dmidecode_read(dmi_type);
+    full = dmidecode_read(type);
     if (full) {
         p = full;
         while(next_nl = strchr(p, '\n')) {
@@ -317,7 +317,7 @@ void dmi_handle_list_free(dmi_handle_list *hl) {
     free(hl);
 }
 
-char *dmidecode_match(const char *name, const unsigned long *dmi_type, const unsigned long *handle) {
+char *dmidecode_match(const char *name, const dmi_type *type, const dmi_handle *handle) {
     gchar *ret = NULL, *full = NULL, *p = NULL, *next_nl = NULL;
     unsigned int ch = 0;
     int ln = 0;
@@ -325,7 +325,7 @@ char *dmidecode_match(const char *name, const unsigned long *dmi_type, const uns
     if (!name) return NULL;
     ln = strlen(name);
 
-    full = dmidecode_read(dmi_type);
+    full = dmidecode_read(type);
     if (full) {
         p = full;
         while(next_nl = strchr(p, '\n')) {
@@ -351,7 +351,7 @@ char *dmidecode_match(const char *name, const unsigned long *dmi_type, const uns
     return ret;
 }
 
-dmi_handle_list *dmidecode_match_value(const char *name, const char *value, const unsigned long *dmi_type) {
+dmi_handle_list *dmidecode_match_value(const char *name, const char *value, const dmi_type *type) {
     dmi_handle_list *hl = NULL;
     gchar *full = NULL, *p = NULL, *next_nl = NULL;
     unsigned int ch = 0;
@@ -361,7 +361,7 @@ dmi_handle_list *dmidecode_match_value(const char *name, const char *value, cons
     ln = strlen(name);
     lnv = (value) ? strlen(value) : 0;
 
-    full = dmidecode_read(dmi_type);
+    full = dmidecode_read(type);
     if (full) {
         p = full;
         while(next_nl = strchr(p, '\n')) {

--- a/includes/dmi_util.h
+++ b/includes/dmi_util.h
@@ -21,6 +21,11 @@
 #ifndef __DMI_UTIL_H__
 #define __DMI_UTIL_H__
 
+#include <inttypes.h>
+
+typedef uint32_t dmi_handle;
+typedef uint32_t dmi_type;
+
 /* -1 = yes, but will be ignored
  *  0 = no
  *  1 = yes */
@@ -34,22 +39,22 @@ char *dmi_get_str_abs(const char *id_str); /* include nonsense */
 char *dmi_chassis_type_str(int chassis_type, gboolean with_val);
 
 typedef struct {
-    unsigned long count;
-    unsigned long *handles;
+    uint32_t count;
+    dmi_handle *handles;
 } dmi_handle_list;
 
 /* get a list of handles that match a dmi_type */
-dmi_handle_list *dmidecode_handles(const unsigned long *dmi_type);
+dmi_handle_list *dmidecode_handles(const dmi_type *type);
 void dmi_handle_list_free(dmi_handle_list *hl);
 
 /* get a list of handles which have a name, and/or optional value, and/or limit to an optional dmi_type
  * dmidecode_match_value("Name", NULL, NULL) : all dmi handles with an item called "Name"
  * dmidecode_match_value("Name", "Value", NULL) : all dmi_handles with an item called "Name" that has a value of "Value"
  * dmidecode_match_value("Name", "Value", &dt) : all dmi_handles with "Name: Value" that are of type stored in dt */
-dmi_handle_list *dmidecode_match_value(const char *name, const char *value, const unsigned long *dmi_type);
+dmi_handle_list *dmidecode_match_value(const char *name, const char *value, const dmi_type *type);
 
 /* get the first value for name, limiting to optional dmi_type and/or optional handle */
-char *dmidecode_match(const char *name, const unsigned long *dmi_type, const unsigned long *handle);
+char *dmidecode_match(const char *name, const dmi_type *type, const dmi_handle *handle);
 
 void dmidecode_cache_free();
 

--- a/modules/devices/dmi_memory.c
+++ b/modules/devices/dmi_memory.c
@@ -234,11 +234,9 @@ dmi_mem_socket *dmi_mem_socket_new(unsigned long h) {
         s->rank = dmidecode_match("Rank", &dtm, &h);
 
         s->mfgr = dmidecode_match("Manufacturer", &dtm, &h);
-        if (g_str_has_prefix(s->mfgr, unknown_mfgr_str)) {
-            /* the manufacturer code is unknown to dmidecode */
-            g_free(s->mfgr);
-            s->mfgr = NULL;
-        }
+        STR_IGNORE(s->mfgr, unknown_mfgr_str);
+        STR_IGNORE(s->mfgr, "Unknown");
+
         null_if_empty(&s->mfgr);
         null_if_empty(&s->partno);
 

--- a/modules/devices/dmi_memory.c
+++ b/modules/devices/dmi_memory.c
@@ -244,8 +244,8 @@ dmi_mem_socket *dmi_mem_socket_new(dmi_handle h) {
         if (SEQ(s->type, "DDR2")) s->ram_type = DDR2_SDRAM;
         if (SEQ(s->type, "DDR3")) s->ram_type = DDR3_SDRAM;
         if (SEQ(s->type, "DDR4")) s->ram_type = DDR4_SDRAM;
-        if (strcasestr(s->type, "RAMBus")
-            || strcasestr(s->type, "RDRAM") ) s->ram_type = RAMBUS;
+        if (SEQ(s->type, "DRDRAM")) s->ram_type = DIRECT_RAMBUS;
+        if (SEQ(s->type, "RDRAM")) s->ram_type = RAMBUS;
         if (s->ram_type)
             dmi_ram_types |= (1 << s->ram_type-1);
         s->type_detail = dmidecode_match("Type Detail", &dtm, &h);

--- a/modules/devices/dmi_memory.c
+++ b/modules/devices/dmi_memory.c
@@ -17,6 +17,8 @@
  *    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
  */
 
+#define _GNU_SOURCE
+
 #include "hardinfo.h"
 #include "devices.h"
 #include "vendor.h"
@@ -200,6 +202,7 @@ dmi_mem_socket *dmi_mem_socket_new(dmi_handle h) {
 
     s->bank_locator = dmidecode_match("Bank Locator", &dtm, &h);
     STR_IGNORE(s->bank_locator, "Unknown");
+    STR_IGNORE(s->bank_locator, "Not Specified");
     null_if_empty(&s->bank_locator);
 
     gchar *ah = dmidecode_match("Array Handle", &dtm, &h);
@@ -241,6 +244,8 @@ dmi_mem_socket *dmi_mem_socket_new(dmi_handle h) {
         if (SEQ(s->type, "DDR2")) s->ram_type = DDR2_SDRAM;
         if (SEQ(s->type, "DDR3")) s->ram_type = DDR3_SDRAM;
         if (SEQ(s->type, "DDR4")) s->ram_type = DDR4_SDRAM;
+        if (strcasestr(s->type, "RAMBus")
+            || strcasestr(s->type, "RDRAM") ) s->ram_type = RAMBUS;
         if (s->ram_type)
             dmi_ram_types |= (1 << s->ram_type-1);
         s->type_detail = dmidecode_match("Type Detail", &dtm, &h);

--- a/modules/devices/spd-decode.c
+++ b/modules/devices/spd-decode.c
@@ -85,7 +85,7 @@ typedef struct {
     const char *form_factor;
     char type_detail[256];
 
-    int size_MiB;
+    dmi_mem_size size_MiB;
 
     int spd_rev_major; // bytes[1] >> 4
     int spd_rev_minor; // bytes[1] & 0xf
@@ -122,7 +122,7 @@ static int parity(int value) {
     return (0x6996 >> value) & 1;
 }
 
-static void decode_sdr_module_size(unsigned char *bytes, int *size) {
+static void decode_sdr_module_size(unsigned char *bytes, dmi_mem_size *size) {
     int i, k = 0;
 
     i = (bytes[3] & 0x0f) + (bytes[4] & 0x0f) - 17;
@@ -331,7 +331,7 @@ static void decode_ddr_module_speed(unsigned char *bytes, float *ddrclk, int *pc
     if (pcclk) *pcclk = pc;
 }
 
-static void decode_ddr_module_size(unsigned char *bytes, int *size) {
+static void decode_ddr_module_size(unsigned char *bytes, dmi_mem_size *size) {
     int i, k;
 
     i = (bytes[3] & 0x0f) + (bytes[4] & 0x0f) - 17;
@@ -435,7 +435,7 @@ static void decode_ddr2_module_speed(unsigned char *bytes, float *ddr_clock, int
     if (pc2_speed) { *pc2_speed = pcclk; }
 }
 
-static void decode_ddr2_module_size(unsigned char *bytes, int *size) {
+static void decode_ddr2_module_size(unsigned char *bytes, dmi_mem_size *size) {
     int i, k;
 
     i = (bytes[3] & 0x0f) + (bytes[4] & 0x0f) - 17;
@@ -518,7 +518,7 @@ static void decode_ddr3_module_speed(unsigned char *bytes, float *ddr_clock, int
     if (pc3_speed) { *pc3_speed = pcclk; }
 }
 
-static void decode_ddr3_module_size(unsigned char *bytes, int *size) {
+static void decode_ddr3_module_size(unsigned char *bytes, dmi_mem_size *size) {
     unsigned int sdr_capacity = 256 << (bytes[4] & 0xF);
     unsigned int sdr_width = 4 << (bytes[7] & 0x7);
     unsigned int bus_width = 8 << (bytes[8] & 0x7);
@@ -776,7 +776,7 @@ static void decode_ddr4_module_spd_timings(unsigned char *bytes, float speed, ch
     }
 }
 
-static void decode_ddr4_module_size(unsigned char *bytes, int *size) {
+static void decode_ddr4_module_size(unsigned char *bytes, dmi_mem_size *size) {
     int sdrcap = 256 << (bytes[4] & 15);
     int buswidth = 8 << (bytes[13] & 7);
     int sdrwidth = 4 << (bytes[12] & 7);

--- a/modules/devices/spd-decode.c
+++ b/modules/devices/spd-decode.c
@@ -645,7 +645,7 @@ static void decode_ddr34_manufacturer(unsigned char count, unsigned char code, c
         return;
     }
 
-    *manufacturer = (char *)vendors[*bank][*index - 1];
+    *manufacturer = (char *)JEDEC_MFG_STR(*bank, *index - 1);
 }
 
 static void decode_ddr3_manufacturer(unsigned char *bytes, char **manufacturer, int *bank, int *index) {
@@ -677,7 +677,7 @@ static void decode_module_manufacturer(unsigned char *bytes, char **manufacturer
         goto end;
     }
 
-    out = (char *)vendors[ai - 1][(first & 0x7f) - 1];
+    out = (char*)JEDEC_MFG_STR(ai - 1, (first & 0x7f) - 1);
 
 end:
     if (manufacturer) { *manufacturer = out; }

--- a/modules/devices/spd-vendors.c
+++ b/modules/devices/spd-vendors.c
@@ -35,7 +35,9 @@
  */
 
 #define VENDORS_BANKS 8
-static const char* vendors[VENDORS_BANKS][128] =
+#define VENDORS_ITEMS 128
+#define JEDEC_MFG_STR(b,i) ( (b >= 0 && b < VENDORS_BANKS && i < VENDORS_ITEMS) ? vendors[(b)][(i)] : NULL )
+static const char* vendors[VENDORS_BANKS][VENDORS_ITEMS] =
 {
 {"AMD", "AMI", "Fairchild", "Fujitsu",
  "GTE", "Harris", "Hitachi", "Inmos",

--- a/modules/devices/x86/processor.c
+++ b/modules/devices/x86/processor.c
@@ -680,7 +680,8 @@ gchar *processor_describe(GSList * processors) {
 
 gchar *dmi_socket_info() {
     gchar *ret = strdup("");
-    unsigned long dt = 4, i;
+    dmi_type dt = 4;
+    int i;
     dmi_handle_list *hl = dmidecode_handles(&dt);
     if (!hl) {
         ret = g_strdup_printf("[%s]\n%s=%s\n",
@@ -690,7 +691,7 @@ gchar *dmi_socket_info() {
                 : _("(Not available; Perhaps try running HardInfo as root.)") );
     } else {
         for(i = 0; i < hl->count; i++) {
-            unsigned long h = hl->handles[i];
+            dmi_handle h = hl->handles[i];
             gchar *upgrade = dmidecode_match("Upgrade", &dt, &h);
             gchar *socket = dmidecode_match("Socket Designation", &dt, &h);
             gchar *bus_clock_str = dmidecode_match("External Clock", &dt, &h);


### PR DESCRIPTION
If a locator of array > socket is not unique, then use array > bank > socket in the list.
As suggested in #386.

How does this work for you @ocerman ?