### PR TITLE
vendor.ids update and vendor.{h,c} improvements from sysobj version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,6 +121,7 @@ set(HARDINFO_RESOURCES
 	"data/benchmark.conf"
 	"data/benchmark.data"
 	"data/vendor.ids"
+	"deps/sysobj_early/data/sdcard.ids"
 )
 
 set(HARDINFO_MANPAGES
@@ -218,6 +219,7 @@ add_library(sysobj_early STATIC
 	deps/sysobj_early/src/gg_slist.c
 	deps/sysobj_early/src/strstr_word.c
 	deps/sysobj_early/src/auto_free.c
+	deps/sysobj_early/src/util_ids.c
 	deps/sysobj_early/gui/uri_handler.c
 )
 set_target_properties(sysobj_early PROPERTIES COMPILE_FLAGS "-std=c99 -Wall -Wextra -Wno-parentheses -Wno-unused-function")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,6 +98,7 @@ include_directories(
 	${CMAKE_SOURCE_DIR}/includes/${HARDINFO_ARCH}
 	${CMAKE_SOURCE_DIR}/deps/uber-graph
 	${CMAKE_SOURCE_DIR}/deps/sysobj_early/include
+	${CMAKE_SOURCE_DIR}/deps/sysobj_early/gui
 	${CMAKE_BINARY_DIR}
 	${GTK_INCLUDE_DIRS}
 	${LIBSOUP_INCLUDE_DIRS}
@@ -216,6 +217,7 @@ endforeach()
 add_library(sysobj_early STATIC
 	deps/sysobj_early/src/gg_slist.c
 	deps/sysobj_early/src/strstr_word.c
+	deps/sysobj_early/gui/uri_handler.c
 )
 set_target_properties(sysobj_early PROPERTIES COMPILE_FLAGS "-std=c99 -Wall -Wextra -Wno-parentheses -Wno-unused-function")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,6 +97,7 @@ include_directories(
 	${CMAKE_SOURCE_DIR}/includes
 	${CMAKE_SOURCE_DIR}/includes/${HARDINFO_ARCH}
 	${CMAKE_SOURCE_DIR}/deps/uber-graph
+	${CMAKE_SOURCE_DIR}/deps/sysobj_early/include
 	${CMAKE_BINARY_DIR}
 	${GTK_INCLUDE_DIRS}
 	${LIBSOUP_INCLUDE_DIRS}
@@ -212,6 +213,12 @@ foreach (_module ${HARDINFO_MODULES})
 	set_target_properties(${_module} PROPERTIES PREFIX "")
 endforeach()
 
+add_library(sysobj_early STATIC
+	deps/sysobj_early/src/gg_slist.c
+	deps/sysobj_early/src/strstr_word.c
+)
+set_target_properties(sysobj_early PROPERTIES COMPILE_FLAGS "-std=c99 -Wall -Wextra -Wno-parentheses -Wno-unused-function")
+
 if (HARDINFO_GTK3)
 add_library(uber-graph STATIC
 	deps/uber-graph/g-ring.c
@@ -267,6 +274,7 @@ add_executable(hardinfo
 	shell/loadgraph-uber.c
 )
 target_link_libraries(hardinfo
+	sysobj_early
 	uber-graph
 	${GTK_LIBRARIES}
 	${LIBSOUP_LIBRARIES}
@@ -302,6 +310,7 @@ add_executable(hardinfo
 	shell/loadgraph.c
 )
 target_link_libraries(hardinfo
+	sysobj_early
 	${GTK_LIBRARIES}
 	${LIBSOUP_LIBRARIES}
 	m

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -217,6 +217,7 @@ endforeach()
 add_library(sysobj_early STATIC
 	deps/sysobj_early/src/gg_slist.c
 	deps/sysobj_early/src/strstr_word.c
+	deps/sysobj_early/src/auto_free.c
 	deps/sysobj_early/gui/uri_handler.c
 )
 set_target_properties(sysobj_early PROPERTIES COMPILE_FLAGS "-std=c99 -Wall -Wextra -Wno-parentheses -Wno-unused-function")

--- a/data/vendor.ids
+++ b/data/vendor.ids
@@ -6,6 +6,8 @@
 #    name_short <shorter name>
 #    url <url>
 #    url_support <url>
+#    wikipedia [language:]<article title>[#section]
+#    note <short note>
 #    ansi_color n[;n][...]
 #    [match_string|match_string_case|match_string_exact] <match>
 #    ...
@@ -21,14 +23,16 @@ name Lenovo Group
     name_short Lenovo
     url www.lenovo.com
     url_support support.lenovo.com
+    wikipedia Lenovo
     ansi_color 0;97;41
     match_string lenovo
-# EDID vendor code: LEN
+    note EDID vendor: LEN
     match_string_exact LEN
 
 name ASUSTeK Computer
     name_short ASUS
     url www.asus.com
+    wikipedia Asus
     ansi_color 0;30;47
     match_string ASUSTek
     match_string ASUS
@@ -37,6 +41,7 @@ name ASUSTeK Computer
 name Advanced Micro Devices
     name_short AMD
     url www.amd.com
+    wikipedia Advanced Micro Devices
     ansi_color 0;97;41
     match_string Advanced Micro Devices
     match_string_case AMD
@@ -45,6 +50,7 @@ name Advanced Micro Devices
 name Advanced Micro Devices (formerly ATI)
     name_short AMD/ATI
     url www.amd.com
+    wikipedia ATI Technologies
     ansi_color 0;97;41
     match_string ATI Technologies
     match_string Advanced Micro Devices, Inc. [AMD/ATI]
@@ -54,23 +60,36 @@ name Advanced Micro Devices (formerly ATI)
 name nVidia Corporation
     name_short nVidia
     url www.nvidia.com
+    wikipedia Nvidia
     ansi_color 0;97;42
     match_string nVidia
 
 name G.Skill International Enterprise
     name_short G.Skill
     url www.gskill.com
+    wikipedia G.Skill
     ansi_color 0;31;107
     match_string G.Skill
     match_string G-Skill
+    match_string G Skill
+
+name XFX Pine Group
+    name_short XFX
+    url www.xfxforce.com
+    wikipedia XFX
+    ansi_color 0;30;42
+    match_string_case XFX
 
 name 3Com
     url www.3com.com
+    wikipedia 3Com
+    ansi_color 0;97;40
     match_string 3Com
 
 name Intel Corporation
     name_short Intel
     url www.intel.com
+    wikipedia Intel Corporation
     ansi_color 0;97;44
     match_string Intel
 
@@ -88,7 +107,7 @@ name NEC Corporation
     name_short NEC
     url www.nec.com
     ansi_color 0;94;107
-# EDID vendor code: NEC
+    note EDID vendor: NEC
     match_string_case NEC
 
 name Realtek Semiconductor
@@ -103,22 +122,25 @@ name Toshiba Corporation
     url www.toshiba.com
     ansi_color 0;91;47
     match_string Toshiba
-# EDID vendor code: TSB
+    note EDID vendor: TSB
     match_string_exact TSB
 
 name Vizio
-# EDID vendor code: VIZ
+    name_short VIZIO
+    ansi_color 0;30;107
+    note EDID vendor: VIZ
     match_string_exact VIZ
 
 name ViewSonic Corporation
     name_short ViewSonic
     url www.viewsonic.com
     ansi_color 0;35;103
-# EDID vendor code: VSC
+    note EDID vendor: VSC
     match_string_exact VSC
 
 name LITE-ON
     url www.liteonit.com
+    ansi_color 0;97;104
     match_string_case LITE-ON
 
 name Maxtor
@@ -129,13 +151,13 @@ name Samsung
     url www.samsung.com
     ansi_color 0;47;30
     match_string Samsung
-# EDID vendor code: SAM
+    note EDID vendor: SAM
     match_string_exact SAM
 
 name Pioneer
     url www.pioneer-eur.com
     match_string Pioneer
-# EDID vendor code: PIO
+    note EDID vendor: PIO
     match_string_exact PIO
 
 name Plextor
@@ -155,13 +177,19 @@ name LG Electronics
     match_string Lucky-Goldstar
     match_string_case LG
 
+name LG Electronics (formerly Goldstar)
+    name_short LG (Goldstar)
+    url www.lge.com
+    ansi_color 0;97;41
+    match_string Goldstar
+
 name LG Display
     name_short LG Display
     url www.lgdisplay.com
     ansi_color 0;97;41
     match_string LG Display
     match_string LG.Philips
-# EDID vendor code: LGD
+    note EDID vendor: LGD
     match_string_exact LGD
 
 name Hitachi-LG Data Storage
@@ -169,12 +197,18 @@ name Hitachi-LG Data Storage
     url http://hlds.co.kr
     match_string_case HL-DT-ST
 
+name Hitachi Global Storage Technologies
+    name_short HGST
+    url hgst.com
+    ansi_color 0;97;40
+    match_string_case HGST
+
 name Hitachi
     name_short HITACHI
     url www.hitachi.com
     ansi_color 0;30;47
     match_string Hitachi
-# EDID vendor code: HTC
+    note EDID vendor: HTC
     match_string_exact HTC
 
 name Lexmark
@@ -185,9 +219,46 @@ name Creative Labs
     url www.creative.com
     match_string Creative Labs
 
-name Conexant
-    url www.brooktree.com
+name NXP Semiconductors
+    name_short NXP
+    url www.nxp.com
+    match_string_case NXP
+
+name Synaptics (formerly Brooktree)
+    name_short Synaptics (Brooktree)
+    url www.synaptics.com
     match_string Brooktree
+
+name Synaptics (formerly Conexant Systems)
+    name_short Synaptics (Conexant)
+    url www.synaptics.com
+    match_string Conexant
+
+name Synaptics
+    url www.synaptics.com
+    match_string Synaptics
+
+name TDK-Micronas
+    url www.micronas.com
+    match_string Micronas
+
+name Apacer Technology
+    name_short Apacer
+    match_string Apacer
+
+name Bright Micron Technology
+    name_short BMT
+    match_string Bright Micron
+
+name HT Micron
+    match_string HT Micron
+
+name Intellitech
+    match_string Intellitech
+
+name Harmony Semiconductor
+    name_short Harmony
+    match_string Harmony
 
 name Atheros Communications
     url www.atheros.com
@@ -198,7 +269,7 @@ name Panasonic Industry Company
     url www.panasonic.com
     ansi_color 0;30;107
     match_string MATSHITA
-# EDID vendor code: MEI
+    note EDID vendor: MEI
     match_string_exact MEI
 
 name Silicon Image
@@ -217,7 +288,7 @@ name Apple Computer
     url www.apple.com
     ansi_color 0;97;100
     match_string Apple
-# EDID vendor code: APP
+    note EDID vendor: APP
     match_string_exact APP
 
 name International Business Machines Corporation
@@ -233,7 +304,7 @@ name Dell Computer
     match_string Dell
 # Dell PowerEdge/PowerVault controller SCSI vendor
     match_string PE/PV
-# EDID vendor code: DEL
+    note EDID vendor: DEL
     match_string_exact DEL
 
 name Logitech International
@@ -243,7 +314,9 @@ name Logitech International
     match_string Logitech
 
 name Fujitsu
+    name_short FUJITSU
     url www.fujitsu.com
+    ansi_color 0;31;107
     match_string FUJITSU
 
 name Sony
@@ -252,7 +325,7 @@ name Sony
     ansi_color 0;30;107
     match_string Sony
 #   match_string_case CDU
-# EDID vendor code: SNY
+    note EDID vendor: SNY
     match_string_exact SNY
 
 name SanDisk
@@ -306,14 +379,16 @@ name Koninklijke Philips
     name_short PHILIPS
     url www.philips.com
     match_string Philips
-# EDID vendor code: PHL
+    ansi_color 0;30;107
+    match_string Philips
+    note EDID vendor: PHL
     match_string_exact PHL
 
 name Sharp Corporation
     name_short SHARP
     ansi_color 0;31;107
     match_string Sharp
-# EDID vendor code: SHP
+    note EDID vendor: SHP
     match_string_exact SHP
 
 name Ralink Technology
@@ -332,9 +407,11 @@ name Hewlett-Packard
     url www.hp.com
     ansi_color 0;97;46
     match_string Hewlett-Packard
-# EDID vendor code: HWP
-    match_string_exact HWP
     match_string_case HP
+    note EDID vendor: HWP
+    match_string_exact HWP
+    note SCSI vendor: hp
+    match_string_exact hp
 
 name TEAC Corporation
     name_short TEAC
@@ -363,9 +440,13 @@ name Canon
 
 name A4tech
     url www.a4tech.com
+    wikipedia A4Tech
+    ansi_color 0;33;40
     match_string A4Tech
 
-name Alcor
+name Alcor Life Extension Foundation
+# Makes devices?
+    name_short Alcor
     url www.alcor.org
     match_string ALCOR
 
@@ -379,14 +460,21 @@ name Ours Technology
 
 name BenQ
     url www.benq.com
+    ansi_color 0;35;107
     match_string BENQ
+
+name Holtek Semiconductor
+    name_short Holtek
+    url www.holtek.com
+    ansi_color 0;34;107
+    match_string Holtek
 
 name Acer
     name_short acer
     url www.acer.com
     ansi_color 0;32;107
     match_string Acer
-# EDID vendor code: ACR
+    note EDID vendor: ACR
     match_string_exact ACR
 
 name Quantum
@@ -402,6 +490,20 @@ name Kingston Technology
 name Chicony
     url www.chicony.com.tw
     match_string Chicony
+
+name Phison Electronics Corporation
+    name_short Phison
+    url www.phison.com
+    wikipedia Phison
+    ansi_color 0;33;44
+    match_string Phison
+
+name Corsair Components
+    name_short Corsair
+    url www.corsair.com
+    wikipedia Corsair Components
+    ansi_color 0;30;43
+    match_string Corsair
 
 name Genius
     url www.genius.ru
@@ -434,6 +536,8 @@ name Crucial (Micron)
 name Toshiba Samsung Storage Technology
     name_short TSST
     url www.tsst.co.kr
+    wikipedia Toshiba Samsung Storage Technology
+    ansi_color 0;34;107
     match_string_case TSST
 
 name Seagate Technology
@@ -505,7 +609,7 @@ name Synopsys
     match_string Synopsys
 
 name Raspberry Pi Foundation
-    name_short RaspberryPi
+    name_short Raspberry Pi
     url www.raspberrypi.org
     ansi_color 0;97;42
     match_string RaspberryPi
@@ -517,11 +621,41 @@ name Embest Technology
     ansi_color 0;96;44
     match_string Embest
 
+# JEDEC mfgr [1][78]
 name Transcend Information
     name_short Transcend
     url transcend-info.com
     ansi_color 0;31;47
+    match_string Transcend Information
+    # More likely this one is T. Information than T. Technology
     match_string Transcend
+
+# JEDEC mfgr [7][105]
+name Transcend Technology
+    name_short Transcend
+    match_string Transcend Technology
+
+# JEDEC mfgr [0][64]
+name Infineon Technologies
+    name_short infineon
+    url www.infineon.com
+    wikipedia Infineon Technologies
+    ansi_color 0;34;107
+    match_string Infineon
+
+name Cypress Semiconductor
+    name_short Cypress
+    url cypress.com
+    wikipedia Cypress Semiconductor
+    ansi_color 0;36;107
+    match_string Cypress
+
+name Renesas Electronics
+    name_short Renesas
+    url www.renesas.com
+    wikipedia Renesas Electronics
+    ansi_color 0;97;44
+    match_string Renesas
 
 name ADATA Technology
     name_short ADATA
@@ -555,10 +689,38 @@ name Elitegroup Computer Systems
     ansi_color 0;36;41
     match_string_case ECS
 
-name SANYO
+
+name Sanyo Electric
     name_short SANYO
     url www.sanyo.com
     match_string SANYO
+
+name Cambridge Silicon Radio
+    name_short CSR
+    url www.csr.com
+    wikipedia Cambridge Silicon Radio
+    ansi_color 0;34;107
+    match_string Cambridge Silicon Radio
+
+name Suprema
+    url www.supremainc.com
+    ansi_color 0;31;107
+    match_string suprema
+
+name Patriot Memory
+    name_short Patriot
+    url www.patriotmemory.com
+    wikipedia Patriot Memory
+    ansi_color 0;97;44
+    match_string Patriot Memory
+
+name SK Hynix
+    name_short SK hynix
+    url www.skhynix.com
+    wikipedia SK Hynix
+    ansi_color 0;31;43
+    match_string Hynix
+    match_string Hyundai
 
 #
 # BIOS manufacturers
@@ -614,6 +776,7 @@ name Canonical
 
 name Ubuntu
     url www.ubuntu.com
+    url_support www.ubuntu.com/support/community-support
     ansi_color 0;97;45
     match_string ubuntu
 
@@ -623,6 +786,46 @@ name Arch Linux
     ansi_color 0;36;107
     match_string arch linux
 
+name Red Hat
+    url www.redhat.com
+    ansi_color 0;31;40
+    match_string Red Hat
+
+name Sun Microsystems
+    name_short Sun
+    wikipedia Sun Microsystems
+    match_string Sun Microsystems
+
+name Oracle Corporation
+    name_short Oracle
+    url www.oracle.com
+    ansi_color 0;97;41
+    match_string Oracle
+
+name Oracle Corporation (formerly InnoTek Systemberatung)
+    name_short Oracle (InnoTek)
+    url www.virtualbox.org/wiki/innotek
+    url_support www.virtualbox.org
+    ansi_color 0;97;41
+    match_string InnoTek
+    match_string VirtualBox
+    match_string_case VBOX
+
+name Slackware
+    url www.slackware.com
+    ansi_color 0;30;107
+    match_string Slackware
+
+name KDE
+    url www.kde.org
+    wikipedia KDE
+    ansi_color 0;97;104
+    match_string_case KDE
+
+name CDEmu
+    url cdemu.sourceforge.io
+    match_string CDEmu
+
 #
 # x86 vendor strings
 #
@@ -630,7 +833,9 @@ name Arch Linux
 name Advanced Micro Devices
     name_short AMD
     url www.amd.com
+    wikipedia Advanced Micro Devices
     ansi_color 0;97;41
+    note x86 processor vendor ID
     match_string AMDisbetter!
     match_string AuthenticAMD
 
@@ -639,56 +844,83 @@ name Intel Corporation
     url www.intel.com
     url_support ark.intel.com
     ansi_color 0;97;44
+    note x86 processor vendor ID
     match_string GenuineIntel
+
+name Chengdu Haiguang Integrated Circuit Design
+    name_short Hygon
+    ansi_color 0;97;104
+    match_string Hygon
+    match_string Higon
+    note x86 processor vendor ID
+    match_string HygonGenuine
 
 name VIA Technologies
     name_short VIA
     url www.via.tw
     ansi_color 0;36;107
+    note x86 processor vendor ID
     match_string VIA VIA VIA
 
 name VIA (formerly Centaur Technology)
     name_short VIA (Centaur)
     url www.via.tw
     ansi_color 0;36;107
+    note x86 processor vendor ID
     match_string CentaurHauls
 
 name VIA (formerly Cyrix)
     name_short VIA (Cyrix)
     url www.via.tw
     ansi_color 0;36;107
+    note x86 processor vendor ID
     match_string CyrixInstead
 
 name Transmeta Corporation
     name_short Transmeta
+    note x86 processor vendor ID
     match_string TransmetaCPU
     match_string GenuineTMx86
 
 name National Semiconductor
     name_short NSC
+    note x86 processor vendor ID
     match_string Geode by NSC
 
 name NexGen
+    note x86 processor vendor ID
     match_string NexGenDriven
 
 name Rise Technology
     name_short Rise
+    note x86 processor vendor ID
     match_string RiseRiseRise
 
 name Silicon Integrated Systems
     name_short SIS
+    note x86 processor vendor ID
     match_string SiS SiS SiS
 
 name United Microelectronics Corporation
     name_short UMC
+    note x86 processor vendor ID
     match_string UMC UMC UMC
 
 name DMP Electronics
+    note x86 processor vendor ID
     match_string Vortex86 SoC
 
 #
 # x86 VM vendor strings
 #
+
+name VMware
+    url www.vmware.com
+    wikipedia VMware
+    ansi_color 0;90;47
+    match_string VMware
+    note x86 VM vendor string
+    match_string VMwareVMware
 
 name KVM
     url www.linux-kvm.org
@@ -701,10 +933,6 @@ name Microsoft Hyper-V
 name Parallels
     url www.parallels.com
     match_string lrpepyh vr
-
-name VMware
-    url www.vmware.com
-    match_string VMwareVMware
 
 name Xen HVM
     url www.xenproject.org

--- a/deps/sysobj_early/data/sdcard.ids
+++ b/deps/sysobj_early/data/sdcard.ids
@@ -1,0 +1,48 @@
+#
+# https://github.com/bp0/verbose-spork/blob/master/data/sdcard.ids
+#
+
+#
+# List of known/observed SD card manfid's
+#
+# Syntax:
+# MANFID id manufacturer_name(s)
+
+MANFID 000001 Panasonic
+MANFID 000002 Toshiba
+MANFID 000003 SanDisk
+MANFID 00001b Samsung
+MANFID 00001d ADATA
+MANFID 000027 Phison
+MANFID 000028 Lexar
+MANFID 000031 Silicon Power
+MANFID 000041 Kingston
+MANFID 000074 Transcend Information
+MANFID 000076 Patriot Memory
+MANFID 000082 Sony
+MANFID 00009c Angelbird / Hoodman
+
+#
+# List of known/observed SD card oemid's
+#
+# Syntax:
+# OEMID id vendor_name(s)
+#
+# The id is normally composed of two ascii
+# characters read as a big-endian 16-bit
+# value.
+
+OEMID 3432 Kingston # "42"
+OEMID 4144 ADATA # "AD"
+OEMID 4245 Lexar / Angelbird / Hoodman # "BE"
+OEMID 4a45 Transcend # "JE"
+OEMID 4a54 Sony # "JT"
+OEMID 4a60 Transcend Information # "J`"
+OEMID 5041 Panasonic # "PA"
+OEMID 5048 Phison # "PH"
+OEMID 5054 SanDisk # "PT"
+OEMID 5344 SanDisk # "SD"
+OEMID 534d Samsung # "SM"
+OEMID 534f Angelbird / Hoodman # "SO"
+OEMID 5350 Silicon Power # "SP"
+OEMID 544d Toshiba # "TM"

--- a/deps/sysobj_early/gui/uri_handler.c
+++ b/deps/sysobj_early/gui/uri_handler.c
@@ -1,0 +1,48 @@
+/*
+ * sysobj - https://github.com/bp0/verbose-spork
+ * Copyright (C) 2018  Burt P. <pburt0@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ */
+
+#include <stdio.h>
+#include "uri_handler.h"
+
+static uri_handler uri_func = NULL;
+
+void uri_set_function(uri_handler f) {
+    uri_func = f;
+}
+
+gboolean uri_open(const gchar *uri) {
+    gboolean ret = FALSE;
+    if (uri_func)
+        ret = uri_func(uri);
+    if (ret) return TRUE;
+
+    return uri_open_default(uri);
+}
+
+gboolean uri_open_default(const gchar *uri) {
+    gchar *argv[] = { "/usr/bin/xdg-open", (gchar*)uri, NULL };
+    GError *err = NULL;
+    g_spawn_async(NULL, argv, NULL, G_SPAWN_DEFAULT, NULL, NULL, NULL, &err );
+    if (err) {
+        fprintf(stderr, "Error opening URI %s: %s\n", uri, err->message);
+        g_error_free(err);
+    }
+    return TRUE;
+}

--- a/deps/sysobj_early/gui/uri_handler.h
+++ b/deps/sysobj_early/gui/uri_handler.h
@@ -1,0 +1,32 @@
+/*
+ * sysobj - https://github.com/bp0/verbose-spork
+ * Copyright (C) 2018  Burt P. <pburt0@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ */
+
+#ifndef URI_HANDLER_H
+#define URI_HANDLER_H
+
+#include <glib.h>
+
+typedef gboolean (*uri_handler)(const gchar *uri);
+
+void uri_set_function(uri_handler f);
+gboolean uri_open(const gchar *uri);
+gboolean uri_open_default(const gchar *uri); /* uses xdg-open */
+
+#endif

--- a/deps/sysobj_early/include/auto_free.h
+++ b/deps/sysobj_early/include/auto_free.h
@@ -1,0 +1,58 @@
+/*
+ * sysobj - https://github.com/bp0/verbose-spork
+ * Copyright (C) 2018  Burt P. <pburt0@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ */
+
+#ifndef _AUTO_FREE_H_
+#define _AUTO_FREE_H_
+
+#include <glib.h>
+
+/* DEBUG_AUTO_FREE messages level:
+ * 0 - none
+ * 1 - some
+ * 2 - much
+ */
+#ifndef DEBUG_AUTO_FREE
+#define DEBUG_AUTO_FREE 0
+#endif
+/* the period between free_auto_free()s in the main loop */
+#define AF_SECONDS 11
+/* the minimum time between auto_free(p) and free(p) */
+#define AF_DELAY_SECONDS 10
+
+#if (DEBUG_AUTO_FREE > 0)
+#define auto_free(p) auto_free_(p, __FILE__, __LINE__, __FUNCTION__)
+#define auto_free_ex(p, f) auto_free_ex_(p, f, __FILE__, __LINE__, __FUNCTION__)
+#else
+#define auto_free(p) auto_free_(p, NULL, 0, NULL)
+#define auto_free_ex(p, f) auto_free_ex_(p, f, NULL, 0, NULL)
+#endif
+gpointer auto_free_(gpointer p, const char *file, int line, const char *func);
+gpointer auto_free_ex_(gpointer p, GDestroyNotify f, const char *file, int line, const char *func);
+
+/* free all the auto_free marked items in the current thread */
+void free_auto_free();
+
+/* call at thread termination */
+void free_auto_free_thread_final();
+
+/* call at program termination */
+void free_auto_free_final();
+
+#endif

--- a/deps/sysobj_early/include/gg_slist.h
+++ b/deps/sysobj_early/include/gg_slist.h
@@ -1,0 +1,30 @@
+/*
+ * sysobj - https://github.com/bp0/verbose-spork
+ * Copyright (C) 2018  Burt P. <pburt0@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ */
+
+#ifndef _GG_SLIST_H_
+#define _GG_SLIST_H_
+
+#include <glib.h>
+
+GSList *gg_slist_remove_null(GSList *sl);
+GSList *gg_slist_remove_duplicates(GSList *sl); /* by pointer */
+GSList *gg_slist_remove_duplicates_custom(GSList *sl, GCompareFunc func);
+
+#endif

--- a/deps/sysobj_early/include/strstr_word.h
+++ b/deps/sysobj_early/include/strstr_word.h
@@ -1,0 +1,30 @@
+/*
+ * sysobj - https://github.com/bp0/verbose-spork
+ * Copyright (C) 2018  Burt P. <pburt0@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ */
+
+/* versions of strstr() and strcasestr() where the match must be preceded and
+ * succeded by a non-alpha-numeric character. */
+
+#ifndef __STRSTR_WORD_H__
+#define __STRSTR_WORD_H__
+
+char *strstr_word(const char *haystack, const char *needle);
+char *strcasestr_word(const char *haystack, const char *needle);
+
+#endif

--- a/deps/sysobj_early/include/util_ids.h
+++ b/deps/sysobj_early/include/util_ids.h
@@ -1,0 +1,66 @@
+/*
+ * sysobj - https://github.com/bp0/verbose-spork
+ * Copyright (C) 2018  Burt P. <pburt0@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ */
+
+#ifndef _UTIL_IDS_H_
+#define _UTIL_IDS_H_
+
+#include <glib.h>
+
+#define IDS_LOOKUP_BUFF_SIZE 220
+#define IDS_LOOKUP_MAX_DEPTH 4
+
+/* may be static, all results[] are NULL or point into _strs */
+typedef struct {
+    gchar *results[IDS_LOOKUP_MAX_DEPTH+1]; /* last always NULL */
+    gchar _strs[IDS_LOOKUP_BUFF_SIZE*IDS_LOOKUP_MAX_DEPTH];
+} ids_query_result;
+#define ids_query_result_new() g_new0(ids_query_result, 1)
+#define ids_query_result_free(s) g_free(s);
+
+/* Given a qpath "/X/Y/Z", find names as:
+ * X <name> ->result[0]
+ * \tY <name> ->result[1]
+ * \t\tZ <name> ->result[2]
+ *
+ * Works with:
+ * - pci.ids "<vendor>/<device>/<subvendor> <subdevice>" or "C <class>/<subclass>/<prog-if>"
+ *     ... need to query "<subvendor>" separately
+ * - arm.ids "<implementer>/<part>"
+ * - sdio.ids "<vendor>/<device>", "C <class>"
+ * - sdcard.ids "OEMID <code>", "MANFID <code>"
+ * - usb.ids "<vendor>/<device>", "C <class>" etc.
+ */
+long scan_ids_file(const gchar *file, const gchar *qpath, ids_query_result *result, long start_offset);
+
+typedef struct {
+    gchar *qpath;
+    ids_query_result result;
+} ids_query;
+
+ids_query *ids_query_new(const gchar *qpath);
+void ids_query_free(ids_query *s);
+typedef GSList* ids_query_list;
+
+/* query_list is a GSList of ids_query* */
+long scan_ids_file_list(const gchar *file, ids_query_list query_list, long start_offset);
+/* after scan_ids_file_list(), count hits */
+int query_list_count_found(ids_query_list query_list);
+
+#endif

--- a/deps/sysobj_early/src/auto_free.c
+++ b/deps/sysobj_early/src/auto_free.c
@@ -1,0 +1,164 @@
+/*
+ * sysobj - https://github.com/bp0/verbose-spork
+ * Copyright (C) 2018  Burt P. <pburt0@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ */
+
+#include "auto_free.h"
+#include <stdio.h>
+//#include "sysobj.h"
+
+static GMutex free_lock;
+static GSList *free_list = NULL;
+static gboolean free_final = FALSE;
+static GTimer *auto_free_timer = NULL;
+static guint free_event_source = 0;
+#define _elapsed() (auto_free_timer ? g_timer_elapsed(auto_free_timer, NULL) : 0)
+
+#define auto_free_msg(msg, ...)  fprintf (stderr, "[%s] " msg "\n", __FUNCTION__, ##__VA_ARGS__) /**/
+
+typedef struct {
+    gpointer ptr;
+    GThread *thread;
+    GDestroyNotify f_free;
+    double stamp;
+
+    const char *file;
+    int  line;
+    const char *func;
+} auto_free_item;
+
+gboolean free_auto_free_sf(gpointer trash) {
+    (void)trash;
+    if (free_final) {
+        free_event_source = 0;
+        return G_SOURCE_REMOVE;
+    }
+    free_auto_free();
+    //sysobj_stats.auto_free_next = sysobj_elapsed() + AF_SECONDS;
+    return G_SOURCE_CONTINUE;
+}
+
+gpointer auto_free_ex_(gpointer p, GDestroyNotify f, const char *file, int line, const char *func) {
+    if (!p) return p;
+
+    /* an auto_free() after free_auto_free_final()?
+     * Changed mind, I guess, just go with it. */
+    if (free_final)
+        free_final = FALSE;
+
+    if (!auto_free_timer) {
+        auto_free_timer = g_timer_new();
+        g_timer_start(auto_free_timer);
+    }
+
+    if (!free_event_source) {
+        /* if there is a main loop, then this will call
+         * free_auto_free() in idle time every AF_SECONDS seconds.
+         * If there is no main loop, then free_auto_free()
+         * will be called at sysobj_cleanup() and when exiting
+         * threads, as in sysobj_foreach(). */
+        free_event_source = g_timeout_add_seconds(AF_SECONDS, (GSourceFunc)free_auto_free_sf, NULL);
+        //sysobj_stats.auto_free_next = sysobj_elapsed() + AF_SECONDS;
+    }
+
+    auto_free_item *z = g_new0(auto_free_item, 1);
+    z->ptr = p;
+    z->f_free = f;
+    z->thread = g_thread_self();
+    z->file = file;
+    z->line = line;
+    z->func = func;
+    z->stamp = _elapsed();
+    g_mutex_lock(&free_lock);
+    free_list = g_slist_prepend(free_list, z);
+    //sysobj_stats.auto_free_len++;
+    g_mutex_unlock(&free_lock);
+    return p;
+}
+
+gpointer auto_free_(gpointer p, const char *file, int line, const char *func) {
+    return auto_free_ex_(p, (GDestroyNotify)g_free, file, line, func);
+}
+
+static struct { GDestroyNotify fptr; char *name; }
+    free_function_tab[] = {
+    { (GDestroyNotify) g_free,             "g_free" },
+    // ...
+    { NULL, "(null)" },
+};
+
+static void free_auto_free_ex(gboolean thread_final) {
+    GThread *this_thread = g_thread_self();
+    GSList *l = NULL, *n = NULL;
+    long long unsigned fc = 0;
+    double now = _elapsed();
+
+    if (!free_list) return;
+
+    g_mutex_lock(&free_lock);
+    if (DEBUG_AUTO_FREE) {
+        unsigned long long ll = g_slist_length(free_list);
+        auto_free_msg("%llu total items in queue, but will free from thread %p only... ", ll, this_thread);
+    }
+    for(l = free_list; l; l = n) {
+        auto_free_item *z = (auto_free_item*)l->data;
+        n = l->next;
+        double age = now - z->stamp;
+        if (free_final || (z->thread == this_thread && (thread_final || age > AF_DELAY_SECONDS) ) ) {
+            if (DEBUG_AUTO_FREE == 2) {
+                char fptr[128] = "", *fname;
+                for(int i = 0; i < (int)G_N_ELEMENTS(free_function_tab); i++)
+                    if (z->f_free == free_function_tab[i].fptr)
+                        fname = free_function_tab[i].name;
+                if (!fname) {
+                    snprintf(fname, 127, "%p", z->f_free);
+                    fname = fptr;
+                }
+                if (z->file || z->func)
+                    auto_free_msg("free: %s(%p) age:%lfs from %s:%d %s()", fname, z->ptr, age, z->file, z->line, z->func);
+                else
+                    auto_free_msg("free: %s(%p) age:%lfs", fname, z->ptr, age);
+            }
+
+            z->f_free(z->ptr);
+            g_free(z);
+            free_list = g_slist_delete_link(free_list, l);
+            fc++;
+        }
+    }
+    if (DEBUG_AUTO_FREE)
+        auto_free_msg("... freed %llu (from thread %p)", fc, this_thread);
+    //sysobj_stats.auto_freed += fc;
+    //sysobj_stats.auto_free_len -= fc;
+    g_mutex_unlock(&free_lock);
+}
+
+void free_auto_free_thread_final() {
+    free_auto_free_ex(TRUE);
+}
+
+void free_auto_free_final() {
+    free_final = TRUE;
+    free_auto_free_ex(TRUE);
+    g_timer_destroy(auto_free_timer);
+    auto_free_timer = NULL;
+}
+
+void free_auto_free() {
+    free_auto_free_ex(FALSE);
+}

--- a/deps/sysobj_early/src/gg_slist.c
+++ b/deps/sysobj_early/src/gg_slist.c
@@ -1,0 +1,49 @@
+/*
+ * sysobj - https://github.com/bp0/verbose-spork
+ * Copyright (C) 2018  Burt P. <pburt0@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ */
+
+#include <glib.h>
+
+GSList *gg_slist_remove_duplicates(GSList *sl) {
+    for (GSList *l = sl; l; l = l->next) {
+        GSList *d = NULL;
+        while(d = g_slist_find(l->next, l->data) )
+            sl = g_slist_delete_link(sl, d);
+    }
+    return sl;
+}
+
+GSList *gg_slist_remove_duplicates_custom(GSList *sl, GCompareFunc func) {
+    for (GSList *l = sl; l; l = l->next) {
+        GSList *d = NULL;
+        while(d = g_slist_find_custom(l->next, l->data, func) )
+            sl = g_slist_delete_link(sl, d);
+    }
+    return sl;
+}
+
+GSList *gg_slist_remove_null(GSList *sl) {
+    GSList *n = sl ? sl->next : NULL;
+    for (GSList *l = sl; l; l = n) {
+        n = l->next;
+        if (l->data == NULL)
+            sl = g_slist_delete_link(sl, l);
+    }
+    return sl;
+}

--- a/deps/sysobj_early/src/strstr_word.c
+++ b/deps/sysobj_early/src/strstr_word.c
@@ -1,0 +1,64 @@
+/*
+ * sysobj - https://github.com/bp0/verbose-spork
+ * Copyright (C) 2018  Burt P. <pburt0@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ */
+
+/* versions of strstr() and strcasestr() where the match must be preceded and
+ * succeded by a non-alpha-numeric character. */
+
+#define _GNU_SOURCE
+#include <string.h>
+#include <ctype.h>
+
+char *strstr_word(const char *haystack, const char *needle) {
+    if (!haystack || !needle)
+        return NULL;
+
+    char *c;
+    const char *p = haystack;
+    size_t l = strlen(needle);
+    while(c = strstr(p, needle)) {
+        const char *before = (c == haystack) ? NULL : c-1;
+        const char *after = c + l;
+        int ok = 1;
+        if (isalnum(*after)) ok = 0;
+        if (before && isalnum(*before)) ok = 0;
+        if (ok) return c;
+        p++;
+    }
+    return NULL;
+}
+
+char *strcasestr_word(const char *haystack, const char *needle) {
+    if (!haystack || !needle)
+        return NULL;
+
+    char *c;
+    const char *p = haystack;
+    size_t l = strlen(needle);
+    while(c = strcasestr(p, needle)) {
+        const char *before = (c == haystack) ? NULL : c-1;
+        const char *after = c + l;
+        int ok = 1;
+        if (isalnum(*after)) ok = 0;
+        if (before && isalnum(*before)) ok = 0;
+        if (ok) return c;
+        p++;
+    }
+    return NULL;
+}

--- a/deps/sysobj_early/src/util_ids.c
+++ b/deps/sysobj_early/src/util_ids.c
@@ -1,0 +1,189 @@
+/*
+ * sysobj - https://github.com/bp0/verbose-spork
+ * Copyright (C) 2018  Burt P. <pburt0@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ */
+
+#include "util_ids.h"
+#include <glib.h>
+#include <stdio.h>
+#include <string.h>
+#include <ctype.h>
+
+#define ids_msg(msg, ...)  fprintf (stderr, "[%s] " msg "\n", __FUNCTION__, ##__VA_ARGS__) /**/
+
+ids_query *ids_query_new(const gchar *qpath) {
+    ids_query *s = g_new0(ids_query, 1);
+    s->qpath = qpath ? g_strdup(qpath) : NULL;
+    return s;
+}
+
+void ids_query_free(ids_query *s) {
+    if (s) g_free(s->qpath);
+    g_free(s);
+}
+
+/* c001 < C 01 */
+//TODO: compare more than the first char
+static int ids_cmp(const char *s1, const char *s2) {
+    int cmp = (s2 ? 1 : 0) - (s1 ? 1 : 0);
+    if (cmp == 0 && isalpha(*s1) && isalpha(*s2))
+        cmp = (islower(*s2) ? 1 : 0) - (islower(*s1) ? 1 : 0);
+    if (cmp == 0)
+        return g_strcmp0(s1, s2);
+    else
+        return cmp;
+}
+
+/* Given a qpath "/X/Y/Z", find names as:
+ * X <name> ->result[0]
+ * \tY <name> ->result[1]
+ * \t\tZ <name> ->result[2]
+ *
+ * Works with:
+ * - pci.ids "<vendor>/<device>/<subvendor> <subdevice>" or "C <class>/<subclass>/<prog-if>"
+ * - arm.ids "<implementer>/<part>"
+ * - sdio.ids "<vendor>/<device>", "C <class>"
+ * - usb.ids "<vendor>/<device>", "C <class>" etc
+ */
+long scan_ids_file(const gchar *file, const gchar *qpath, ids_query_result *result, long start_offset) {
+    gchar **qparts = NULL;
+    gchar buff[IDS_LOOKUP_BUFF_SIZE] = "";
+    ids_query_result ret = {};
+    gchar *p = NULL;
+
+    FILE *fd;
+    int tabs;
+    int qdepth;
+    int qpartlen[IDS_LOOKUP_MAX_DEPTH];
+    long last_root_fpos = -1, fpos, line = -1;
+
+    if (!qpath)
+        return -1;
+
+    fd = fopen(file, "r");
+    if (!fd) {
+        ids_msg("file could not be read: %s", file);
+        return -1;
+    }
+
+    qparts = g_strsplit(qpath, "/", -1);
+    qdepth = g_strv_length(qparts);
+    if (qdepth > IDS_LOOKUP_MAX_DEPTH) {
+        ids_msg("qdepth (%d) > ids_max_depth (%d) for %s", qdepth, IDS_LOOKUP_MAX_DEPTH, qpath);
+        qdepth = IDS_LOOKUP_MAX_DEPTH;
+    }
+    for(int i = 0; i < qdepth; i++)
+        qpartlen[i] = strlen(qparts[i]);
+
+    if (start_offset > 0)
+        fseek(fd, start_offset, SEEK_SET);
+
+    for (fpos = ftell(fd); fgets(buff, IDS_LOOKUP_BUFF_SIZE, fd); fpos = ftell(fd)) {
+        p = strchr(buff, '\n');
+        if (!p)
+            ids_msg("line longer than IDS_LOOKUP_BUFF_SIZE (%d), file: %s, offset: %ld", IDS_LOOKUP_BUFF_SIZE, file, fpos);
+        line++;
+
+        /* line ends at comment */
+        p = strchr(buff, '#');
+        if (p) *p = 0;
+        /* trim trailing white space */
+        if (!p) p = buff + strlen(buff);
+        p--;
+        while(p > buff && isspace((unsigned char)*p)) p--;
+        *(p+1) = 0;
+        p = buff;
+
+        if (buff[0] == 0)    continue; /* empty line */
+        if (buff[0] == '\n') continue; /* empty line */
+
+        /* scan for fields */
+        tabs = 0;
+        while(*p == '\t') { tabs++; p++; }
+
+        if (tabs >= qdepth) continue; /* too deep */
+        if (tabs != 0 && !ret.results[tabs-1])
+            continue; /* not looking at this depth, yet */
+
+        //ids_msg("looking at (%d) %s...", tabs, p);
+
+        if (g_str_has_prefix(p, qparts[tabs])
+            && isspace(*(p + qpartlen[tabs])) ) {
+            /* found */
+            p += qpartlen[tabs];
+            while(isspace((unsigned char)*p)) p++; /* ffwd */
+
+            if (tabs == 0) {
+                last_root_fpos = fpos;
+                ret.results[tabs] = ret._strs;
+                strncpy(ret.results[tabs], p, IDS_LOOKUP_BUFF_SIZE-1);
+            } else {
+                ret.results[tabs] = ret.results[tabs-1] + strlen(ret.results[tabs-1]) + 1;
+                strncpy(ret.results[tabs], p, IDS_LOOKUP_BUFF_SIZE-1);
+            }
+            continue;
+        }
+
+        if (ids_cmp(p, qparts[tabs]) == 1) {
+            //ids_msg("will not be found p = %s (%d) qparts[tabs] = %s", p, qparts[tabs]);
+            goto ids_lookup_done; /* will not be found */
+        }
+
+    } /* for each line */
+
+ids_lookup_done:
+    //ids_msg("bailed at line %ld...", line);
+    fclose(fd);
+
+    if (result) {
+        memcpy(result, &ret, sizeof(ids_query_result));
+        for(int i = 0; result->results[i]; i++)
+            result->results[i] = result->_strs + (ret.results[i] - ret._strs);
+
+        return last_root_fpos;
+    }
+    return last_root_fpos;
+}
+
+static gint _ids_query_list_cmp(const ids_query *ql1, const ids_query *ql2) {
+    return g_strcmp0(ql1->qpath, ql2->qpath);
+}
+
+long scan_ids_file_list(const gchar *file, ids_query_list query_list, long start_offset) {
+    GSList *tmp = g_slist_copy(query_list);
+    tmp = g_slist_sort(tmp, (GCompareFunc)_ids_query_list_cmp);
+
+    long offset = start_offset;
+    for (GSList *l = query_list; l; l = l->next) {
+        ids_query *q = l->data;
+        offset = scan_ids_file(file, q->qpath, &(q->result), offset);
+        if (offset == -1)
+            break;
+    }
+    g_slist_free(tmp);
+    return offset;
+}
+
+int query_list_count_found(ids_query_list query_list) {
+    long count = 0;
+    for (GSList *l = query_list; l; l = l->next) {
+        ids_query *q = l->data;
+        if (q->result.results[0]) count++;
+    }
+    return count;
+}

--- a/hardinfo/hardinfo.c
+++ b/hardinfo/hardinfo.c
@@ -162,6 +162,7 @@ int main(int argc, char **argv)
     moreinfo_shutdown();
     vendor_cleanup();
     dmidecode_cache_free();
+    free_auto_free_final();
 
     DEBUG("finished");
     return exit_code;

--- a/hardinfo/util.c
+++ b/hardinfo/util.c
@@ -1031,28 +1031,6 @@ gint tree_view_get_visible_height(GtkTreeView * tv)
     return nrows * rect.height;
 }
 
-static gboolean __idle_free_do(gpointer ptr)
-{
-    g_free(ptr);
-
-    return FALSE;
-}
-
-#if RELEASE == 1
-gpointer idle_free(gpointer ptr)
-#else
-gpointer __idle_free(gpointer ptr, gchar * f, gint l)
-#endif
-{
-    DEBUG("file: %s, line: %d, ptr %p", f, l, ptr);
-
-    if (ptr) {
-	g_timeout_add(10000, __idle_free_do, ptr);
-    }
-
-    return ptr;
-}
-
 void module_entry_scan_all_except(ModuleEntry * entries, gint except_entry)
 {
     ModuleEntry entry;

--- a/includes/hardinfo.h
+++ b/includes/hardinfo.h
@@ -117,12 +117,11 @@ gchar    *file_chooser_build_filename(GtkWidget *chooser, gchar *extension);
 gpointer  file_types_get_data_by_name(FileTypes *file_types, gchar *name);
 
 /* Misc utility functions */
-#if RELEASE == 1
-gpointer idle_free(gpointer ptr);
-#else
-gpointer __idle_free(gpointer ptr, gchar *f, gint l);
-#define  idle_free(p) __idle_free(p, __FILE__, __LINE__)
-#endif	/* RELEASE == 1 */
+#if !(RELEASE == 1)
+#define DEBUG_AUTO_FREE 2
+#endif
+#include "auto_free.h"
+#define idle_free(ptr) auto_free(ptr)
 
 gchar	     *find_program(gchar *program_name);
 gchar      *size_human_readable(gfloat size);

--- a/includes/udisks2_util.h
+++ b/includes/udisks2_util.h
@@ -1,3 +1,5 @@
+#include "vendor.h"
+
 typedef struct udiskp {
     gchar *block;
     gchar *type;
@@ -31,6 +33,7 @@ typedef struct udiskd {
     guint64 smart_poweron;
     gint64 smart_bad_sectors;
     gint32 smart_temperature;
+    vendor_list vendors;
 } udiskd;
 
 typedef struct udiskt {

--- a/includes/vendor.h
+++ b/includes/vendor.h
@@ -18,16 +18,30 @@
 
 #ifndef __VENDOR_H__
 #define __VENDOR_H__
+#include "gg_slist.h"
 
-typedef struct _Vendor	Vendor;
-struct _Vendor {
+typedef GSList* vendor_list;
+#define vendor_list_append(vl, v) g_slist_append(vl, (Vendor*)v)
+#define vendor_list_concat(vl, ext) g_slist_concat(vl, ext)
+vendor_list vendor_list_concat_va(int count, vendor_list vl, ...); /* count = -1 for NULL terminated list */
+#define vendor_list_free(vl) g_slist_free(vl)
+#define vendor_list_remove_duplicates(vl) gg_slist_remove_duplicates(vl)
+vendor_list vendor_list_remove_duplicates_deep(vendor_list vl);
+
+typedef struct {
   char *match_string;
-  int match_case; /* 0 = ignore case, 1 = match case */
+  int match_rule; /* 0 = ignore case, 1 = match case, 2 = exact */
   char *name;
   char *name_short;
   char *url;
   char *url_support;
-};
+  char *wikipedia; /* wikipedia page title (assumes en:, otherwise include langauge), usually more informative than the vendor's page */
+  char *note;      /* a short stored comment */
+  char *ansi_color;
+
+  unsigned long file_line;
+  unsigned long ms_length;
+} Vendor;
 
 void vendor_init(void);
 void vendor_cleanup(void);
@@ -38,5 +52,7 @@ const gchar *vendor_get_url(const gchar *id_str);
 gchar *vendor_get_link(const gchar *id_str);
 gchar *vendor_get_link_from_vendor(const Vendor *v);
 void vendor_free(Vendor *v);
+
+vendor_list vendors_match_core(const gchar *str, int limit);
 
 #endif	/* __VENDOR_H__ */

--- a/includes/vendor.h
+++ b/includes/vendor.h
@@ -45,7 +45,8 @@ typedef struct {
 
 void vendor_init(void);
 void vendor_cleanup(void);
-const Vendor *vendor_match(const gchar *id_str, ...); /* end list of strings with NULL */
+const Vendor *vendor_match(const gchar *id_str, ...) /* end list of strings with NULL */
+  __attribute__((sentinel));
 const gchar *vendor_get_name(const gchar *id_str);
 const gchar *vendor_get_shortest_name(const gchar *id_str);
 const gchar *vendor_get_url(const gchar *id_str);

--- a/shell/shell.c
+++ b/shell/shell.c
@@ -720,6 +720,22 @@ select_first_tree_item(gpointer data)
     return FALSE;
 }
 
+gboolean hardinfo_link(const gchar *uri) {
+    /* Clicked link events pass through here on their
+     * way to the default handler (xdg-open).
+     *
+     * TODO: In the future, links could be used to
+     * jump to different pages in hardinfo.
+     *
+     * if (g_str_has_prefix(uri, "hardinfo:")) {
+     *       hardinfo_navigate(g_utf8_strchr(uri, strlen("hardinfo"), ':') + 1);
+     *       return TRUE;
+     * }
+     */
+
+    return FALSE; /* didn't handle it */
+}
+
 void shell_init(GSList * modules)
 {
     if (shell) {
@@ -728,6 +744,8 @@ void shell_init(GSList * modules)
     }
 
     DEBUG("initializing shell");
+
+    uri_set_function(hardinfo_link);
 
     create_window();
 
@@ -1502,6 +1520,10 @@ static void module_selected_show_info_list(GKeyFile *key_file,
                                      ngroups > 1);
 }
 
+static gboolean detail_activate_link (GtkLabel *label, gchar *uri, gpointer user_data) {
+    return uri_open(uri);
+}
+
 static void module_selected_show_info_detail(GKeyFile *key_file,
                                              ShellModuleEntry *entry,
                                              gchar **groups)
@@ -1567,6 +1589,9 @@ static void module_selected_show_info_detail(GKeyFile *key_file,
                 GtkWidget *value_box = gtk_hbox_new(FALSE, 4);
                 gtk_box_pack_start(GTK_BOX(value_box), value_icon, FALSE, FALSE, 0);
                 gtk_box_pack_start(GTK_BOX(value_box), value_label, TRUE, TRUE, 0);
+
+                g_signal_connect(key_label, "activate-link", G_CALLBACK(detail_activate_link), NULL);
+                g_signal_connect(value_label, "activate-link", G_CALLBACK(detail_activate_link), NULL);
 
                 gtk_widget_show(key_label);
                 gtk_widget_show(value_box);


### PR DESCRIPTION
* more fields in Vendor struct.
* match_case -> match_rule and new match rule "exact". match_rule
  remains compatible with match_case for old conf format.
* matches must be "whole word" matches so "Harmony" no longer hits
  for "ARM".
* Parts outside of () are checked first, so "Foo (formerly Barly)"
  matches Foo before Barly, even though Barly is longer and would
  otherwise match first.
* vendor_list type (a blessed GSList*) and helper functions to manage
  it.