### PR TITLE
devices/storage: fix crash on double free

### DIFF
--- a/modules/devices/storage.c
+++ b/modules/devices/storage.c
@@ -218,6 +218,7 @@ gboolean __scan_udisks2_devices(void) {
         g_free(features);
         g_free(label);
         g_free(media_comp);
+        media_comp = NULL;
 
         features = NULL;
         moreinfo = NULL;


### PR DESCRIPTION
Fixes #394

`media_comp` doesn't always get set, so
needs to be set to null after free to be
re-used.


