### PR TITLE
shell: fix icons with flags [v3]

### DIFF
--- a/includes/shell.h
+++ b/includes/shell.h
@@ -219,11 +219,11 @@ void		shell_update_remote_menu(void);
 void		shell_set_remote_label(Shell *shell, gchar *label);
 
 /* decode special information in keys */
-gboolean    key_is_flagged(gchar *key);       /* has $[<flags>][<tag>]$ at the start of the key */
-gboolean    key_is_highlighted(gchar *key);   /* flag '*' = select/highlight */
-gboolean    key_wants_details(gchar *key);    /* flag '!' = report should include the "moreinfo" */
-gchar       *key_mi_tag(gchar *key);          /* moreinfo lookup tag */
-const gchar *key_get_name(gchar *key);        /* get the key's name, flagged or not */
+gboolean    key_is_flagged(const gchar *key);       /* has $[<flags>][<tag>]$ at the start of the key */
+gboolean    key_is_highlighted(const gchar *key);   /* flag '*' = select/highlight */
+gboolean    key_wants_details(const gchar *key);    /* flag '!' = report should include the "moreinfo" */
+gchar       *key_mi_tag(const gchar *key);          /* moreinfo lookup tag */
+const gchar *key_get_name(const gchar *key);        /* get the key's name, flagged or not */
 
 #endif				/* __SHELL_H__ */
 

--- a/includes/shell.h
+++ b/includes/shell.h
@@ -218,12 +218,31 @@ void		shell_update_remote_menu(void);
 
 void		shell_set_remote_label(Shell *shell, gchar *label);
 
-/* decode special information in keys */
+/* decode special information in keys
+ *
+ * key syntax:
+ *  [$[<flags>][<tag>]$]<name>[#[<dis>]]
+ * flags:
+ *  [[!][*]]
+ *  ! = show details (moreinfo) in reports
+ *  * = highlight/select this row
+ */
 gboolean    key_is_flagged(const gchar *key);       /* has $[<flags>][<tag>]$ at the start of the key */
 gboolean    key_is_highlighted(const gchar *key);   /* flag '*' = select/highlight */
 gboolean    key_wants_details(const gchar *key);    /* flag '!' = report should include the "moreinfo" */
 gchar       *key_mi_tag(const gchar *key);          /* moreinfo lookup tag */
 const gchar *key_get_name(const gchar *key);        /* get the key's name, flagged or not */
+/*
+ * example for key = "$*!Foo$Bar#7":
+ * flags = "$*!Foo$"  // key_is/wants_*() still works on flags
+ * tag = "Foo"        // the moreinfo/icon tag
+ * name = "Bar#7"     // the full unique name
+ * label = "Bar"      // the label displayed
+ * dis = "7"
+ */
+void key_get_components(const gchar *key,
+    gchar **flags, gchar **tag, gchar **name, gchar **label, gchar **dis,
+    gboolean null_empty);
 
 #endif				/* __SHELL_H__ */
 

--- a/shell/shell.c
+++ b/shell/shell.c
@@ -2149,11 +2149,11 @@ static ShellTree *tree_new()
     return shelltree;
 }
 
-gboolean key_is_flagged(gchar *key) {
+gboolean key_is_flagged(const gchar *key) {
     return (key && *key == '$' && strchr(key+1, '$')) ? TRUE : FALSE;
 }
 
-gboolean key_is_highlighted(gchar *key) {
+gboolean key_is_highlighted(const gchar *key) {
     if (key_is_flagged(key)) {
         if (strchr(key, '*'))
             return TRUE;
@@ -2161,7 +2161,7 @@ gboolean key_is_highlighted(gchar *key) {
     return FALSE;
 }
 
-gboolean key_wants_details(gchar *key) {
+gboolean key_wants_details(const gchar *key) {
     if (key_is_flagged(key)) {
         if (strchr(key, '!'))
             return TRUE;
@@ -2169,8 +2169,8 @@ gboolean key_wants_details(gchar *key) {
     return FALSE;
 }
 
-gchar *key_mi_tag(gchar *key) {
-    gchar *p = key, *l, *t;
+gchar *key_mi_tag(const gchar *key) {
+    gchar *p = (gchar*)key, *l, *t;
 
     if (key_is_flagged(key)) {
         l = strchr(key+1, '$');
@@ -2186,7 +2186,7 @@ gchar *key_mi_tag(gchar *key) {
     return NULL;
 }
 
-const gchar *key_get_name(gchar *key) {
+const gchar *key_get_name(const gchar *key) {
     if (key_is_flagged(key))
         return strchr(key+1, '$')+1;
     return key;


### PR DESCRIPTION
See: #391
I split this out of #393 because it isn't really related to the struct Info stuff, it just fixes a bug in the existing icon handling.
