### PR TITLE
Raise GTK2 requirement from 2.10 to 2.18

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,7 +81,7 @@ if (HARDINFO_GTK3)
 	add_definitions(-DGTK_DISABLE_SINGLE_INCLUDES)
 else()
 	message(STATUS "Building for GTK2")
-	pkg_check_modules(GTK REQUIRED gtk+-2.0>=2.10 glib-2.0>=2.10 gthread-2.0>=2.10 gmodule-export-2.0>=2.10)
+	pkg_check_modules(GTK REQUIRED gtk+-2.0>=2.18 glib-2.0>=2.10 gthread-2.0>=2.10 gmodule-export-2.0>=2.10)
 endif()
 
 if(NOT HARDINFO_NOSYNC)

--- a/shell/callbacks.c
+++ b/shell/callbacks.c
@@ -115,11 +115,7 @@ void cb_about_module(GtkAction * action)
 	    gtk_window_set_transient_for(GTK_WINDOW(about), GTK_WINDOW(shell->window));
 
 	    text = g_strdup(sm->name);
-#if GTK_CHECK_VERSION(2, 12, 0)
 	    gtk_about_dialog_set_program_name(GTK_ABOUT_DIALOG(about), text);
-#else
-	    gtk_about_dialog_set_name(GTK_ABOUT_DIALOG(about), text);
-#endif
 	    g_free(text);
 
 	    gtk_about_dialog_set_version(GTK_ABOUT_DIALOG(about),
@@ -187,11 +183,7 @@ void cb_about()
     about = gtk_about_dialog_new();
     gtk_window_set_transient_for(GTK_WINDOW(about), GTK_WINDOW(shell->window));
 
-#if GTK_CHECK_VERSION(2, 12, 0)
     gtk_about_dialog_set_program_name(GTK_ABOUT_DIALOG(about), "HardInfo");
-#else
-    gtk_about_dialog_set_name(GTK_ABOUT_DIALOG(about), "HardInfo");
-#endif
 
     copyright = g_strdup_printf("Copyright \302\251 2003-%d Leandro A. F. Pereira", HARDINFO_COPYRIGHT_LATEST_YEAR);
 

--- a/shell/report.c
+++ b/shell/report.c
@@ -1053,11 +1053,8 @@ static ReportDialog
     gtk_window_set_type_hint(GTK_WINDOW(dialog),
 			     GDK_WINDOW_TYPE_HINT_DIALOG);
 
-#if GTK_CHECK_VERSION(2, 14, 0)
+
     dialog1_vbox = gtk_dialog_get_content_area(GTK_DIALOG(dialog));
-#else
-    dialog1_vbox = GTK_DIALOG(dialog)->vbox;
-#endif
     gtk_box_set_spacing(GTK_BOX(dialog1_vbox), 5);
     gtk_container_set_border_width(GTK_CONTAINER(dialog1_vbox), 4);
     gtk_widget_show(dialog1_vbox);
@@ -1144,35 +1141,23 @@ static ReportDialog
     button3 = gtk_button_new_with_mnemonic(_("Select _None"));
     gtk_widget_show(button3);
     gtk_container_add(GTK_CONTAINER(vbuttonbox3), button3);
-#if GTK_CHECK_VERSION(2, 18, 0)
     gtk_widget_set_can_default(button3, TRUE);
-#else
-    GTK_WIDGET_SET_FLAGS(button3, GTK_CAN_DEFAULT);
-#endif
     g_signal_connect(button3, "clicked",
 		     G_CALLBACK(report_dialog_sel_none), rd);
 
     button6 = gtk_button_new_with_mnemonic(_("Select _All"));
     gtk_widget_show(button6);
     gtk_container_add(GTK_CONTAINER(vbuttonbox3), button6);
-#if GTK_CHECK_VERSION(2, 18, 0)
     gtk_widget_set_can_default(button6, TRUE);
-#else
-    GTK_WIDGET_SET_FLAGS(button6, GTK_CAN_DEFAULT);
-#endif
     g_signal_connect(button6, "clicked", G_CALLBACK(report_dialog_sel_all),
 		     rd);
 
-#if GTK_CHECK_VERSION(2, 14, 0)
 /* TODO:GTK3
  * [https://developer.gnome.org/gtk3/stable/GtkDialog.html#gtk-dialog-get-action-area]
  * gtk_dialog_get_action_area has been deprecated since version 3.12 and should not be used in newly-written code.
  * Direct access to the action area is discouraged; use gtk_dialog_add_button(), etc.
  */
     dialog1_action_area = gtk_dialog_get_content_area(GTK_DIALOG(dialog));
-#else
-    dialog1_action_area = GTK_DIALOG(dialog)->action_area;
-#endif
     gtk_widget_show(dialog1_action_area);
     gtk_button_box_set_layout(GTK_BUTTON_BOX(dialog1_action_area),
 			      GTK_BUTTONBOX_END);
@@ -1181,21 +1166,13 @@ static ReportDialog
     gtk_widget_show(button8);
     gtk_dialog_add_action_widget(GTK_DIALOG(dialog), button8,
 				 GTK_RESPONSE_CANCEL);
-#if GTK_CHECK_VERSION(2, 18, 0)
     gtk_widget_set_can_default(button8, TRUE);
-#else
-    GTK_WIDGET_SET_FLAGS(button8, GTK_CAN_DEFAULT);
-#endif
 
     button7 = gtk_button_new_with_mnemonic(_("_Generate"));
     gtk_widget_show(button7);
     gtk_dialog_add_action_widget(GTK_DIALOG(dialog), button7,
 				 GTK_RESPONSE_ACCEPT);
-#if GTK_CHECK_VERSION(2, 18, 0)
     gtk_widget_set_can_default(button7, TRUE);
-#else
-    GTK_WIDGET_SET_FLAGS(button7, GTK_CAN_DEFAULT);
-#endif
 
     rd->dialog = dialog;
     rd->btn_cancel = button8;

--- a/shell/shell.c
+++ b/shell/shell.c
@@ -129,7 +129,6 @@ void shell_action_set_property(const gchar * action_name,
 
 void shell_action_set_label(const gchar * action_name, gchar * label)
 {
-#if GTK_CHECK_VERSION(2,16,0)
     if (params.gui_running && shell->action_group) {
 	GtkAction *action;
 
@@ -139,7 +138,6 @@ void shell_action_set_label(const gchar * action_name, gchar * label)
 	    gtk_action_set_label(action, label);
 	}
     }
-#endif
 }
 
 void shell_action_set_enabled(const gchar * action_name, gboolean setting)
@@ -880,9 +878,7 @@ static void detail_view_clear(DetailView *detail_view)
 static gboolean reload_section(gpointer data)
 {
     ShellModuleEntry *entry = (ShellModuleEntry *)data;
-#if GTK_CHECK_VERSION(2, 14, 0)
     GdkWindow *gdk_window = gtk_widget_get_window(GTK_WIDGET(shell->window));
-#endif
 
     /* if the entry is still selected, update it */
     if (entry->selected) {
@@ -900,11 +896,7 @@ static gboolean reload_section(gpointer data)
 #endif
 
         /* avoid drawing the window while we reload */
-#if GTK_CHECK_VERSION(2, 14, 0)
         gdk_window_freeze_updates(gdk_window);
-#else
-        gdk_window_freeze_updates(shell->window->window);
-#endif
 
         /* gets the current selected path */
         if (gtk_tree_selection_get_selected(shell->info_tree->selection,
@@ -937,11 +929,7 @@ static gboolean reload_section(gpointer data)
 #endif
 
         /* make the window drawable again */
-#if GTK_CHECK_VERSION(2, 14, 0)
         gdk_window_thaw_updates(gdk_window);
-#else
-        gdk_window_thaw_updates(shell->window->window);
-#endif
     }
 
     /* destroy the timeout: it'll be set up again */
@@ -993,9 +981,7 @@ info_tree_compare_val_func(GtkTreeModel * model,
 
 static void set_view_type(ShellViewType viewtype, gboolean reload)
 {
-#if GTK_CHECK_VERSION(2, 18, 0)
     GtkAllocation* alloc;
-#endif
     gboolean type_changed = FALSE;
     if (viewtype != shell->view_type)
         type_changed = TRUE;
@@ -1048,15 +1034,10 @@ static void set_view_type(ShellViewType viewtype, gboolean reload)
         gtk_widget_show(shell->notebook);
 
         if (type_changed) {
-#if GTK_CHECK_VERSION(2, 18, 0)
             alloc = g_new(GtkAllocation, 1);
             gtk_widget_get_allocation(shell->hbox, alloc);
             gtk_paned_set_position(GTK_PANED(shell->vpaned), alloc->height / 2);
             g_free(alloc);
-#else
-            gtk_paned_set_position(GTK_PANED(shell->vpaned),
-                            shell->hbox->allocation.height / 2);
-#endif
         }
         break;
     case SHELL_VIEW_LOAD_GRAPH:
@@ -1066,17 +1047,11 @@ static void set_view_type(ShellViewType viewtype, gboolean reload)
         load_graph_clear(shell->loadgraph);
 
         if (type_changed) {
-#if GTK_CHECK_VERSION(2, 18, 0)
             alloc = g_new(GtkAllocation, 1);
             gtk_widget_get_allocation(shell->hbox, alloc);
             gtk_paned_set_position(GTK_PANED(shell->vpaned),
                     alloc->height - load_graph_get_height(shell->loadgraph) - 16);
             g_free(alloc);
-#else
-            gtk_paned_set_position(GTK_PANED(shell->vpaned),
-                           shell->hbox->allocation.height -
-                           load_graph_get_height(shell->loadgraph) - 16);
-#endif
         }
         break;
     case SHELL_VIEW_PROGRESS_DUAL:
@@ -2098,10 +2073,8 @@ static ShellTree *tree_new()
     treeview = gtk_tree_view_new_with_model(model);
     gtk_tree_view_set_headers_visible(GTK_TREE_VIEW(treeview), FALSE);
 
-#if GTK_CHECK_VERSION(2,12,0)
     gtk_tree_view_set_show_expanders(GTK_TREE_VIEW(treeview), FALSE);
     gtk_tree_view_set_level_indentation(GTK_TREE_VIEW(treeview), 24);
-#endif
 
     column = gtk_tree_view_column_new();
     gtk_tree_view_append_column(GTK_TREE_VIEW(treeview), column);

--- a/shell/syncmanager.c
+++ b/shell/syncmanager.c
@@ -667,11 +667,7 @@ static SyncDialog *sync_dialog_new(GtkWidget *parent)
 
     gtk_container_set_border_width(GTK_CONTAINER(dialog), 5);
 
-#if GTK_CHECK_VERSION(2, 14, 0)
     dialog1_vbox = gtk_dialog_get_content_area(GTK_DIALOG(dialog));
-#else
-    dialog1_vbox = GTK_DIALOG(dialog)->vbox;
-#endif
     gtk_box_set_spacing(GTK_BOX(dialog1_vbox), 5);
     gtk_container_set_border_width(GTK_CONTAINER(dialog1_vbox), 4);
     gtk_widget_show(dialog1_vbox);
@@ -736,11 +732,7 @@ static SyncDialog *sync_dialog_new(GtkWidget *parent)
 
     populate_store(store);
 
-#if GTK_CHECK_VERSION(2, 14, 0)
     dialog1_action_area = gtk_dialog_get_action_area(GTK_DIALOG(dialog));
-#else
-    dialog1_action_area = GTK_DIALOG(dialog)->action_area;
-#endif
     gtk_widget_show(dialog1_action_area);
     gtk_button_box_set_layout(GTK_BUTTON_BOX(dialog1_action_area),
 			      GTK_BUTTONBOX_END);
@@ -749,30 +741,18 @@ static SyncDialog *sync_dialog_new(GtkWidget *parent)
     gtk_widget_show(button8);
     gtk_dialog_add_action_widget(GTK_DIALOG(dialog), button8,
 				 GTK_RESPONSE_CANCEL);
-#if GTK_CHECK_VERSION(2, 18, 0)
     gtk_widget_set_can_default(button8, TRUE);
-#else
-    GTK_WIDGET_SET_FLAGS(button8, GTK_CAN_DEFAULT);
-#endif
     button7 = gtk_button_new_with_mnemonic(_("_Synchronize"));
     gtk_widget_show(button7);
     gtk_dialog_add_action_widget(GTK_DIALOG(dialog), button7,
 				 GTK_RESPONSE_ACCEPT);
-#if GTK_CHECK_VERSION(2, 18, 0)
     gtk_widget_set_can_default(button7, TRUE);
-#else
-    GTK_WIDGET_SET_FLAGS(button7, GTK_CAN_DEFAULT);
-#endif
     button6 = gtk_button_new_from_stock(GTK_STOCK_CLOSE);
     g_signal_connect(G_OBJECT(button6), "clicked",
 		     (GCallback) close_clicked, NULL);
     gtk_dialog_add_action_widget(GTK_DIALOG(dialog), button6,
 				 GTK_RESPONSE_ACCEPT);
-#if GTK_CHECK_VERSION(2, 18, 0)
     gtk_widget_set_can_default(button6, TRUE);
-#else
-    GTK_WIDGET_SET_FLAGS(button6, GTK_CAN_DEFAULT);
-#endif
 
     sd->dialog = dialog;
     sd->button_sync = button7;


### PR DESCRIPTION
As links in labels are now being used, 2.18 is required.

See: https://github.com/lpereira/hardinfo/issues/379#issuecomment-507857291
