### PR TITLE
name cleanup for x86 model strings and intel pci device strings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -220,6 +220,9 @@ add_library(sysobj_early STATIC
 	deps/sysobj_early/src/strstr_word.c
 	deps/sysobj_early/src/auto_free.c
 	deps/sysobj_early/src/util_ids.c
+	deps/sysobj_early/src/util_sysobj.c
+	deps/sysobj_early/src/appf.c
+	deps/sysobj_early/src/nice_name.c
 	deps/sysobj_early/gui/uri_handler.c
 )
 set_target_properties(sysobj_early PROPERTIES COMPILE_FLAGS "-std=c99 -Wall -Wextra -Wno-parentheses -Wno-unused-function")

--- a/deps/sysobj_early/include/appf.h
+++ b/deps/sysobj_early/include/appf.h
@@ -1,0 +1,40 @@
+/*
+ * sysobj - https://github.com/bp0/verbose-spork
+ * Copyright (C) 2018  Burt P. <pburt0@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ */
+
+#ifndef _APPF_H_
+#define _APPF_H_
+
+/* Appends a formatted element to a string, adding an optional
+ * separator string if the string is not empty.
+ * The string is created if str is null.
+ * ex: ret = appf(ret, "; ", "%s = %d", name, value); */
+char *appf(char *str, const char *sep, const char *fmt, ...)
+    __attribute__ ((format (printf, 3, 4)));
+
+/* Same as above except that str is untouched.
+ * ex: ret = appf(keeper, "; ", "%s = %d", name, value); */
+char *appfdup(const char *str, const char *sep, const char *fmt, ...)
+    __attribute__ ((format (printf, 3, 4)));
+
+/* for convenience */
+#define appfsp(str, fmt, ...) appf(str, " ", fmt, __VA_ARGS__)
+#define appfnl(str, fmt, ...) appf(str, "\n", fmt, __VA_ARGS__)
+
+#endif

--- a/deps/sysobj_early/include/nice_name.h
+++ b/deps/sysobj_early/include/nice_name.h
@@ -1,0 +1,32 @@
+/*
+ * sysobj - https://github.com/bp0/verbose-spork
+ * Copyright (C) 2018  Burt P. <pburt0@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ */
+
+#ifndef _NICE_NAME_H_
+#define _NICE_NAME_H_
+
+/* cleaned in-place */
+void nice_name_x86_cpuid_model_string(char *cpuid_model_string);
+
+/* Intel Graphics may have very long names,
+ * like "Intel Corporation Seventh Generation Something Core Something Something Integrated Graphics Processor Revision Ninety-four"
+ * cleaned in-place */
+void nice_name_intel_gpu_device(char *pci_ids_device_string);
+
+#endif

--- a/deps/sysobj_early/include/util_sysobj.h
+++ b/deps/sysobj_early/include/util_sysobj.h
@@ -1,0 +1,53 @@
+/*
+ * sysobj - https://github.com/bp0/verbose-spork
+ * Copyright (C) 2018  Burt P. <pburt0@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ */
+
+#ifndef _UTIL_SYSOBJ_H_
+#define _UTIL_SYSOBJ_H_
+
+#include <glib.h>
+#include "appf.h"
+
+/* string eq */
+#define SEQ(s1, s2) (g_strcmp0((s1), (s2)) == 0)
+
+/* handy for static halp */
+#define BULLET "\u2022"
+#define REFLINK(URI) "<a href=\"" URI "\">" URI "</a>"
+#define REFLINKT(TEXT, URI) "<a href=\"" URI "\">" TEXT "</a>"
+
+gboolean util_have_root();
+void util_null_trailing_slash(gchar *str); /* in-place */
+void util_compress_space(gchar *str); /* in-place, multiple whitespace replaced by one space */
+void util_strstrip_double_quotes_dumb(gchar *str); /* in-place, strips any double-quotes from the start and end of str */
+gchar *util_build_fn(const gchar *base, const gchar *name); /* returns "<base>[/<name>]" */
+gchar *util_canonicalize_path(const gchar *path); /* resolve . and .., but not symlinks */
+gchar *util_normalize_path(const gchar *path, const gchar *relto); /* resolve . and .., and symlinks */
+gsize util_count_lines(const gchar *str); /* doesn't count empty last line */
+gchar *util_escape_markup(gchar *v, gboolean replacing);
+int util_get_did(gchar *str, const gchar *lbl); /* ("cpu6", "cpu") -> 6, returns -1 if error */
+int util_maybe_num(gchar *str); /* returns the guessed base, 0 for not num */
+gchar *util_find_line_value(gchar *data, gchar *key, gchar delim);
+gchar *util_strchomp_float(gchar* str_float); /* in-place, must use , or . for decimal sep */
+gchar *util_safe_name(const gchar *name, gboolean lower_case); /* make a string into a name nice and safe for file name */
+
+/* to quiet -Wunused-parameter nagging.  */
+#define PARAM_NOT_UNUSED(p) (void)p
+
+#endif

--- a/deps/sysobj_early/src/appf.c
+++ b/deps/sysobj_early/src/appf.c
@@ -1,0 +1,63 @@
+/*
+ * sysobj - https://github.com/bp0/verbose-spork
+ * Copyright (C) 2018  Burt P. <pburt0@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ */
+
+#include "appf.h"
+#define _GNU_SOURCE /* for vasprintf() */
+#include <stdlib.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <string.h>
+
+char *appf(char *str, const char *sep, const char *fmt, ...) {
+    char *buf = NULL;
+    int inlen, seplen, len;
+    va_list args;
+    va_start(args, fmt);
+    len = vasprintf(&buf, fmt, args);
+    va_end(args);
+    if (len < 0) return str;
+    if (!str) return buf;
+    inlen = strlen(str);
+    seplen = (inlen && sep) ? strlen(sep) : 0;
+    str = realloc(str, inlen + seplen + len + 1);
+    if (seplen) strcpy(str + inlen, sep);
+    strcpy(str + inlen + seplen, buf);
+    free(buf);
+    return str;
+}
+
+char *appfdup(const char *str, const char *sep, const char *fmt, ...) {
+    char *buf = NULL, *ret = NULL;
+    int inlen, seplen, len;
+    va_list args;
+    va_start(args, fmt);
+    len = vasprintf(&buf, fmt, args);
+    va_end(args);
+    if (len < 0) return NULL;
+    if (!str) return buf;
+    inlen = strlen(str);
+    seplen = (inlen && sep) ? strlen(sep) : 0;
+    ret = malloc(inlen + seplen + len + 1);
+    strcpy(ret, str);
+    if (seplen) strcpy(ret + inlen, sep);
+    strcpy(ret + inlen + seplen, buf);
+    free(buf);
+    return ret;
+}

--- a/deps/sysobj_early/src/nice_name.c
+++ b/deps/sysobj_early/src/nice_name.c
@@ -1,0 +1,157 @@
+/*
+ * sysobj - https://github.com/bp0/verbose-spork
+ * Copyright (C) 2018  Burt P. <pburt0@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ */
+
+#define _GNU_SOURCE
+#include <string.h>
+#include <ctype.h>
+
+#include "nice_name.h"
+#include "util_sysobj.h"
+
+/* export */
+/* replaces the extra chars with spaces, then when done with a series of
+ * str_shorten()s, use util_compress_space() to squeeze. */
+gboolean str_shorten(gchar *str, const gchar *find, const gchar *replace) {
+    if (!str || !find || !replace) return FALSE;
+    long unsigned lf = strlen(find);
+    long unsigned lr = strlen(replace);
+    gchar *p = strstr(str, find);
+    if (p) {
+        if (lr > lf) lr = lf;
+        gchar *buff = g_strnfill(lf, ' ');
+        strncpy(buff, replace, lr);
+        strncpy(p, buff, lf);
+        g_free(buff);
+        return TRUE;
+    }
+    return FALSE;
+}
+
+void nice_name_x86_cpuid_model_string(char *cpuid_model_string) {
+    static gboolean move_vendor_to_front = TRUE;
+    static gboolean remove_amd_compute_cores = FALSE;
+    static gboolean remove_amd_xn_ncore_redundancy = TRUE;
+    static gboolean remove_processor_cpu_apu_etc = TRUE;
+    static gboolean remove_mhz_ghz = TRUE;
+
+    if (!cpuid_model_string) return;
+    g_strstrip(cpuid_model_string);
+
+    while(str_shorten(cpuid_model_string, "Genuine Intel", "Intel")) {};
+    while(str_shorten(cpuid_model_string, "(R)", "")) {};
+    while(str_shorten(cpuid_model_string, "(r)", "")) {};
+    while(str_shorten(cpuid_model_string, "(TM)", "")) {};
+    while(str_shorten(cpuid_model_string, "(tm)", "")) {};
+    while(str_shorten(cpuid_model_string, "(c)", "")) {};
+    while(str_shorten(cpuid_model_string, "(C)", "")) {};
+    while(str_shorten(cpuid_model_string, "@", "")) {};
+
+    if (move_vendor_to_front) {
+        /* vendor not at the beginning, try to move there.
+         * ex: Mobile AMD Sempron(tm) Processor 3600+
+         * ex: Dual Core AMD Opteron(tm) Processor 165 */
+        char *intel = strstr(cpuid_model_string, "Intel ");
+        char *amd = strstr(cpuid_model_string, "AMD ");
+        if (amd || intel) {
+            if (amd && !intel) {
+                if (amd != cpuid_model_string) {
+                    int l = amd - cpuid_model_string;
+                    memmove(cpuid_model_string+4, cpuid_model_string, l);
+                    memcpy(cpuid_model_string, "AMD ", 4);
+                }
+            } else if (intel && !amd) {
+                int l = intel - cpuid_model_string;
+                memmove(cpuid_model_string+6, cpuid_model_string, l);
+                memcpy(cpuid_model_string, "Intel ", 6);
+            }
+        }
+    }
+
+    if (g_str_has_prefix(cpuid_model_string, "AMD")) {
+        while(str_shorten(cpuid_model_string, "Mobile Technology", "Mobile")) {};
+
+        if (remove_amd_compute_cores) {
+            if (strcasestr(cpuid_model_string, " COMPUTE CORES ")) {
+                /* ex: AMD FX-9800P RADEON R7, 12 COMPUTE CORES 4C+8G */
+                char *comma = strchr(cpuid_model_string, ',');
+                if (comma) *comma = 0;
+            }
+        }
+
+        if (remove_amd_xn_ncore_redundancy) {
+            /* remove Xn n-core redundancy */
+            if (strstr(cpuid_model_string, "X2")) {
+                str_shorten(cpuid_model_string, "Dual Core", "");
+                str_shorten(cpuid_model_string, "Dual-Core", "");
+            }
+            if (strstr(cpuid_model_string, "X3"))
+                str_shorten(cpuid_model_string, "Triple-Core", "");
+            if (strstr(cpuid_model_string, "X4"))
+                str_shorten(cpuid_model_string, "Quad-Core", "");
+        }
+    }
+
+    if (g_str_has_prefix(cpuid_model_string, "Cyrix")) {
+        while(str_shorten(cpuid_model_string, "tm ", "")) {};
+    }
+
+    if (remove_processor_cpu_apu_etc) {
+        while(str_shorten(cpuid_model_string, " CPU", "")) {};
+        while(str_shorten(cpuid_model_string, " APU", "")) {};
+        while(str_shorten(cpuid_model_string, " Integrated Processor", "")) {};
+        while(str_shorten(cpuid_model_string, " Processor", "")) {};
+        while(str_shorten(cpuid_model_string, " processor", "")) {};
+    } else {
+        while(str_shorten(cpuid_model_string, " processor", " Processor")) {};
+    }
+
+    if (remove_mhz_ghz) {
+        /* 1400MHz, 1.6+ GHz, etc */
+        char *u = NULL;
+        while((u = strcasestr(cpuid_model_string, "GHz"))
+            || (u = strcasestr(cpuid_model_string, "MHz")) ) {
+            if (u[3] == '+') u[3] = ' ';
+            strncpy(u, " ", 3);
+            while(isspace(*u)) {u--;}
+            while (isdigit(*u) || *u == '.' || *u == '+')
+                { *u = ' '; u--;}
+        }
+    }
+
+    /* finalize */
+    util_compress_space(cpuid_model_string);
+    g_strstrip(cpuid_model_string);
+}
+
+/* Intel Graphics may have very long names,
+ * like "Intel Corporation Seventh Generation Something Core Something Something Integrated Graphics Processor Revision Ninety-four" */
+void nice_name_intel_gpu_device(char *pci_ids_device_string) {
+    while(str_shorten(pci_ids_device_string, "(R)", "")) {}; /* Intel(R) -> Intel */
+    str_shorten(pci_ids_device_string, "Graphics Controller", "Graphics");
+    str_shorten(pci_ids_device_string, "Graphics Device", "Graphics");
+    str_shorten(pci_ids_device_string, "Generation", "Gen");
+    str_shorten(pci_ids_device_string, "Core Processor", "Core");
+    str_shorten(pci_ids_device_string, "Atom Processor", "Atom");
+    str_shorten(pci_ids_device_string, "Xeon Processor", "Xeon");
+    str_shorten(pci_ids_device_string, "Celeron Processor", "Celeron");
+    str_shorten(pci_ids_device_string, "Pentium Processor", "Pentium");
+    util_compress_space(pci_ids_device_string);
+    g_strstrip(pci_ids_device_string);
+}

--- a/deps/sysobj_early/src/util_sysobj.c
+++ b/deps/sysobj_early/src/util_sysobj.c
@@ -1,0 +1,303 @@
+/*
+ * sysobj - https://github.com/bp0/verbose-spork
+ * Copyright (C) 2018  Burt P. <pburt0@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ */
+
+#define _GNU_SOURCE
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>  /* for realpath() */
+#include <unistd.h>  /* for getuid() */
+#include <ctype.h>   /* for isxdigit(), etc. */
+
+#include "util_sysobj.h"
+
+gchar *util_build_fn(const gchar *base, const gchar *name) {
+    gchar *ret = NULL;
+    gboolean slash = TRUE;
+
+    if (!base) return NULL;
+    if (base[strlen(base)-1] == '/')
+        slash = FALSE;
+
+    if (name) {
+        if (*name == '/') slash = FALSE;
+        ret = g_strdup_printf("%s%s%s", base, slash ? "/" : "", name);
+    } else
+        ret = g_strdup(base);
+
+    util_null_trailing_slash(ret);
+    return ret;
+}
+
+gboolean util_have_root() {
+    return (getuid() == 0) ? TRUE : FALSE;
+}
+
+void util_compress_space(gchar *str) {
+    gchar *p = str, *t = str;
+    if (str && *str) {
+        int n = 0;
+        while(*p) {
+            if (isspace(*p) ) {
+                if (!n)
+                    *t++ = ' ';
+                n++;
+            } else {
+                n = 0;
+                if (t != p)
+                    *t = *p;
+                t++;
+            }
+            p++;
+        }
+    }
+    if (t != p)
+        *t = 0;
+}
+
+void util_null_trailing_slash(gchar *str) {
+    if (str && *str) {
+        if (str[strlen(str)-1] == '/' )
+            str[strlen(str)-1] = 0;
+    }
+}
+
+gsize util_count_lines(const gchar *str) {
+    gchar **lines = NULL;
+    gsize count = 0;
+
+    if (str) {
+        lines = g_strsplit(str, "\n", 0);
+        count = g_strv_length(lines);
+        if (count && *lines[count-1] == 0) {
+            /* if the last line is empty, don't count it */
+            count--;
+        }
+        g_strfreev(lines);
+    }
+
+    return count;
+}
+
+int util_get_did(gchar *str, const gchar *lbl) {
+    int id = -2;
+    gchar tmpfmt[128] = "";
+    gchar tmpchk[128] = "";
+    sprintf(tmpfmt, "%s%s", lbl, "%d");
+    if ( sscanf(str, tmpfmt, &id) ) {
+        sprintf(tmpchk, tmpfmt, id);
+        if ( SEQ(str, tmpchk) )
+            return id;
+    }
+    return -1;
+}
+
+gchar *util_escape_markup(gchar *v, gboolean replacing) {
+    gchar *clean, *tmp;
+    gchar **vl;
+    if (v == NULL) return NULL;
+
+    vl = g_strsplit(v, "&", -1);
+    if (g_strv_length(vl) > 1)
+        clean = g_strjoinv("&amp;", vl);
+    else
+        clean = g_strdup(v);
+    g_strfreev(vl);
+
+    vl = g_strsplit(clean, "<", -1);
+    if (g_strv_length(vl) > 1) {
+        tmp = g_strjoinv("&lt;", vl);
+        g_free(clean);
+        clean = tmp;
+    }
+    g_strfreev(vl);
+
+    vl = g_strsplit(clean, ">", -1);
+    if (g_strv_length(vl) > 1) {
+        tmp = g_strjoinv("&gt;", vl);
+        g_free(clean);
+        clean = tmp;
+    }
+    g_strfreev(vl);
+
+    if (replacing)
+        g_free((gpointer)v);
+    return clean;
+}
+
+void util_strstrip_double_quotes_dumb(gchar *str) {
+    if (!str) return;
+    g_strstrip(str);
+    gchar *front = str, *back = str + strlen(str) - 1;
+    if (back <= front) return;
+    while(*front == '"') { *front = 'X'; front++; }
+    while(*back == '"') { *back = 0; back--; }
+    int nl = strlen(front);
+    memmove(str, front, nl);
+    str[nl] = 0;
+}
+
+/* "194.110 MHz" -> "194.11 MHz"
+ * "5,0 golden rings" -> "5 golden rings" */
+gchar *util_strchomp_float(gchar* str_float) {
+    if (!str_float) return NULL;
+    char *dot = strchr(str_float, '.');
+    char *comma = strchr(str_float, ',');
+    char *p = NULL, *dec = NULL, *src = NULL, *target = NULL;
+    if (!dot && !comma) return str_float;
+    if (dot > comma)
+        dec = dot;
+    else
+        dec = comma;
+    p = dec + 1;
+    while(isdigit(*p)) p++;
+    target = src = p;
+    p--;
+    while(*p == '0') { target = p; p--; };
+    if (target == dec + 1)
+        target = dec;
+    if (target != src)
+        memmove(target, src, strlen(src)+1);
+    return str_float;
+}
+
+/* resolve . and .., but not symlinks */
+gchar *util_normalize_path(const gchar *path, const gchar *relto) {
+    gchar *resolved = NULL;
+#if GLIB_CHECK_VERSION(2, 58, 0)
+    resolved = g_canonicalize_filename(path, relto);
+#else
+    /* burt's hack version */
+    gchar *frt = relto ? g_strdup(relto) : NULL;
+    util_null_trailing_slash(frt);
+    gchar *fpath = frt
+        ? g_strdup_printf("%s%s%s", frt, (*path == '/') ? "" : "/", path)
+        : g_strdup(path);
+    g_free(frt);
+
+    /* note: **parts will own all the part strings throughout */
+    gchar **parts = g_strsplit(fpath, "/", -1);
+    gsize i, pn = g_strv_length(parts);
+    GList *lparts = NULL, *l = NULL, *n = NULL, *p = NULL;
+    for (i = 0; i < pn; i++)
+        lparts = g_list_append(lparts, parts[i]);
+
+    i = 0;
+    gchar *part = NULL;
+    l = lparts;
+    while(l) {
+        n = l->next; p = l->prev;
+        part = l->data;
+
+        if (SEQ(part, ".") )
+            lparts = g_list_delete_link(lparts, l);
+
+        if (SEQ(part, "..") ) {
+            if (p)
+                lparts = g_list_delete_link(lparts, p);
+            lparts = g_list_delete_link(lparts, l);
+        }
+
+        l = n;
+    }
+
+    resolved = g_strdup("");
+    l = lparts;
+    while(l) {
+        resolved = g_strdup_printf("%s%s/", resolved, (gchar*)l->data );
+        l = l->next;
+    }
+    g_list_free(lparts);
+    util_null_trailing_slash(resolved);
+    g_free(fpath);
+
+    g_strfreev(parts);
+#endif
+
+    return resolved;
+}
+
+/* resolve . and .. and symlinks */
+gchar *util_canonicalize_path(const gchar *path) {
+    char *resolved = realpath(path, NULL);
+    gchar *ret = g_strdup(resolved); /* free with g_free() instead of free() */
+    free(resolved);
+    return ret;
+}
+
+int util_maybe_num(gchar *str) {
+    int r = 10, i = 0, l = (str) ? strlen(str) : 0;
+    if (!l || l > 32) return 0;
+    gchar *chk = g_strdup(str);
+    g_strstrip(chk);
+    l = strlen(chk);
+    if (l > 2 && !strncmp(chk, "0x", 2)) {
+        i = 2; r = 16;
+    }
+    for (; i < l; i++) {
+        if (isxdigit(chk[i]))  {
+            if (!isdigit(chk[i]))
+                r = 16;
+        } else {
+            r = 0;
+            break;
+        }
+    }
+    g_free(chk);
+    return r;
+}
+
+gchar *util_safe_name(const gchar *name, gboolean lower_case) {
+    if (!name) return NULL;
+    const gchar *p = name;
+    gchar *buff = g_new0(gchar, strlen(name) + 1);
+    gchar *t = buff;
+    while(*p) {
+        gboolean ok = g_ascii_isalnum(*p);
+        if (*p == '.' || *p == '-') ok = TRUE;
+        if (*p == '/') ok = FALSE;
+        *t = ok ? *p : '_';
+        t++;
+        p = g_utf8_next_char(p);
+    }
+    gchar *ret = lower_case ? g_ascii_strdown(buff, -1) : g_strdup(buff);
+    g_free(buff);
+    return ret;
+}
+
+gchar *util_find_line_value(gchar *data, gchar *key, gchar delim) {
+    gchar *ret = NULL;
+    gchar **lines = g_strsplit(data, "\n", -1);
+    gsize line_count = g_strv_length(lines);
+    gsize i = 0;
+    for (i = 0; i < line_count; i++) {
+        gchar *line = lines[i];
+        gchar *value = g_utf8_strchr(line, -1, delim);
+        if (!value) continue;
+        *value = 0;
+        value = g_strstrip(value+1);
+        gchar *lkey = g_strstrip(line);
+
+        if (SEQ(lkey, key) ) {
+            ret = g_strdup(value);
+        }
+    }
+    g_strfreev(lines);
+    return ret;
+}

--- a/hardinfo/dt_util.c
+++ b/hardinfo/dt_util.c
@@ -27,6 +27,7 @@
 #include <endian.h>
 #include "hardinfo.h"
 #include "dt_util.h"
+#include "appf.h"
 
 static struct {
     char *name; int type;
@@ -682,14 +683,14 @@ char *dtr_list_override(dtr_obj *obj) {
         src += 4; consumed += 4;
         l = strlen(src) + 1; /* consume the null */
         str = dtr_list_str0(src, l);
-        ret = appf(ret, "<%s -> %s>", ph, str);
+        ret = appfsp(ret, "<%s -> %s>", ph, str);
         src += l; consumed += l;
         free(ph);
         free(str);
     }
     if (consumed < obj->length) {
         str = dtr_list_byte((uint8_t*)src, obj->length - consumed);
-        ret = appf(ret, "%s", str);
+        ret = appfsp(ret, "%s", str);
         free(str);
     }
     return ret;
@@ -720,7 +721,7 @@ char *dtr_list_phref(dtr_obj *obj, char *ext_cell_prop) {
         ph = dtr_elem_phref(obj->dt, obj->data_int[i], 0, NULL); i++;
         if (ext_cells > count - i) ext_cells = count - i;
         ext = dtr_list_hex((obj->data_int + i), ext_cells); i+=ext_cells;
-        ret = appf(ret, "<%s%s%s>",
+        ret = appfsp(ret, "<%s%s%s>",
             ph, (ext_cells) ? " " : "", ext);
         g_free(ph);
         g_free(ext);
@@ -748,7 +749,7 @@ char *dtr_list_interrupts(dtr_obj *obj) {
     while (i < count) {
         icells = UMIN(icells, count - i);
         ext = dtr_list_hex((obj->data_int + i), icells); i+=icells;
-        ret = appf(ret, "<%s>", ext);
+        ret = appfsp(ret, "<%s>", ext);
     }
     return ret;
 
@@ -782,7 +783,7 @@ char *dtr_list_reg(dtr_obj *obj) {
     consumed = 0;
     while (consumed + (tup_len * 4) <= obj->length) {
         tup_str = dtr_list_hex(next, tup_len);
-        ret = appf(ret, "<%s>", tup_str);
+        ret = appfsp(ret, "<%s>", tup_str);
         free(tup_str);
         consumed += (tup_len * 4);
         next += tup_len;
@@ -1184,22 +1185,3 @@ char *dtr_maps_info(dtr *s) {
     g_free(sy_map);
     return ret;
 }
-
-char *appf(char *src, char *fmt, ...) {
-    gchar *buf, *ret;
-    va_list args;
-
-    va_start(args, fmt);
-    buf = g_strdup_vprintf(fmt, args);
-    va_end(args);
-
-    if (src != NULL) {
-        ret = g_strdup_printf("%s%s%s", src, sp_sep(src), buf);
-        g_free(buf);
-        g_free(src);
-    } else
-        ret = buf;
-
-    return ret;
-}
-

--- a/hardinfo/gpu_util.c
+++ b/hardinfo/gpu_util.c
@@ -20,7 +20,7 @@
 
 #include "hardinfo.h"
 #include "gpu_util.h"
-
+#include "nice_name.h"
 #include "cpu_util.h" /* for EMPIFNULL() */
 
 nvgpu *nvgpu_new() {
@@ -229,14 +229,12 @@ static void make_nice_name(gpud *s) {
     /* try and a get a "short name" for the vendor */
     vendor_str = vendor_get_shortest_name(vendor_str);
 
-    /* These two former special cases are currently handled by the vendor_get_shortest_name()
-     * function well enough, but the notes are preserved here. */
-        /* nvidia PCI strings are pretty nice already,
-         * just shorten the company name */
-        // s->nice_name = g_strdup_printf("%s %s", "nVidia", device_str);
-        /* Intel Graphics may have very long names, like "Intel Corporation Seventh Generation Something Core Something Something Integrated Graphics Processor Revision Ninety-four"
-         * but for now at least shorten "Intel Corporation" to just "Intel" */
-        // s->nice_name = g_strdup_printf("%s %s", "Intel", device_str);
+    if (strstr(vendor_str, "Intel")) {
+        gchar *device_str_clean = strdup(device_str);
+        nice_name_intel_gpu_device(device_str_clean);
+        s->nice_name = g_strdup_printf("%s %s", vendor_str, device_str_clean);
+        g_free(device_str_clean);
+    }
 
     if (strstr(vendor_str, "AMD")) {
         /* AMD PCI strings are crazy stupid because they use the exact same

--- a/hardinfo/gpu_util.c
+++ b/hardinfo/gpu_util.c
@@ -234,9 +234,7 @@ static void make_nice_name(gpud *s) {
         nice_name_intel_gpu_device(device_str_clean);
         s->nice_name = g_strdup_printf("%s %s", vendor_str, device_str_clean);
         g_free(device_str_clean);
-    }
-
-    if (strstr(vendor_str, "AMD")) {
+    } else if (strstr(vendor_str, "AMD")) {
         /* AMD PCI strings are crazy stupid because they use the exact same
          * chip and device id for a zillion "different products" */
         char *full_name = strdup(device_str);

--- a/hardinfo/info.c
+++ b/hardinfo/info.c
@@ -17,6 +17,7 @@
  */
 
 #include "hardinfo.h"
+#include "util_sysobj.h" /* for SEQ() */
 
 static const gchar *info_column_titles[] = {
     "TextValue", "Value", "Progress", "Extra1", "Extra2"
@@ -368,8 +369,6 @@ gchar *info_flatten(struct Info *info)
 
     return g_string_free(values, FALSE);
 }
-
-#define SEQ(a,b) (g_strcmp0(a,b) == 0)
 
 struct InfoField *info_find_field(struct Info *info, const gchar *tag, const gchar *name) {
     struct InfoGroup *group;

--- a/hardinfo/vendor.c
+++ b/hardinfo/vendor.c
@@ -26,9 +26,7 @@
 #include "config.h"
 #include "hardinfo.h"
 #include "strstr_word.h"
-
-#include "dt_util.h" /* for appf() */
-#define SEQ(a,b) (g_strcmp0(a,b) == 0)
+#include "util_sysobj.h" /* for appfsp() and SEQ() */
 
 /* { match_string, match_rule, name, url } */
 static Vendor vendors_builtin[] = {
@@ -347,14 +345,14 @@ const Vendor *vendor_match(const gchar *id_str, ...) {
     if (id_str) {
         c++;
         tl += strlen(id_str);
-        tmp = appf(tmp, "%s", id_str);
+        tmp = appfsp(tmp, "%s", id_str);
 
         va_start(ap, id_str);
         p = va_arg(ap, gchar*);
         while(p) {
             c++;
             tl += strlen(p);
-            tmp = appf(tmp, "%s", p);
+            tmp = appfsp(tmp, "%s", p);
             p = va_arg(ap, gchar*);
         }
         va_end(ap);
@@ -506,14 +504,14 @@ vendor_list vendors_match(const gchar *id_str, ...) {
     if (id_str) {
         c++;
         tl += strlen(id_str);
-        tmp = appf(tmp, "%s", id_str);
+        tmp = appfsp(tmp, "%s", id_str);
 
         va_start(ap, id_str);
         p = va_arg(ap, gchar*);
         while(p) {
             c++;
             tl += strlen(p);
-            tmp = appf(tmp, "%s", p);
+            tmp = appfsp(tmp, "%s", p);
             p = va_arg(ap, gchar*);
         }
         va_end(ap);

--- a/includes/dt_util.h
+++ b/includes/dt_util.h
@@ -86,12 +86,6 @@ const char *dtr_find_device_tree_root(void);
 /* write to the message log */
 void dtr_msg(dtr *s, char *fmt, ...);
 
-#define sp_sep(STR) (strlen(STR) ? " " : "")
-/* appends an element to a string, adding a space if
- * the string is not empty.
- * ex: ret = appf(ret, "%s=%s\n", name, value); */
-char *appf(char *src, char *fmt, ...);
-
 /* operating-points v0,v1,v2 */
 typedef struct {
     uint32_t version; /* opp version, 0 = clock-frequency only */

--- a/modules/computer/ubuntu_flavors.c
+++ b/modules/computer/ubuntu_flavors.c
@@ -19,9 +19,7 @@
 
 #include <hardinfo.h>
 #include "distro_flavors.h"
-
-#include "dt_util.h" /* for appf() */
-#define SEQ(s,m) (g_strcmp0(s, m) == 0)
+#include "util_sysobj.h" /* for appfsp() */
 
 static const UbuntuFlavor ubuntu_flavors[] = {
     { "Vanilla Server", "distros/ubuntu.svg", "https://ubuntu.org", "ubuntu-server" },
@@ -59,7 +57,7 @@ GSList *ubuntu_flavors_scan(void) {
     gchar *cmd_line = g_strdup("apt-cache policy");
     int i;
     for(i = 0; ubuntu_flavors[i].base.name; i++) {
-        cmd_line = appf(cmd_line, "%s", ubuntu_flavors[i].package);
+        cmd_line = appfsp(cmd_line, "%s", ubuntu_flavors[i].package);
     }
     if (!i)
         return NULL;

--- a/modules/devices/devicetree.c
+++ b/modules/devices/devicetree.c
@@ -28,6 +28,7 @@
 #include "devices.h"
 #include "cpu_util.h"
 #include "dt_util.h"
+#include "appf.h"
 
 gchar *dtree_info = NULL;
 const char *dtree_mem_str = NULL; /* used by memory devices when nothing else is available */
@@ -267,12 +268,12 @@ static void add_keys(dtr *dt, char *np) {
 static char *msg_section(dtr *dt, int dump) {
     gchar *aslbl = NULL;
     gchar *messages = dtr_messages(dt);
-    gchar *ret = g_strdup_printf("[%s]\n", _("Messages"));
+    gchar *ret = g_strdup_printf("[%s]", _("Messages"));
     gchar **lines = g_strsplit(messages, "\n", 0);
     int i = 0;
     while(lines[i] != NULL) {
         aslbl = hardinfo_clean_label(lines[i], 0);
-        ret = appf(ret, "%s=\n", aslbl);
+        ret = appfnl(ret, "%s=", aslbl);
         g_free(aslbl);
         i++;
     }

--- a/modules/devices/dmi_memory.c
+++ b/modules/devices/dmi_memory.c
@@ -26,7 +26,7 @@
 
 extern const char *dtree_mem_str; /* in devicetree.c */
 
-#include "dt_util.h" /* for appf() */
+#include "util_sysobj.h" /* for appfsp() */
 #define dmi_spd_msg(...)  /* fprintf (stderr, __VA_ARGS__) */
 
 typedef uint64_t dmi_mem_size;
@@ -51,7 +51,6 @@ static const char empty_icon[] = "module.png";
 
 #define UNKIFNULL2(f) ((f) ? f : _("(Unknown)"))
 #define UNKIFEMPTY2(f) ((*f) ? f : _("(Unknown)"))
-#define SEQ(s,m) (g_strcmp0(s, m) == 0)
 #define STR_IGNORE(str, ignore) if (SEQ(str, ignore)) { *str = 0; null_if_empty(&str); }
 
 const char *problem_marker() {
@@ -682,7 +681,7 @@ gchar *memory_devices_get_info() {
         for(i = 1; i < N_RAM_TYPES; i++) {
             int bit = 1 << (i-1);
             if (a->ram_types & bit)
-                types_str = appf(types_str, "%s", GET_RAM_TYPE_STR(i));
+                types_str = appfsp(types_str, "%s", GET_RAM_TYPE_STR(i));
         }
 
         gchar *details = g_strdup_printf("[%s]\n"
@@ -824,7 +823,7 @@ gchar *memory_devices_get_info() {
         for(i = 1; i < N_RAM_TYPES; i++) {
             int bit = 1 << (i-1);
             if (mem->spd_ram_types & bit)
-                types_str = appf(types_str, "%s", GET_RAM_TYPE_STR(i));
+                types_str = appfsp(types_str, "%s", GET_RAM_TYPE_STR(i));
         }
 
         gchar *details = g_strdup_printf("[%s]\n"
@@ -924,7 +923,7 @@ gchar *memory_devices_get_system_memory_types_str() {
     for(i = 1; i < N_RAM_TYPES; i++) {
         int bit = 1 << (i-1);
         if (rtypes & bit)
-            types_str = appf(types_str, "%s", GET_RAM_TYPE_STR(i));
+            types_str = appfsp(types_str, "%s", GET_RAM_TYPE_STR(i));
     }
     ret = g_strdup(UNKIFNULL2(types_str));
     g_free(types_str);
@@ -954,9 +953,9 @@ static gchar *note_state = NULL;
 
 gboolean memory_devices_hinote(const char **msg) {
 
-    gchar *want_dmi    = _(" <b><i>dmidecode</i></b> utility available\n");
-    gchar *want_root   = _(" ... <i>and</i> HardInfo running with superuser privileges\n");
-    gchar *want_eeprom = _(" <b><i>eeprom</i></b> module loaded (for SDR, DDR, DDR2, DDR3)\n");
+    gchar *want_dmi    = _(" <b><i>dmidecode</i></b> utility available");
+    gchar *want_root   = _(" ... <i>and</i> HardInfo running with superuser privileges");
+    gchar *want_eeprom = _(" <b><i>eeprom</i></b> module loaded (for SDR, DDR, DDR2, DDR3)");
     gchar *want_ee1004 = _(" ... <i>or</i> <b><i>ee1004</i></b> module loaded <b>and configured!</b> (for DDR4)");
 
     gboolean has_root = (getuid() == 0);
@@ -968,11 +967,11 @@ gboolean memory_devices_hinote(const char **msg) {
     char *bullet_no = "<big><b>\u2022<tt> </tt></b></big>";
 
     g_free(note_state);
-    note_state = g_strdup(_("Memory information requires <b>one or both</b> of the following:\n"));
-    note_state = appf(note_state, "<tt>1. </tt>%s%s", has_dmi ? bullet_yes : bullet_no, want_dmi);
-    note_state = appf(note_state, "<tt>   </tt>%s%s", has_root ? bullet_yes : bullet_no, want_root);
-    note_state = appf(note_state, "<tt>2. </tt>%s%s", has_eeprom ? bullet_yes : bullet_no, want_eeprom);
-    note_state = appf(note_state, "<tt>   </tt>%s%s", has_ee1004 ? bullet_yes : bullet_no, want_ee1004);
+    note_state = g_strdup(_("Memory information requires <b>one or both</b> of the following:"));
+    note_state = appfnl(note_state, "<tt>1. </tt>%s%s", has_dmi ? bullet_yes : bullet_no, want_dmi);
+    note_state = appfnl(note_state, "<tt>   </tt>%s%s", has_root ? bullet_yes : bullet_no, want_root);
+    note_state = appfnl(note_state, "<tt>2. </tt>%s%s", has_eeprom ? bullet_yes : bullet_no, want_eeprom);
+    note_state = appfnl(note_state, "<tt>   </tt>%s%s", has_ee1004 ? bullet_yes : bullet_no, want_ee1004);
 
     gboolean ddr3_ee1004 = ((dmi_ram_types & (1<<DDR3_SDRAM)) && has_ee1004);
 

--- a/modules/devices/x86/processor.c
+++ b/modules/devices/x86/processor.c
@@ -19,7 +19,7 @@
 #include "hardinfo.h"
 #include "devices.h"
 #include "cpu_util.h"
-
+#include "nice_name.h"
 #include "x86_data.h"
 #include "x86_data.c"
 
@@ -567,6 +567,8 @@ GSList *processor_scan(void)
 
         if (processor->cpufreq->cpukhz_max)
             processor->cpu_mhz = processor->cpufreq->cpukhz_max / 1000;
+
+        nice_name_x86_cpuid_model_string(processor->model_name);
     }
 
     return procs;
@@ -648,7 +650,7 @@ gchar *processor_get_detailed_info(Processor * processor)
                    processor->model,
                    processor->stepping,
                    processor->strmodel,
-                   _("Vendor"), idle_free(vendor_get_link(processor->vendor_id)),
+                   _("Vendor"), (char*)idle_free(vendor_get_link(processor->vendor_id)),
                    _("Microcode Version"), processor->microcode,
                    _("Configuration"),
                    _("Cache Size"), processor->cache_size, _("kb"),


### PR DESCRIPTION
x86 CPU:
* Remove (R), (TM), etc
* AMD: remove redundant "X2 Dual Core", "X4 Quad Core", etc
* Move vendor to front if not already
* Remove speed, as the actual speed is usually right next to it
* Remove "CPU", "APU", "Processor" to shorten
* Compress space

Intel GPU:
* Remove (R)
* Abbreviate "Generation": "Gen"
* Remove "Processor", "Controller", and "Device" to shorten
* Compress space

Some examples:
x86 CPU:
```
'AMD Turion(tm) 64 Mobile Technology ML-32' ---> 'AMD Turion 64 Mobile ML-32'
'Cyrix MediaGXtm MMXtm Enhanced' ---> 'Cyrix MediaGX MMX Enhanced'
'Transmeta(tm) Crusoe(tm) Processor TM5800' ---> 'Transmeta Crusoe TM5800'
'VIA Nano X2 L4350 @ 1.6+ GHz' ---> 'VIA Nano X2 L4350'
'AMD Athlon(tm) 64 X2 Dual-Core Processor TK-53' ---> 'AMD Athlon 64 X2 TK-53'
'Embedded AMD Opteron(tm) Processor 23KS EE' ---> 'AMD Embedded Opteron 23KS EE'
'Intel(R) Atom(TM) x5-Z8300 CPU @ 1.44GHz' ---> 'Intel Atom x5-Z8300'
'Intel(R) Pentium(R) III CPU - S         1400MHz' ---> 'Intel Pentium III - S'
'Dual Core AMD Opteron(tm) Processor 165' ---> 'AMD Dual Core Opteron 165'
'Genuine Intel(R) CPU T1350 @ 1.86GHz' ---> 'Intel T1350'
'AMD Phenom(tm) 9350e Quad-Core Processor' ---> 'AMD Phenom 9350e Quad-Core'
```
Intel GPU:
```
'Atom/Celeron/Pentium Processor x5-E8000/J3xxx/N3xxx Integrated Graphics Controller' ---> 'Atom/Celeron/Pentium x5-E8000/J3xxx/N3xxx Integrated Graphics'
'4th Generation Core Processor Family Integrated Graphics Controller' ---> '4th Gen Core Family Integrated Graphics'
'Mobile GM965/GL960 Integrated Graphics Controller (secondary)' ---> 'Mobile GM965/GL960 Integrated Graphics (secondary)'
'Mobile 915GM/GMS/910GML Express Graphics Controller' ---> 'Mobile 915GM/GMS/910GML Express Graphics'
```
Also:
Fix/replace the appf() and SEQ() that were peppered about.
