### PR TITLE
Improved USB devices

### DIFF
--- a/hardinfo/usb_util.c
+++ b/hardinfo/usb_util.c
@@ -30,6 +30,7 @@ usbi *usbi_new() {
 
 void usbi_free(usbi *s) {
     if (s) {
+        g_free(s->if_label);
         g_free(s->if_class_str);
         g_free(s->if_subclass_str);
         g_free(s->if_protocol_str);
@@ -234,6 +235,11 @@ static gboolean usb_get_device_lsusb(int bus, int dev, usbd *s) {
                     if (t = strchr(l, ' '))
                         curr_if->if_protocol_str = g_strdup(t + 1);
                 }
+            } else if (l = lsusb_line_value(p, "iInterface")) {
+                if (curr_if != NULL){
+                    if (t = strchr(l, ' '))
+                        curr_if->if_label = g_strdup(t + 1);
+                }
             }
 
             p = next_nl + 1;
@@ -269,6 +275,9 @@ static gboolean usb_get_interface_sysfs(int conf, int number,
     intf->if_class = h_sysfs_read_hex(ifpath, "bInterfaceClass");
     intf->if_subclass = h_sysfs_read_hex(ifpath, "bInterfaceSubClass");
     intf->if_protocol = h_sysfs_read_hex(ifpath, "bInterfaceProtocol");
+
+    if (intf->if_label == NULL)
+        intf->if_label = h_sysfs_read_string(ifpath, "interface");
 
     g_free(ifpath);
     return TRUE;

--- a/hardinfo/usb_util.c
+++ b/hardinfo/usb_util.c
@@ -92,6 +92,40 @@ static int usbd_list_append(usbd *l, usbd *n) {
     return c;
 }
 
+/* returns new top of the list */
+static usbd *usbd_list_append_sorted(usbd *l, usbd *n) {
+    usbd *b = NULL;
+    usbd *t = l;
+
+    if (n == NULL)
+        return l;
+
+    while(l != NULL) {
+        if ((n->bus > l->bus) ||
+            ((n->bus == l->bus) && (n->dev >= l->dev))) {
+            if (l->next == NULL) {
+                l->next = n;
+                break;
+            }
+            b = l;
+            l = l->next;
+        }
+        else {
+            if (b == NULL) {
+                t = n;
+                n->next = l;
+            }
+            else {
+                b->next = n;
+                n->next = l;
+            }
+            break;
+        }
+    }
+
+    return t;
+}
+
 void usbd_append_interface(usbd *dev, usbi *new_if){
     usbi *curr_if;
     if (dev->if_list == NULL){
@@ -352,7 +386,7 @@ static usbd *usb_get_device_list_sysfs() {
                 if (head == NULL) {
                     head = nd;
                 } else {
-                    usbd_list_append(head, nd);
+                    head = usbd_list_append_sorted(head, nd);
                 }
             }
             g_free(devpath);

--- a/hardinfo/util.c
+++ b/hardinfo/util.c
@@ -1237,6 +1237,22 @@ h_sysfs_read_int(const gchar *endpoint, const gchar *entry)
 	return return_value;
 }
 
+gint
+h_sysfs_read_hex(const gchar *endpoint, const gchar *entry)
+{
+	gchar *tmp, *buffer;
+	gint return_value = 0;
+
+	tmp = g_build_filename(endpoint, entry, NULL);
+	if (g_file_get_contents(tmp, &buffer, NULL, NULL))
+		return_value = (gint) strtoll(buffer, NULL, 16);
+
+	g_free(tmp);
+	g_free(buffer);
+
+	return return_value;
+}
+
 gchar *
 h_sysfs_read_string(const gchar *endpoint, const gchar *entry)
 {

--- a/includes/hardinfo.h
+++ b/includes/hardinfo.h
@@ -163,6 +163,7 @@ gchar           *module_call_method_param(gchar * method, gchar * parameter);
 /* Sysfs stuff */
 gfloat		h_sysfs_read_float(const gchar *endpoint, const gchar *entry);
 gint		h_sysfs_read_int(const gchar *endpoint, const gchar *entry);
+gint		h_sysfs_read_hex(const gchar *endpoint, const gchar *entry);
 gchar	       *h_sysfs_read_string(const gchar *endpoint, const gchar *entry);
 
 #define SCAN_START()  static gboolean scanned = FALSE; if (reload) scanned = FALSE; if (scanned) return;

--- a/includes/usb_util.h
+++ b/includes/usb_util.h
@@ -52,6 +52,7 @@ typedef struct usbi {
     int if_class;
     int if_subclass;
     int if_protocol;
+    char *if_label;
     char *if_class_str;
     char *if_subclass_str;
     char *if_protocol_str;

--- a/includes/usb_util.h
+++ b/includes/usb_util.h
@@ -25,6 +25,8 @@ typedef struct usbd {
     int vendor_id, product_id;
     char *vendor;
     char *product;
+    char *manufacturer;
+    char *device;
 
     int dev_class;
     int dev_subclass;
@@ -36,7 +38,7 @@ typedef struct usbd {
 
     int max_curr_ma;
 
-    int speed_mbs; /* TODO: */
+    int speed_mbs;
 
     gboolean user_scan; /* not scanned as root */
     struct usbi *if_list;
@@ -53,6 +55,7 @@ typedef struct usbi {
     char *if_class_str;
     char *if_subclass_str;
     char *if_protocol_str;
+    char *driver;
 
     struct usbi *next;
 } usbi;
@@ -61,7 +64,7 @@ usbd *usb_get_device_list();
 int usbd_list_count(usbd *);
 void usbd_list_free(usbd *);
 
-usbd *usb_get_device(int bus, int dev);
+usbd *usb_get_device(int bus, int dev, const gchar* sysfspath);
 void usbd_free(usbd *);
 
 #endif

--- a/modules/devices/usb.c
+++ b/modules/devices/usb.c
@@ -131,13 +131,13 @@ static void _usb_dev(const usbd *u) {
             if_protocol_str = UNKIFNULL_AC(i->if_protocol_str);
             if_driver = UNKIFNULL_AC(i->driver);
 
-            interfaces = h_strdup_cprintf("[%s %d]\n"
+            interfaces = h_strdup_cprintf("[%s %d %s]\n"
                 /* Class */       "%s=[%d] %s\n"
                 /* Sub-class */   "%s=[%d] %s\n"
                 /* Protocol */    "%s=[%d] %s\n"
                 /* Driver */      "%s=%s\n",
                     interfaces,
-                    _("Interface"), i->if_number,
+                    _("Interface"), i->if_number, i->if_label? i->if_label: "",
                     _("Class"), i->if_class, if_class_str,
                     _("Sub-class"), i->if_subclass, if_subclass_str,
                     _("Protocol"), i->if_protocol, if_protocol_str,


### PR DESCRIPTION
This PR adds sysfs information about USB devices.
This brings additional information (speed, used driver, interface label, reported manufacturer and device name) and also sysfs can be used as a fallback when lsusb is not available.

This PR also contains workaround when same USB interface is parsed multiple times from lsusb output.
