### PR TITLE
shell/report.c: fix "return with no value"

### DIFF
--- a/shell/report.c
+++ b/shell/report.c
@@ -100,7 +100,7 @@ gchar *icon_name_css_id(const gchar *file) {
 
 gchar *make_icon_css(const gchar *file) {
     if (!file || *file == 0)
-        return;
+        return g_strdup("");
     gchar *ret = NULL;
     gchar *path = g_build_filename(params.path_data, "pixmaps", file, NULL);
     gchar *contents = NULL;


### PR DESCRIPTION
Fix the warning:
report.c: In function ‘make_icon_css’:
shell/report.c:103:9: warning: ‘return’ with no value, in function returning non-void [-Wreturn-type]

Failure of the sanity test at the beginning of "make_icon_css" will result in returning
of a random value instead of a gchar*.
With this patch we return a gchar* to an empty string instead.

Signed-off-by: Juro Bystricky <juro.bystricky@intel.com>