### PR TITLE
struct info unflatten [v2]

### DIFF
--- a/hardinfo/info.c
+++ b/hardinfo/info.c
@@ -107,12 +107,27 @@ void info_add_computed_group(struct Info *info, const gchar *name, const gchar *
     /* This is a scaffolding method: HardInfo should move away from pre-computing
      * the strings in favor of storing InfoGroups instead; while modules are not
      * fully converted, use this instead. */
-    struct InfoGroup group = {
-        .name = name,
-        .computed = value,
-    };
+    struct Info *tmp_info = NULL;
+    struct InfoGroup donor = {};
+    gchar *tmp_str = NULL;
 
-    g_array_append_val(info->groups, group);
+    if (name)
+        tmp_str = g_strdup_printf("[%s]\n%s", name, value);
+    else
+        tmp_str = g_strdup(value);
+
+    tmp_info = info_unflatten(tmp_str);
+    if (tmp_info->groups->len != 1) {
+        fprintf(stderr,
+            "info_add_computed_group(): expected only one group in value! (actual: %d)\n",
+            tmp_info->groups->len);
+    } else {
+        donor = g_array_index(tmp_info->groups, struct InfoGroup, 0);
+        g_array_append_val(info->groups, donor);
+    }
+
+    g_free(tmp_info); // TODO: doesn't do enough
+    g_free(tmp_str);
 }
 
 void info_set_column_title(struct Info *info, const gchar *column, const gchar *title)

--- a/includes/info.h
+++ b/includes/info.h
@@ -105,3 +105,4 @@ void info_set_view_type(struct Info *info, ShellViewType setting);
 void info_set_reload_interval(struct Info *info, int setting);
 
 gchar *info_flatten(struct Info *info);
+struct Info *info_unflatten(const gchar *str);


### PR DESCRIPTION
I started this a while ago (2017, I think, see #180 and #197) when I was trying to make a new shell that only operated using struct Info. The info_unflatten() function makes an Info struct from the old shell key/value file format string. Trying to do it exposed many problems with the Info struct at the time and I gave up trying to solve them all, and gave up on the new shell.

I've updated the function for more recent changes to the Info struct and shell, but there are still a few problems. For example, group.name always leaks from an unflatten()-ed Info.

This function seems very useful for the original purpose: shell could be rewritten to be Info-only without changing everything else. I've also found it can be useful for debugging.
