### PR TITLE
info struct bug Fixes, add tagged update fields

### DIFF
--- a/hardinfo/info.c
+++ b/hardinfo/info.c
@@ -198,6 +198,29 @@ static const GCompareFunc sort_functions[INFO_GROUP_SORT_MAX] = {
     [INFO_GROUP_SORT_TAG_DESCENDING] = info_field_cmp_tag_descending,
 };
 
+static void _field_free_strings(struct InfoField *field)
+{
+    if (field) {
+        if (field->free_value_on_flatten)
+            g_free((gchar *)field->value);
+        if (field->free_name_on_flatten)
+            g_free((gchar *)field->name);
+        g_free(field->tag);
+    }
+}
+
+static void _group_free_field_strings(struct InfoGroup *group)
+{
+    guint i;
+    if (group && group->fields) {
+        for (i = 0; i < group->fields->len; i++) {
+            struct InfoField field;
+            field = g_array_index(group->fields, struct InfoField, i);
+            _field_free_strings(&field);
+        }
+    }
+}
+
 static void flatten_group(GString *output, const struct InfoGroup *group, guint group_count)
 {
     guint i;
@@ -212,29 +235,24 @@ static void flatten_group(GString *output, const struct InfoGroup *group, guint 
     if (group->fields) {
         for (i = 0; i < group->fields->len; i++) {
             struct InfoField field;
-            gchar tag[256] = "";
+            gchar tmp_tag[256] = ""; /* for generated tag */
 
             field = g_array_index(group->fields, struct InfoField, i);
+            const gchar *tp = field.tag;
+            gboolean tagged = !!tp;
+            gboolean flagged = field.highlight || field.report_details;
+            if (!tp) {
+                snprintf(tmp_tag, 255, "ITEM%d-%d", group_count, i);
+                tp = tmp_tag;
+            }
 
-            if (field.tag)
-                strncpy(tag, field.tag, 255);
-            else
-                snprintf(tag, 255, "ITEM%d-%d", group_count, i);
-
-            if (*tag != 0 || field.highlight || field.report_details)
+            if (tagged || flagged || field.icon)
                 g_string_append_printf(output, "$%s%s%s$",
                     field.highlight ? "*" : "",
                     field.report_details ? "!" : "",
-                    tag);
+                    tp);
 
             g_string_append_printf(output, "%s=%s\n", field.name, field.value);
-
-            if (field.free_value_on_flatten)
-                g_free((gchar *)field.value);
-            if (field.free_name_on_flatten)
-                g_free((gchar *)field.name);
-
-            g_free(field.tag);
         }
     } else if (group->computed) {
         g_string_append_printf(output, "%s\n", group->computed);
@@ -250,17 +268,26 @@ static void flatten_shell_param(GString *output, const struct InfoGroup *group, 
 
     for (i = 0; i < group->fields->len; i++) {
         struct InfoField field;
+        gchar tmp_tag[256] = ""; /* for generated tag */
 
         field = g_array_index(group->fields, struct InfoField, i);
+        const gchar *tp = field.tag;
+        gboolean tagged = !!tp;
+        if (!tp) {
+            snprintf(tmp_tag, 255, "ITEM%d-%d", group_count, i);
+            tp = tmp_tag;
+        }
 
         if (field.update_interval) {
-            g_string_append_printf(output, "UpdateInterval$%s=%d\n",
-                field.name, field.update_interval);
+            g_string_append_printf(output, "UpdateInterval$%s%s%s=%d\n",
+                tagged ? tp : "", tagged ? "$" : "", /* tag and close or nothing */
+                field.name,
+                field.update_interval);
         }
 
         if (field.icon) {
-            g_string_append_printf(output, "Icon$ITEM%d-%d$=%s\n",
-                group_count, i, field.icon);
+            g_string_append_printf(output, "Icon$%s$=%s\n",
+                tp, field.icon);
         }
     }
 }
@@ -312,6 +339,8 @@ gchar *info_flatten(struct Info *info)
 
             flatten_group(values, &group, i);
             flatten_shell_param(shell_param, &group, i);
+
+            _group_free_field_strings(&group);
 
             if (group.fields)
                 g_array_free(group.fields, TRUE);

--- a/shell/shell.c
+++ b/shell/shell.c
@@ -1126,7 +1126,13 @@ static void group_handle_special(GKeyFile *key_file,
 
             ms = g_key_file_get_integer(key_file, group, key, NULL);
 
-            fu->field_name = g_strdup(g_utf8_strchr(key, -1, '$') + 1);
+            /* Old style used just the label which has to be checked by translating it,
+             * and potentially could by ambiguous.
+             * New style can use tag or label. If new style including a tag,
+             * send both tag and label and let the hi_get_field() function use
+             * key_get_components() to split it. */
+            const gchar *chk = g_utf8_strchr(key, -1, '$');
+            fu->field_name = g_strdup(key_is_flagged(chk) ? chk : chk + 1);
             fu->entry = entry;
 
             sfutbl = g_new0(ShellFieldUpdateSource, 1);
@@ -1537,7 +1543,7 @@ static void module_selected_show_info_detail(GKeyFile *key_file,
 
                 if (entry && entry->fieldfunc && value && g_str_equal(value, "...")) {
                     g_free(value);
-                    value = entry->fieldfunc(name);
+                    value = entry->fieldfunc(keys[j]);
                 }
 
                 key_markup =


### PR DESCRIPTION
* tag was always included even when it didn't need to be. Now only
  include it when tag specified, flagged, or includes an icon.
  This messed up the existing update fields system.
* The update fields system has been changed to allow updating by tag
  instead of the translated label. By label still works, however.
  I think it would be best to switch to using tags in the future.
* info_flatten() calls flatten_shell_param() after flatten_group()
  which could cause a field name or tag to be used after it was freed.
  Created special free functions to handle this after all is used. 
  #411 would really be good here.
