### PR TITLE
Raspberry Pi memory types

### DIFF
--- a/modules/devices/devicetree.c
+++ b/modules/devices/devicetree.c
@@ -29,14 +29,15 @@
 #include "cpu_util.h"
 #include "dt_util.h"
 
+gchar *dtree_info = NULL;
+const char *dtree_mem_str = NULL; /* used by memory devices when nothing else is available */
+
 /* These should really go into CMakeLists.txt */
 #if defined(__arm__)
 #include "devicetree/rpi_data.c"
 #elif defined(__powerpc__)
 #include "devicetree/pmac_data.c"
 #endif
-
-gchar *dtree_info = NULL;
 
 static gchar *get_node(dtr *dt, char *np) {
     gchar *nodes = NULL, *props = NULL, *ret = NULL;

--- a/modules/devices/devicetree/rpi_data.c
+++ b/modules/devices/devicetree/rpi_data.c
@@ -21,54 +21,55 @@
 static char unk[] = "(Unknown)";
 
 /* information table from: http://elinux.org/RPi_HardwareHistory */
-static struct {
+typedef struct {
     char *value, *intro, *model, *pcb, *mem, *mfg, *soc;
-} rpi_boardinfo[] = {
+} RaspberryPiBoard;
+
+static const RaspberryPiBoard rpi_boardinfo[] = {
 /*  Value        Introduction  Model Name             PCB rev.  Memory(spec)   Manufacturer  SOC(spec) *
  *                             Raspberry Pi %s                                                         */
   { unk,         unk,          unk,                   unk,      unk,        unk,             NULL },
-  { "Beta",      "Q1 2012",    "B (Beta)",            unk,      "256MB",    "(Beta board)",  NULL },
-  { "0002",      "Q1 2012",    "B",                   "1.0",    "256MB",    unk,             "BCM2835" },
-  { "0003",      "Q3 2012",    "B (ECN0001)",         "1.0",    "256MB",    "(Fuses mod and D14 removed)",   NULL },
-  { "0004",      "Q3 2012",    "B",                   "2.0",    "256MB",    "Sony",          NULL },
-  { "0005",      "Q4 2012",    "B",                   "2.0",    "256MB",    "Qisda",         NULL },
-  { "0006",      "Q4 2012",    "B",                   "2.0",    "256MB",    "Egoman",        NULL },
-  { "0007",      "Q1 2013",    "A",                   "2.0",    "256MB",    "Egoman",        NULL },
-  { "0008",      "Q1 2013",    "A",                   "2.0",    "256MB",    "Sony",          NULL },
-  { "0009",      "Q1 2013",    "A",                   "2.0",    "256MB",    "Qisda",         NULL },
-  { "000d",      "Q4 2012",    "B",                   "2.0",    "512MB",    "Egoman",        NULL },
-  { "000e",      "Q4 2012",    "B",                   "2.0",    "512MB",    "Sony",          NULL },
-  { "000f",      "Q4 2012",    "B",                   "2.0",    "512MB",    "Qisda",         NULL },
-  { "0010",      "Q3 2014",    "B+",                  "1.0",    "512MB",    "Sony",          NULL },
-  { "0011",      "Q2 2014",    "Compute Module 1",    "1.0",    "512MB",    "Sony",          NULL },
-  { "0012",      "Q4 2014",    "A+",                  "1.1",    "256MB",    "Sony",          NULL },
-  { "0013",      "Q1 2015",    "B+",                  "1.2",    "512MB",    unk,             NULL },
-  { "0014",      "Q2 2014",    "Compute Module 1",    "1.0",    "512MB",    "Embest",        NULL },
-  { "0015",      unk,          "A+",                  "1.1",    "256MB/512MB",    "Embest",      NULL  },
-  { "a01040",    unk,          "2 Model B",           "1.0",    "1GB",      "Sony",          "BCM2836" },
-  { "a01041",    "Q1 2015",    "2 Model B",           "1.1",    "1GB",      "Sony",          "BCM2836" },
-  { "a21041",    "Q1 2015",    "2 Model B",           "1.1",    "1GB",      "Embest",        "BCM2836" },
-  { "a22042",    "Q3 2016",    "2 Model B",           "1.2",    "1GB",      "Embest",        "BCM2837" },  /* (with BCM2837) */
-  { "900021",    "Q3 2016",    "A+",                  "1.1",    "512MB",    "Sony",          NULL },
-  { "900032",    "Q2 2016?",    "B+",                 "1.2",    "512MB",    "Sony",          NULL },
-  { "900092",    "Q4 2015",    "Zero",                "1.2",    "512MB",    "Sony",          NULL },
-  { "900093",    "Q2 2016",    "Zero",                "1.3",    "512MB",    "Sony",          NULL },
-  { "920093",    "Q4 2016?",   "Zero",                "1.3",    "512MB",    "Embest",        NULL },
-  { "9000c1",    "Q1 2017",    "Zero W",              "1.1",    "512MB",    "Sony",          NULL },
-  { "a02082",    "Q1 2016",    "3 Model B",           "1.2",    "1GB",      "Sony",          "BCM2837" },
-  { "a020a0",    "Q1 2017",    "Compute Module 3 or CM3 Lite",  "1.0",    "1GB",    "Sony",          NULL },
-  { "a22082",    "Q1 2016",    "3 Model B",           "1.2",    "1GB",      "Embest",        "BCM2837" },
-  { "a32082",    "Q4 2016",    "3 Model B",           "1.2",    "1GB",      "Sony Japan",    NULL  },
-  { "a020d3",    "Q1 2018",    "3 Model B+",          "1.3",    "1GB",      "Sony",          "BCM2837" },
-  { "9020e0",    "Q4 2018",    "3 Model A+",          "1.0",    "512MB",    "Sony",          "BCM2837" },
+  { "Beta",      "Q1 2012",    "B (Beta)",            unk,      "256 MB",    "(Beta board)",  NULL },
+  { "0002",      "Q1 2012",    "B",                   "1.0",    "256 MB",    unk,             "BCM2835" },
+  { "0003",      "Q3 2012",    "B (ECN0001)",         "1.0",    "256 MB",    "(Fuses mod and D14 removed)",   NULL },
+  { "0004",      "Q3 2012",    "B",                   "2.0",    "256 MB",    "Sony",          NULL },
+  { "0005",      "Q4 2012",    "B",                   "2.0",    "256 MB",    "Qisda",         NULL },
+  { "0006",      "Q4 2012",    "B",                   "2.0",    "256 MB",    "Egoman",        NULL },
+  { "0007",      "Q1 2013",    "A",                   "2.0",    "256 MB",    "Egoman",        NULL },
+  { "0008",      "Q1 2013",    "A",                   "2.0",    "256 MB",    "Sony",          NULL },
+  { "0009",      "Q1 2013",    "A",                   "2.0",    "256 MB",    "Qisda",         NULL },
+  { "000d",      "Q4 2012",    "B",                   "2.0",    "512 MB",    "Egoman",        NULL },
+  { "000e",      "Q4 2012",    "B",                   "2.0",    "512 MB",    "Sony",          NULL },
+  { "000f",      "Q4 2012",    "B",                   "2.0",    "512 MB",    "Qisda",         NULL },
+  { "0010",      "Q3 2014",    "B+",                  "1.0",    "512 MB",    "Sony",          NULL },
+  { "0011",      "Q2 2014",    "Compute Module 1",    "1.0",    "512 MB",    "Sony",          NULL },
+  { "0012",      "Q4 2014",    "A+",                  "1.1",    "256 MB",    "Sony",          NULL },
+  { "0013",      "Q1 2015",    "B+",                  "1.2",    "512 MB",    unk,             NULL },
+  { "0014",      "Q2 2014",    "Compute Module 1",    "1.0",    "512 MB",    "Embest",        NULL },
+  { "0015",      unk,          "A+",                  "1.1",    "256 MB/512 MB",    "Embest",      NULL  },
+  { "a01040",    unk,          "2 Model B",           "1.0",    "1 GB DDR2",      "Sony",          "BCM2836" },
+  { "a01041",    "Q1 2015",    "2 Model B",           "1.1",    "1 GB DDR2",      "Sony",          "BCM2836" },
+  { "a21041",    "Q1 2015",    "2 Model B",           "1.1",    "1 GB DDR2",      "Embest",        "BCM2836" },
+  { "a22042",    "Q3 2016",    "2 Model B",           "1.2",    "1 GB DDR2",      "Embest",        "BCM2837" },  /* (with BCM2837) */
+  { "900021",    "Q3 2016",    "A+",                  "1.1",    "512 MB",    "Sony",          NULL },
+  { "900032",    "Q2 2016?",    "B+",                 "1.2",    "512 MB",    "Sony",          NULL },
+  { "900092",    "Q4 2015",    "Zero",                "1.2",    "512 MB",    "Sony",          NULL },
+  { "900093",    "Q2 2016",    "Zero",                "1.3",    "512 MB",    "Sony",          NULL },
+  { "920093",    "Q4 2016?",   "Zero",                "1.3",    "512 MB",    "Embest",        NULL },
+  { "9000c1",    "Q1 2017",    "Zero W",              "1.1",    "512 MB",    "Sony",          NULL },
+  { "a02082",    "Q1 2016",    "3 Model B",           "1.2",    "1 GB DDR2",      "Sony",          "BCM2837" },
+  { "a020a0",    "Q1 2017",    "Compute Module 3 or CM3 Lite",  "1.0",    "1 GB DDR2",    "Sony",          NULL },
+  { "a22082",    "Q1 2016",    "3 Model B",           "1.2",    "1 GB DDR2",      "Embest",        "BCM2837" },
+  { "a32082",    "Q4 2016",    "3 Model B",           "1.2",    "1 GB DDR2",      "Sony Japan",    NULL  },
+  { "a020d3",    "Q1 2018",    "3 Model B+",          "1.3",    "1 GB DDR2",      "Sony",          "BCM2837" },
+  { "9020e0",    "Q4 2018",    "3 Model A+",          "1.0",    "512 MB DDR2",    "Sony",          "BCM2837" },
 
-  { "a03111",    "Q2 2019",    "4 Model B",           "1.0",    "1GB",      "Sony",          "BCM2838" },
-  { "b03111",    "Q2 2019",    "4 Model B",           "1.0",    "2GB",      "Sony",          "BCM2838" },
-  //{ "c?03111",    "Q2 2019",    "4 Model B",           "1.0",    "4GB",      "Sony",          "BCM2838" },
+  { "a03111",    "Q2 2019",    "4 Model B",           "1.0",    "1 GB DDR4",      "Sony",          "BCM2838" },
+  { "b03111",    "Q2 2019",    "4 Model B",           "1.0",    "2 GB DDR4",      "Sony",          "BCM2838" },
+  //{ "c?03111",    "Q2 2019",    "4 Model B",           "1.0",    "4 GB DDR4",      "Sony",          "BCM2838" },
 
   { NULL, NULL, NULL, NULL, NULL, NULL, NULL }
 };
-
 
 /* return number of chars to skip */
 static int rpi_ov_check(const char *r_code) {
@@ -169,5 +170,9 @@ static gchar *rpi_board_details(void) {
 
     g_free(soc);
     g_free(revision);
+
+    if (rpi_boardinfo[i].mem)
+        dtree_mem_str = rpi_boardinfo[i].mem;
+
     return ret;
 }

--- a/modules/devices/devicetree/rpi_data.c
+++ b/modules/devices/devicetree/rpi_data.c
@@ -47,26 +47,26 @@ static const RaspberryPiBoard rpi_boardinfo[] = {
   { "0013",      "Q1 2015",    "B+",                  "1.2",    "512 MB",    unk,             NULL },
   { "0014",      "Q2 2014",    "Compute Module 1",    "1.0",    "512 MB",    "Embest",        NULL },
   { "0015",      unk,          "A+",                  "1.1",    "256 MB/512 MB",    "Embest",      NULL  },
-  { "a01040",    unk,          "2 Model B",           "1.0",    "1 GB DDR2",      "Sony",          "BCM2836" },
-  { "a01041",    "Q1 2015",    "2 Model B",           "1.1",    "1 GB DDR2",      "Sony",          "BCM2836" },
-  { "a21041",    "Q1 2015",    "2 Model B",           "1.1",    "1 GB DDR2",      "Embest",        "BCM2836" },
-  { "a22042",    "Q3 2016",    "2 Model B",           "1.2",    "1 GB DDR2",      "Embest",        "BCM2837" },  /* (with BCM2837) */
+  { "a01040",    unk,          "2 Model B",           "1.0",    "1024 MB DDR2",      "Sony",          "BCM2836" },
+  { "a01041",    "Q1 2015",    "2 Model B",           "1.1",    "1024 MB DDR2",      "Sony",          "BCM2836" },
+  { "a21041",    "Q1 2015",    "2 Model B",           "1.1",    "1024 MB DDR2",      "Embest",        "BCM2836" },
+  { "a22042",    "Q3 2016",    "2 Model B",           "1.2",    "1024 MB DDR2",      "Embest",        "BCM2837" },  /* (with BCM2837) */
   { "900021",    "Q3 2016",    "A+",                  "1.1",    "512 MB",    "Sony",          NULL },
   { "900032",    "Q2 2016?",    "B+",                 "1.2",    "512 MB",    "Sony",          NULL },
   { "900092",    "Q4 2015",    "Zero",                "1.2",    "512 MB",    "Sony",          NULL },
   { "900093",    "Q2 2016",    "Zero",                "1.3",    "512 MB",    "Sony",          NULL },
   { "920093",    "Q4 2016?",   "Zero",                "1.3",    "512 MB",    "Embest",        NULL },
   { "9000c1",    "Q1 2017",    "Zero W",              "1.1",    "512 MB",    "Sony",          NULL },
-  { "a02082",    "Q1 2016",    "3 Model B",           "1.2",    "1 GB DDR2",      "Sony",          "BCM2837" },
-  { "a020a0",    "Q1 2017",    "Compute Module 3 or CM3 Lite",  "1.0",    "1 GB DDR2",    "Sony",          NULL },
-  { "a22082",    "Q1 2016",    "3 Model B",           "1.2",    "1 GB DDR2",      "Embest",        "BCM2837" },
-  { "a32082",    "Q4 2016",    "3 Model B",           "1.2",    "1 GB DDR2",      "Sony Japan",    NULL  },
-  { "a020d3",    "Q1 2018",    "3 Model B+",          "1.3",    "1 GB DDR2",      "Sony",          "BCM2837" },
+  { "a02082",    "Q1 2016",    "3 Model B",           "1.2",    "1024 MB DDR2",      "Sony",          "BCM2837" },
+  { "a020a0",    "Q1 2017",    "Compute Module 3 or CM3 Lite",  "1.0",    "1024 MB DDR2",    "Sony",          NULL },
+  { "a22082",    "Q1 2016",    "3 Model B",           "1.2",    "1024 MB DDR2",      "Embest",        "BCM2837" },
+  { "a32082",    "Q4 2016",    "3 Model B",           "1.2",    "1024 MB DDR2",      "Sony Japan",    NULL  },
+  { "a020d3",    "Q1 2018",    "3 Model B+",          "1.3",    "1024 MB DDR2",      "Sony",          "BCM2837" },
   { "9020e0",    "Q4 2018",    "3 Model A+",          "1.0",    "512 MB DDR2",    "Sony",          "BCM2837" },
 
-  { "a03111",    "Q2 2019",    "4 Model B",           "1.0",    "1 GB DDR4",      "Sony",          "BCM2838" },
-  { "b03111",    "Q2 2019",    "4 Model B",           "1.0",    "2 GB DDR4",      "Sony",          "BCM2838" },
-  //{ "c?03111",    "Q2 2019",    "4 Model B",           "1.0",    "4 GB DDR4",      "Sony",          "BCM2838" },
+  { "a03111",    "Q2 2019",    "4 Model B",           "1.0",    "1024 MB DDR4",      "Sony",          "BCM2838" },
+  { "b03111",    "Q2 2019",    "4 Model B",           "1.0",    "2048 MB DDR4",      "Sony",          "BCM2838" },
+  { "c03111",    "Q2 2019",    "4 Model B",           "1.1",    "4096 MB DDR4",      "Sony",          "BCM2838" },
 
   { NULL, NULL, NULL, NULL, NULL, NULL, NULL }
 };


### PR DESCRIPTION
Using a lookup table, get the physical memory size and type for known Raspberry Pi boards. This can be used in Computer Summary > Memory as with DMI or SPD sourced information.

![rpimem](https://user-images.githubusercontent.com/1758090/61190607-b085a600-a664-11e9-94c0-9739b4737801.png)
