### PR TITLE
benchmark: add extra fields to result for revision and information

### DIFF
--- a/data/benchmark.conf
+++ b/data/benchmark.conf
@@ -319,9 +319,9 @@ PowerPC 740/750=58.07682|280.00 MHz|Unknown
 2_0___X370_SLI_PLUS_(MS_7A33)_(Micro_Star_International_Co___Ltd_);AMD_Ryzen_5_1600_Six_Core_Processor;38400_00 = 1.209032; 1.209032; 1|1|2.0 / X370 SLI PLUS (MS-7A33) (Micro-Star International Co., Ltd.)|AMD Ryzen 5 1600 Six-Core Processor|1 physical processor; 6 cores; 12 threads|12x 3200.00 MHz|16377260|1|6|12|AMD Radeon (TM) R9 390 Series (HAWAII, DRM 3.26.0, 4.18.0, LLVM 6.0.1)|AMD/ATI Hawaii PRO + NVIDIA GeForce GTX 750
 
 [CPU Zlib]
-Raspberry_Pi_Model_B_Rev_1;Broadcom_BCM2835;900_00=0.550000; 7.000921; 1|1|Raspberry Pi Model B Rev 1|Broadcom BCM2835|1x ARM ARM1176 r0p7 (AArch32)|1x 900.00 MHz|233612|1|1|1||Broadcom VideoCore IV
-ASUS_PRIME_B350_PLUS;AMD_Ryzen_5_1600_Six_Core_Processor;38400_00=97.400000; 7.000335; 12|12|ASUS PRIME B350-PLUS|AMD Ryzen 5 1600 Six-Core Processor|1 physical processor; 6 cores; 12 threads|12x 3200.00 MHz|16423392|1|6|12|Radeon RX 560 Series (POLARIS11, DRM 3.26.0, 4.18.0-10-generic, LLVM 7.0.0)|AMD/ATI Baffin
-HP_18E7_(HP_ProDesk_600_G1_SFF);Intel(R)_Core(TM)_i5_4570_CPU___3_20GHz;14400_00=49.490000; 7.000286; 4|4|HP 18E7 (HP ProDesk 600 G1 SFF)|Intel(R) Core(TM) i5-4570 CPU @ 3.20GHz|1 physical processor; 4 cores; 4 threads|4x 3600.00 MHz|8075460|1|4|4|Mesa DRI Intel(R) Haswell Desktop|Intel Xeon E3-1200 v3/4th Gen Core Processor Integrated Graphics Controller
+Raspberry_Pi_Model_B_Rev_1;Broadcom_BCM2835;900_00=0.550000; 7.000921; 1; 2|1|Raspberry Pi Model B Rev 1|Broadcom BCM2835|1x ARM ARM1176 r0p7 (AArch32)|1x 900.00 MHz|233612|1|1|1||Broadcom VideoCore IV
+ASUS_PRIME_B350_PLUS;AMD_Ryzen_5_1600_Six_Core_Processor;38400_00=97.400000; 7.000335; 12; 2|12|ASUS PRIME B350-PLUS|AMD Ryzen 5 1600 Six-Core Processor|1 physical processor; 6 cores; 12 threads|12x 3200.00 MHz|16423392|1|6|12|Radeon RX 560 Series (POLARIS11, DRM 3.26.0, 4.18.0-10-generic, LLVM 7.0.0)|AMD/ATI Baffin
+HP_18E7_(HP_ProDesk_600_G1_SFF);Intel(R)_Core(TM)_i5_4570_CPU___3_20GHz;14400_00=49.490000; 7.000286; 4; 2|4|HP 18E7 (HP ProDesk 600 G1 SFF)|Intel(R) Core(TM) i5-4570 CPU @ 3.20GHz|1 physical processor; 4 cores; 4 threads|4x 3600.00 MHz|8075460|1|4|4|Mesa DRI Intel(R) Haswell Desktop|Intel Xeon E3-1200 v3/4th Gen Core Processor Integrated Graphics Controller
 
 [GPU Drawing]
 

--- a/includes/benchmark.h
+++ b/includes/benchmark.h
@@ -35,9 +35,11 @@ typedef struct {
     double result;
     double elapsed_time;
     int threads_used;
+    int revision;
+    char extra[256]; /* no \n, ; or | */
 } bench_value;
 
-#define EMPTY_BENCH_VALUE {-1.0f,0,0}
+#define EMPTY_BENCH_VALUE {-1.0f,0,0,-1,""}
 
 char *bench_value_to_str(bench_value r);
 bench_value bench_value_from_str(const char* str);

--- a/modules/benchmark.c
+++ b/modules/benchmark.c
@@ -44,19 +44,26 @@ static gchar *benchmark_include_results(bench_value result, const gchar * benchm
 static gboolean sending_benchmark_results = FALSE;
 
 char *bench_value_to_str(bench_value r) {
-    return g_strdup_printf("%lf; %lf; %d", r.result, r.elapsed_time, r.threads_used);
+    return g_strdup_printf("%lf; %lf; %d; %d; %s", r.result, r.elapsed_time, r.threads_used, r.revision, r.extra);
 }
 
 bench_value bench_value_from_str(const char* str) {
     bench_value ret = EMPTY_BENCH_VALUE;
     double r, e;
-    int t, c;
+    int t, c, v;
+    char extra[256];
     if (str) {
-        c = sscanf(str, "%lf; %lf; %d", &r, &e, &t);
+        c = sscanf(str, "%lf; %lf; %d; %d; %255[^\r\n;|]", &r, &e, &t, &v, extra);
         if (c >= 3) {
             ret.result = r;
             ret.elapsed_time = e;
             ret.threads_used = t;
+        }
+        if (c >= 4) {
+            ret.revision = v;
+        }
+        if (c >= 5) {
+            strcpy(ret.extra, extra);
         }
     }
     return ret;

--- a/modules/benchmark/bench_results.c
+++ b/modules/benchmark/bench_results.c
@@ -374,10 +374,15 @@ static char *bench_result_more_info_less(bench_result *b) {
         (b->machine->memory_kiB > 0)
         ? g_strdup_printf("%d %s", b->machine->memory_kiB, _("kiB") )
         : g_strdup(_(unk) );
+    char bench_str[256] = "";
+    if (b->bvalue.revision >= 0)
+        snprintf(bench_str, 127, "%d", b->bvalue.revision);
 
     char *ret = g_strdup_printf("[%s]\n"
         /* threads */   "%s=%d\n"
         /* elapsed */   "%s=%0.4f %s\n"
+                        "%s=%s\n"
+                        "%s=%s\n"
         /* legacy */    "%s=%s\n"
                         "[%s]\n"
         /* board */     "%s=%s\n"
@@ -391,6 +396,8 @@ static char *bench_result_more_info_less(bench_result *b) {
                         _("Benchmark Result"),
                         _("Threads"), b->bvalue.threads_used,
                         _("Elapsed Time"), b->bvalue.elapsed_time, _("seconds"),
+                        *bench_str ? _("Revision") : _("#Revision"), bench_str,
+                        *b->bvalue.extra ? _("Extra Information") : _("#Extra"), b->bvalue.extra,
                         b->legacy ? _("Note") : "#Note",
                         b->legacy ? _("This result is from an old version of HardInfo. Results might not be comparable to current version. Some details are missing.") : "",
                         _("Machine"),
@@ -408,11 +415,17 @@ static char *bench_result_more_info_less(bench_result *b) {
 }
 
 static char *bench_result_more_info_complete(bench_result *b) {
+    char bench_str[256] = "";
+    strncpy(bench_str, b->name, 127);
+    if (b->bvalue.revision >= 0)
+        snprintf(bench_str + strlen(bench_str), 127, " (r%d)", b->bvalue.revision);
+
     return g_strdup_printf("[%s]\n"
         /* bench name */"%s=%s\n"
         /* threads */   "%s=%d\n"
         /* result */    "%s=%0.2f\n"
         /* elapsed */   "%s=%0.4f %s\n"
+                        "%s=%s\n"
         /* legacy */    "%s=%s\n"
                         "[%s]\n"
         /* board */     "%s=%s\n"
@@ -427,10 +440,11 @@ static char *bench_result_more_info_complete(bench_result *b) {
         /* mid */       "%s=%s\n"
         /* cfg_val */   "%s=%.2f\n",
                         _("Benchmark Result"),
-                        _("Benchmark"), b->name,
+                        _("Benchmark"), bench_str,
                         _("Threads"), b->bvalue.threads_used,
                         _("Result"), b->bvalue.result,
                         _("Elapsed Time"), b->bvalue.elapsed_time, _("seconds"),
+                        *b->bvalue.extra ? _("Extra Information") : _("#Extra"), b->bvalue.extra,
                         b->legacy ? _("Note") : "#Note",
                         b->legacy ? _("This result is from an old version of HardInfo. Results might not be comparable to current version. Some details are missing.") : "",
                         _("Machine"),

--- a/modules/benchmark/zlib.c
+++ b/modules/benchmark/zlib.c
@@ -93,6 +93,8 @@ benchmark_zlib(void)
 
     r = benchmark_crunch_for(CRUNCH_TIME, 0, zlib_for, data);
     r.result /= 100;
+    r.revision = 2;
+    snprintf(r.extra, 255, "zlib %s (built against: %s)", zlib_version, ZLIB_VERSION);
     bench_results[BENCHMARK_ZLIB] = r;
 
     g_free(data);


### PR DESCRIPTION
* add an integer revision field
* add an extra information string field
* zlib benchmark: new revision[1] is 2, so that old results are obviously old,
  and now the zlib version string will be stored in extra information.

[1] as of 6a8e19a14305079b03e45eeb0580a45104f300dd