### PR TITLE
update hardinfo.pot

### DIFF
--- a/po/hardinfo.pot
+++ b/po/hardinfo.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-06-09 14:09-0500\n"
+"POT-Creation-Date: 2019-08-15 02:04-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -26,19 +26,20 @@ msgstr ""
 msgid "Big Endian"
 msgstr ""
 
-#: hardinfo/cpu_util.c:184 hardinfo/cpu_util.c:195
+#: hardinfo/cpu_util.c:184 hardinfo/cpu_util.c:195 modules/devices/gpu.c:200
 msgid "Frequency Scaling"
 msgstr ""
 
-#: hardinfo/cpu_util.c:185
+#: hardinfo/cpu_util.c:185 modules/devices/gpu.c:201
 msgid "Minimum"
 msgstr ""
 
 #: hardinfo/cpu_util.c:185 hardinfo/cpu_util.c:186 hardinfo/cpu_util.c:187
+#: hardinfo/dt_util.c:589 modules/devices/gpu.c:201 modules/devices/gpu.c:202
 msgid "kHz"
 msgstr ""
 
-#: hardinfo/cpu_util.c:186
+#: hardinfo/cpu_util.c:186 modules/devices/gpu.c:202
 msgid "Maximum"
 msgstr ""
 
@@ -46,11 +47,11 @@ msgstr ""
 msgid "Current"
 msgstr ""
 
-#: hardinfo/cpu_util.c:188
+#: hardinfo/cpu_util.c:188 modules/devices/gpu.c:203
 msgid "Transition Latency"
 msgstr ""
 
-#: hardinfo/cpu_util.c:188
+#: hardinfo/cpu_util.c:188 modules/devices/gpu.c:203
 msgid "ns"
 msgstr ""
 
@@ -58,13 +59,13 @@ msgstr ""
 msgid "Governor"
 msgstr ""
 
-#: hardinfo/cpu_util.c:190 hardinfo/cpu_util.c:196 modules/devices/gpu.c:149
-#: modules/devices/pci.c:116
+#: hardinfo/cpu_util.c:190 hardinfo/cpu_util.c:196 modules/devices/gpu.c:153
+#: modules/devices/pci.c:134 modules/devices/usb.c:136
 msgid "Driver"
 msgstr ""
 
-#: hardinfo/cpu_util.c:202 modules/computer.c:596
-#: modules/devices/arm/processor.c:242 modules/devices/x86/processor.c:284
+#: hardinfo/cpu_util.c:202 modules/computer.c:737
+#: modules/devices/arm/processor.c:256 modules/devices/x86/processor.c:284
 #: modules/devices/x86/processor.c:388 modules/devices/x86/processor.c:524
 msgid "(Not Available)"
 msgstr ""
@@ -73,7 +74,8 @@ msgstr ""
 msgid "Socket"
 msgstr ""
 
-#: hardinfo/cpu_util.c:215 hardinfo/cpu_util.c:217
+#: hardinfo/cpu_util.c:215 hardinfo/cpu_util.c:217 modules/devices/gpu.c:149
+#: modules/devices/gpu.c:227
 msgid "Core"
 msgstr ""
 
@@ -85,8 +87,8 @@ msgstr ""
 msgid "Drawer"
 msgstr ""
 
-#: hardinfo/cpu_util.c:228 modules/devices/arm/processor.c:449
-#: modules/devices/x86/processor.c:697
+#: hardinfo/cpu_util.c:228 modules/devices/arm/processor.c:471
+#: modules/devices/x86/processor.c:750
 msgid "Topology"
 msgstr ""
 
@@ -94,112 +96,336 @@ msgstr ""
 msgid "ID"
 msgstr ""
 
-#: hardinfo/dmi_util.c:130
+#: hardinfo/dmi_util.c:25
+msgid "BIOS Information"
+msgstr ""
+
+#: hardinfo/dmi_util.c:26 modules/devices/parisc/processor.c:157
+msgid "System"
+msgstr ""
+
+#: hardinfo/dmi_util.c:27
+msgid "Base Board"
+msgstr ""
+
+#: hardinfo/dmi_util.c:28 modules/devices/dmi.c:53
+msgid "Chassis"
+msgstr ""
+
+#: hardinfo/dmi_util.c:29 modules/computer.c:529 modules/computer.c:1000
+#: modules/devices/alpha/processor.c:87 modules/devices/arm/processor.c:341
+#: modules/devices.c:96 modules/devices/ia64/processor.c:159
+#: modules/devices/m68k/processor.c:83 modules/devices/mips/processor.c:74
+#: modules/devices/parisc/processor.c:154 modules/devices/ppc/processor.c:157
+#: modules/devices/riscv/processor.c:181 modules/devices/s390/processor.c:131
+#: modules/devices/sh/processor.c:83 modules/devices/sparc/processor.c:74
+#: modules/devices/x86/processor.c:646
+msgid "Processor"
+msgstr ""
+
+#: hardinfo/dmi_util.c:30
+msgid "Memory Controller"
+msgstr ""
+
+#: hardinfo/dmi_util.c:31
+msgid "Memory Module"
+msgstr ""
+
+#: hardinfo/dmi_util.c:32 modules/devices/parisc/processor.c:163
+#: modules/devices/x86/processor.c:662
+msgid "Cache"
+msgstr ""
+
+#: hardinfo/dmi_util.c:33
+msgid "Port Connector"
+msgstr ""
+
+#: hardinfo/dmi_util.c:34
+msgid "System Slots"
+msgstr ""
+
+#: hardinfo/dmi_util.c:35
+msgid "On Board Devices"
+msgstr ""
+
+#: hardinfo/dmi_util.c:36
+msgid "OEM Strings"
+msgstr ""
+
+#: hardinfo/dmi_util.c:37
+msgid "System Configuration Options"
+msgstr ""
+
+#: hardinfo/dmi_util.c:38
+msgid "BIOS Language"
+msgstr ""
+
+#: hardinfo/dmi_util.c:39
+msgid "Group Associations"
+msgstr ""
+
+#: hardinfo/dmi_util.c:40
+msgid "System Event Log"
+msgstr ""
+
+#: hardinfo/dmi_util.c:41
+msgid "Physical Memory Array"
+msgstr ""
+
+#: hardinfo/dmi_util.c:42
+msgid "Memory Device"
+msgstr ""
+
+#: hardinfo/dmi_util.c:43
+msgid "32-bit Memory Error"
+msgstr ""
+
+#: hardinfo/dmi_util.c:44
+msgid "Memory Array Mapped Address"
+msgstr ""
+
+#: hardinfo/dmi_util.c:45
+msgid "Memory Device Mapped Address"
+msgstr ""
+
+#: hardinfo/dmi_util.c:46
+msgid "Built-in Pointing Device"
+msgstr ""
+
+#: hardinfo/dmi_util.c:47
+msgid "Portable Battery"
+msgstr ""
+
+#: hardinfo/dmi_util.c:48
+msgid "System Reset"
+msgstr ""
+
+#: hardinfo/dmi_util.c:49
+msgid "Hardware Security"
+msgstr ""
+
+#: hardinfo/dmi_util.c:50
+msgid "System Power Controls"
+msgstr ""
+
+#: hardinfo/dmi_util.c:51
+msgid "Voltage Probe"
+msgstr ""
+
+#: hardinfo/dmi_util.c:52
+msgid "Cooling Device"
+msgstr ""
+
+#: hardinfo/dmi_util.c:53
+msgid "Temperature Probe"
+msgstr ""
+
+#: hardinfo/dmi_util.c:54
+msgid "Electrical Current Probe"
+msgstr ""
+
+#: hardinfo/dmi_util.c:55
+msgid "Out-of-band Remote Access"
+msgstr ""
+
+#: hardinfo/dmi_util.c:56
+msgid "Boot Integrity Services"
+msgstr ""
+
+#: hardinfo/dmi_util.c:57
+msgid "System Boot"
+msgstr ""
+
+#: hardinfo/dmi_util.c:58
+msgid "64-bit Memory Error"
+msgstr ""
+
+#: hardinfo/dmi_util.c:59
+msgid "Management Device"
+msgstr ""
+
+#: hardinfo/dmi_util.c:60
+msgid "Management Device Component"
+msgstr ""
+
+#: hardinfo/dmi_util.c:61
+msgid "Management Device Threshold Data"
+msgstr ""
+
+#: hardinfo/dmi_util.c:62
+msgid "Memory Channel"
+msgstr ""
+
+#: hardinfo/dmi_util.c:63
+msgid "IPMI Device"
+msgstr ""
+
+#: hardinfo/dmi_util.c:64
+msgid "Power Supply"
+msgstr ""
+
+#: hardinfo/dmi_util.c:65
+msgid "Additional Information"
+msgstr ""
+
+#: hardinfo/dmi_util.c:66
+msgid "Onboard Device"
+msgstr ""
+
+#: hardinfo/dmi_util.c:226
 msgid "Invalid chassis type (0)"
 msgstr ""
 
-#: hardinfo/dmi_util.c:131 hardinfo/dmi_util.c:132
+#: hardinfo/dmi_util.c:227 hardinfo/dmi_util.c:228
 msgid "Unknown chassis type"
 msgstr ""
 
-#: hardinfo/dmi_util.c:133
+#: hardinfo/dmi_util.c:229
 msgid "Desktop"
 msgstr ""
 
-#: hardinfo/dmi_util.c:134
+#: hardinfo/dmi_util.c:230
 msgid "Low-profile Desktop"
 msgstr ""
 
-#: hardinfo/dmi_util.c:135
+#: hardinfo/dmi_util.c:231
 msgid "Pizza Box"
 msgstr ""
 
-#: hardinfo/dmi_util.c:136
+#: hardinfo/dmi_util.c:232
 msgid "Mini Tower"
 msgstr ""
 
-#: hardinfo/dmi_util.c:137
+#: hardinfo/dmi_util.c:233
 msgid "Tower"
 msgstr ""
 
-#: hardinfo/dmi_util.c:138
+#: hardinfo/dmi_util.c:234
 msgid "Portable"
 msgstr ""
 
-#: hardinfo/dmi_util.c:139 modules/computer.c:330 modules/computer.c:339
-#: modules/computer.c:361
+#: hardinfo/dmi_util.c:235 modules/computer.c:391 modules/computer.c:400
+#: modules/computer.c:422
 msgid "Laptop"
 msgstr ""
 
-#: hardinfo/dmi_util.c:140
+#: hardinfo/dmi_util.c:236
 msgid "Notebook"
 msgstr ""
 
-#: hardinfo/dmi_util.c:141
+#: hardinfo/dmi_util.c:237
 msgid "Handheld"
 msgstr ""
 
-#: hardinfo/dmi_util.c:142
+#: hardinfo/dmi_util.c:238
 msgid "Docking Station"
 msgstr ""
 
-#: hardinfo/dmi_util.c:143
+#: hardinfo/dmi_util.c:239
 msgid "All-in-one"
 msgstr ""
 
-#: hardinfo/dmi_util.c:144
+#: hardinfo/dmi_util.c:240
 msgid "Subnotebook"
 msgstr ""
 
-#: hardinfo/dmi_util.c:145
+#: hardinfo/dmi_util.c:241
 msgid "Space-saving"
 msgstr ""
 
-#: hardinfo/dmi_util.c:146
+#: hardinfo/dmi_util.c:242
 msgid "Lunch Box"
 msgstr ""
 
-#: hardinfo/dmi_util.c:147
+#: hardinfo/dmi_util.c:243
 msgid "Main Server Chassis"
 msgstr ""
 
-#: hardinfo/dmi_util.c:148
+#: hardinfo/dmi_util.c:244
 msgid "Expansion Chassis"
 msgstr ""
 
-#: hardinfo/dmi_util.c:149
+#: hardinfo/dmi_util.c:245
 msgid "Sub Chassis"
 msgstr ""
 
-#: hardinfo/dmi_util.c:150
+#: hardinfo/dmi_util.c:246
 msgid "Bus Expansion Chassis"
 msgstr ""
 
-#: hardinfo/dmi_util.c:151
+#: hardinfo/dmi_util.c:247
 msgid "Peripheral Chassis"
 msgstr ""
 
-#: hardinfo/dmi_util.c:152
+#: hardinfo/dmi_util.c:248
 msgid "RAID Chassis"
 msgstr ""
 
-#: hardinfo/dmi_util.c:153
+#: hardinfo/dmi_util.c:249
 msgid "Rack Mount Chassis"
 msgstr ""
 
-#: hardinfo/dmi_util.c:154
+#: hardinfo/dmi_util.c:250
 msgid "Sealed-case PC"
 msgstr ""
 
-#: hardinfo/dt_util.c:1011
+#: hardinfo/dmi_util.c:251
+msgid "Multi-system"
+msgstr ""
+
+#: hardinfo/dmi_util.c:252
+msgid "CompactPCI"
+msgstr ""
+
+#: hardinfo/dmi_util.c:253
+msgid "AdvancedTCA"
+msgstr ""
+
+#: hardinfo/dmi_util.c:254
+msgid "Blade"
+msgstr ""
+
+#: hardinfo/dmi_util.c:255
+msgid "Blade Enclosing"
+msgstr ""
+
+#: hardinfo/dmi_util.c:256
+msgid "Tablet"
+msgstr ""
+
+#: hardinfo/dmi_util.c:257
+msgid "Convertible"
+msgstr ""
+
+#: hardinfo/dmi_util.c:258
+msgid "Detachable"
+msgstr ""
+
+#: hardinfo/dmi_util.c:259
+msgid "IoT Gateway"
+msgstr ""
+
+#: hardinfo/dmi_util.c:260
+msgid "Embedded PC"
+msgstr ""
+
+#: hardinfo/dmi_util.c:261
+msgid "Mini PC"
+msgstr ""
+
+#: hardinfo/dmi_util.c:262
+msgid "Stick PC"
+msgstr ""
+
+#: hardinfo/dt_util.c:1179
 msgid "phandle Map"
 msgstr ""
 
-#: hardinfo/dt_util.c:1012
+#: hardinfo/dt_util.c:1180
 msgid "Alias Map"
 msgstr ""
 
-#: hardinfo/dt_util.c:1013
+#: hardinfo/dt_util.c:1181
 msgid "Symbol Map"
 msgstr ""
 
@@ -222,12 +448,16 @@ msgid ""
 "  Compiled for:      %s\n"
 msgstr ""
 
-#: hardinfo/hardinfo.c:58 hardinfo/hardinfo.c:59 modules/computer.c:644
-#: modules/devices/inputdevices.c:128 modules/devices/printers.c:138
+#: hardinfo/hardinfo.c:58 hardinfo/hardinfo.c:59 modules/computer.c:785
+#: modules/computer/modules.c:131 modules/computer/modules.c:132
+#: modules/devices/inputdevices.c:123 modules/devices/printers.c:138
+#: modules/devices/spd-decode.c:903
 msgid "Yes"
 msgstr ""
 
-#: hardinfo/hardinfo.c:59 modules/computer.c:644 modules/devices/printers.c:138
+#: hardinfo/hardinfo.c:59 modules/computer.c:785 modules/computer/modules.c:131
+#: modules/computer/modules.c:132 modules/devices/printers.c:138
+#: modules/devices/spd-decode.c:900
 msgid "No"
 msgstr ""
 
@@ -251,30 +481,36 @@ msgstr ""
 msgid "File Name"
 msgstr ""
 
-#: hardinfo/hardinfo.c:78 modules/computer.c:528 modules/computer.c:556
-#: modules/computer.c:674 modules/computer/languages.c:104
-#: modules/computer/modules.c:146 modules/devices/arm/processor.c:447
-#: modules/devices/dmi.c:37 modules/devices/dmi.c:46
-#: modules/devices/ia64/processor.c:160 modules/devices/inputdevices.c:116
-#: modules/devices/sh/processor.c:84 modules/devices/x86/processor.c:696
-#: modules/network.c:326
+#: hardinfo/hardinfo.c:78 modules/computer.c:666 modules/computer.c:694
+#: modules/computer.c:815 modules/computer/languages.c:95
+#: modules/computer/modules.c:149 modules/devices/arm/processor.c:469
+#: modules/devices/dmi.c:37 modules/devices/dmi.c:48 modules/devices/gpu.c:233
+#: modules/devices/ia64/processor.c:160 modules/devices/inputdevices.c:111
+#: modules/devices/sh/processor.c:84 modules/devices/x86/processor.c:749
+#: modules/network.c:332
 msgid "Name"
 msgstr ""
 
-#: hardinfo/hardinfo.c:78 modules/computer.c:304 modules/computer.c:499
-#: modules/computer.c:501 modules/computer.c:602 modules/devices/dmi.c:40
-#: modules/devices/dmi.c:44 modules/devices/dmi.c:48 modules/devices/dmi.c:54
-#: modules/devices/inputdevices.c:121
+#: hardinfo/hardinfo.c:78 modules/computer.c:347 modules/computer.c:572
+#: modules/computer.c:574 modules/computer.c:743 modules/computer/modules.c:151
+#: modules/devices/dmi.c:40 modules/devices/dmi.c:46 modules/devices/dmi.c:50
+#: modules/devices/dmi.c:56 modules/devices/firmware.c:105
+#: modules/devices/inputdevices.c:116
 msgid "Version"
 msgstr ""
 
-#: hardinfo/hardinfo.c:125
+#: hardinfo/hardinfo.c:129
 #, c-format
 msgid "Unknown benchmark ``%s'' or benchmark.so not loaded"
 msgstr ""
 
-#: hardinfo/hardinfo.c:155
+#: hardinfo/hardinfo.c:159
 msgid "Don't know what to do. Exiting."
+msgstr ""
+
+#: hardinfo/usb_util.c:290 modules/devices/devicetree.c:91
+#: modules/devices/devicetree.c:92 modules/devices/storage.c:185
+msgid "(None)"
 msgstr ""
 
 #: hardinfo/util.c:104 modules/computer/uptime.c:54
@@ -347,91 +583,111 @@ msgstr ""
 msgid "Fatal Error"
 msgstr ""
 
-#: hardinfo/util.c:403
+#: hardinfo/util.c:406
 msgid "creates a report and prints to standard output"
 msgstr ""
 
-#: hardinfo/util.c:409
-msgid "chooses a report format (text, html)"
+#: hardinfo/util.c:412
+msgid "chooses a report format ([text], html)"
 msgstr ""
 
-#: hardinfo/util.c:415
+#: hardinfo/util.c:418
 msgid "run benchmark; requires benchmark.so to be loaded"
 msgstr ""
 
-#: hardinfo/util.c:421
+#: hardinfo/util.c:424
+msgid "note attached to benchmark results"
+msgstr ""
+
+#: hardinfo/util.c:430
 msgid "benchmark result format ([short], conf, shell)"
 msgstr ""
 
-#: hardinfo/util.c:427
+#: hardinfo/util.c:436
+msgid ""
+"maximum number of benchmark results to include (-1 for no limit, default is "
+"10)"
+msgstr ""
+
+#: hardinfo/util.c:442
 msgid "lists modules"
 msgstr ""
 
-#: hardinfo/util.c:433
+#: hardinfo/util.c:448
 msgid "specify module to load"
 msgstr ""
 
-#: hardinfo/util.c:439
+#: hardinfo/util.c:454
 msgid "automatically load module dependencies"
 msgstr ""
 
-#: hardinfo/util.c:446
+#: hardinfo/util.c:461
 msgid "run in XML-RPC server mode"
 msgstr ""
 
-#: hardinfo/util.c:453
+#: hardinfo/util.c:468
 msgid "shows program version and quit"
 msgstr ""
 
-#: hardinfo/util.c:459
+#: hardinfo/util.c:474
 msgid "do not run benchmarks"
 msgstr ""
 
-#: hardinfo/util.c:464
+#: hardinfo/util.c:480
+msgid "show all details"
+msgstr ""
+
+#: hardinfo/util.c:485
 msgid "- System Profiler and Benchmark tool"
 msgstr ""
 
-#: hardinfo/util.c:474
+#: hardinfo/util.c:495
 #, c-format
 msgid ""
 "Unrecognized arguments.\n"
 "Try ``%s --help'' for more information.\n"
 msgstr ""
 
-#: hardinfo/util.c:542
-#, c-format
-msgid "Couldn't find a Web browser to open URL %s."
-msgstr ""
-
-#: hardinfo/util.c:891
+#: hardinfo/util.c:903
 #, c-format
 msgid "Module \"%s\" depends on module \"%s\", load it?"
 msgstr ""
 
-#: hardinfo/util.c:914
+#: hardinfo/util.c:926
 #, c-format
 msgid "Module \"%s\" depends on module \"%s\"."
 msgstr ""
 
-#: hardinfo/util.c:959
+#: hardinfo/util.c:971
 #, c-format
 msgid "No module could be loaded. Check permissions on \"%s\" and try again."
 msgstr ""
 
-#: hardinfo/util.c:963
+#: hardinfo/util.c:975
 msgid ""
 "No module could be loaded. Please use hardinfo -l to list all available "
 "modules and try again with a valid module list."
 msgstr ""
 
-#: hardinfo/util.c:1040
+#: hardinfo/util.c:1030
 #, c-format
 msgid "Scanning: %s..."
 msgstr ""
 
-#: hardinfo/util.c:1050 shell/shell.c:301 shell/shell.c:772 shell/shell.c:1850
-#: modules/benchmark.c:549 modules/benchmark.c:557
+#: hardinfo/util.c:1040 shell/shell.c:310 shell/shell.c:794 shell/shell.c:1961
+#: modules/benchmark.c:583 modules/benchmark.c:591
 msgid "Done."
+msgstr ""
+
+#: hardinfo/vendor.c:437 modules/computer.c:573 modules/computer.c:765
+#: modules/computer/os.c:79 modules/computer/os.c:263 modules/computer/os.c:300
+#: modules/computer/os.c:499 modules/computer/os.c:569 modules/devices.c:350
+#: modules/devices.c:496 modules/devices/printers.c:99
+#: modules/devices/printers.c:106 modules/devices/printers.c:116
+#: modules/devices/printers.c:131 modules/devices/printers.c:140
+#: modules/devices/printers.c:243 modules/devices/spd-decode.c:312
+#: modules/devices/usb.c:146
+msgid "Unknown"
 msgstr ""
 
 #: shell/callbacks.c:128
@@ -454,63 +710,63 @@ msgstr ""
 msgid "Contributors:"
 msgstr ""
 
-#: shell/callbacks.c:166
+#: shell/callbacks.c:167
 msgid "Based on work by:"
 msgstr ""
 
-#: shell/callbacks.c:167
+#: shell/callbacks.c:168
 msgid "MD5 implementation by Colin Plumb (see md5.c for details)"
 msgstr ""
 
-#: shell/callbacks.c:168
+#: shell/callbacks.c:169
 msgid "SHA1 implementation by Steve Reid (see sha1.c for details)"
 msgstr ""
 
-#: shell/callbacks.c:169
+#: shell/callbacks.c:170
 msgid "Blowfish implementation by Paul Kocher (see blowfich.c for details)"
 msgstr ""
 
-#: shell/callbacks.c:170
+#: shell/callbacks.c:171
 msgid "Raytracing benchmark by John Walker (see fbench.c for details)"
 msgstr ""
 
-#: shell/callbacks.c:171
+#: shell/callbacks.c:172
 msgid "FFT benchmark by Scott Robert Ladd (see fftbench.c for details)"
 msgstr ""
 
-#: shell/callbacks.c:172
+#: shell/callbacks.c:173
 msgid "Some code partly based on x86cpucaps by Osamu Kayasono"
 msgstr ""
 
-#: shell/callbacks.c:173
+#: shell/callbacks.c:174
 msgid "Vendor list based on GtkSysInfo by Pissens Sebastien"
 msgstr ""
 
-#: shell/callbacks.c:174
+#: shell/callbacks.c:175
 msgid "DMI support based on code by Stewart Adam"
 msgstr ""
 
-#: shell/callbacks.c:175
+#: shell/callbacks.c:176
 msgid "SCSI support based on code by Pascal F. Martin"
 msgstr ""
 
-#: shell/callbacks.c:180
+#: shell/callbacks.c:181
 msgid "Tango Project"
 msgstr ""
 
-#: shell/callbacks.c:181
+#: shell/callbacks.c:182
 msgid "The GNOME Project"
 msgstr ""
 
-#: shell/callbacks.c:182
+#: shell/callbacks.c:183
 msgid "VMWare, Inc. (USB icon from VMWare Workstation 6)"
 msgstr ""
 
-#: shell/callbacks.c:200
+#: shell/callbacks.c:201
 msgid "System information and benchmark tool"
 msgstr ""
 
-#: shell/callbacks.c:205
+#: shell/callbacks.c:206
 msgid ""
 "HardInfo is free software; you can redistribute it and/or modify it under "
 "the terms of the GNU General Public License as published by the Free "
@@ -526,167 +782,167 @@ msgid ""
 "Franklin St, Fifth Floor, Boston, MA  02110-1301 USA"
 msgstr ""
 
-#: shell/callbacks.c:220
+#: shell/callbacks.c:221
 msgid "translator-credits"
 msgstr ""
 
-#: shell/menu.c:35
+#: shell/menu.c:43
 msgid "_Information"
 msgstr ""
 
-#: shell/menu.c:36
+#: shell/menu.c:44
 msgid "_Remote"
 msgstr ""
 
-#: shell/menu.c:37
+#: shell/menu.c:45
 msgid "_View"
 msgstr ""
 
-#: shell/menu.c:38
+#: shell/menu.c:46
 msgid "_Help"
 msgstr ""
 
-#: shell/menu.c:39
+#: shell/menu.c:47
 msgid "About _Modules"
 msgstr ""
 
-#: shell/menu.c:43
+#: shell/menu.c:51
 msgid "Generate _Report"
 msgstr ""
 
-#: shell/menu.c:48
+#: shell/menu.c:56
 msgid "_Network Updater..."
 msgstr ""
 
-#: shell/menu.c:53
+#: shell/menu.c:61
 msgid "_Open..."
 msgstr ""
 
-#: shell/menu.c:58
+#: shell/menu.c:66
 msgid "_Copy to Clipboard"
 msgstr ""
 
-#: shell/menu.c:59
+#: shell/menu.c:67
 msgid "Copy to clipboard"
 msgstr ""
 
-#: shell/menu.c:63
+#: shell/menu.c:71
 msgid "_Refresh"
 msgstr ""
 
-#: shell/menu.c:68
+#: shell/menu.c:76
 msgid "_Open HardInfo Web Site"
 msgstr ""
 
-#: shell/menu.c:73
+#: shell/menu.c:81
 msgid "_Report bug"
 msgstr ""
 
-#: shell/menu.c:78
+#: shell/menu.c:86
 msgid "_About HardInfo"
 msgstr ""
 
-#: shell/menu.c:79
+#: shell/menu.c:87
 msgid "Displays program version information"
 msgstr ""
 
-#: shell/menu.c:83
+#: shell/menu.c:91
 msgid "_Quit"
 msgstr ""
 
-#: shell/menu.c:90
+#: shell/menu.c:98
 msgid "_Side Pane"
 msgstr ""
 
-#: shell/menu.c:91
+#: shell/menu.c:99
 msgid "Toggles side pane visibility"
 msgstr ""
 
-#: shell/menu.c:94
+#: shell/menu.c:102
 msgid "_Toolbar"
 msgstr ""
 
-#: shell/report.c:500 shell/report.c:508
+#: shell/report.c:722 shell/report.c:730
 msgid "Save File"
 msgstr ""
 
-#: shell/report.c:503 shell/report.c:935 shell/syncmanager.c:748
+#: shell/report.c:725 shell/report.c:1196 shell/syncmanager.c:748
 msgid "_Cancel"
 msgstr ""
 
-#: shell/report.c:505
+#: shell/report.c:727
 msgid "_Save"
 msgstr ""
 
-#: shell/report.c:635
+#: shell/report.c:896
 msgid "Cannot create ReportContext. Programming bug?"
 msgstr ""
 
-#: shell/report.c:654
+#: shell/report.c:915
 msgid "Open the report with your web browser?"
 msgstr ""
 
-#: shell/report.c:657
+#: shell/report.c:918
 msgid "_No"
 msgstr ""
 
-#: shell/report.c:658
+#: shell/report.c:919
 msgid "_Open"
 msgstr ""
 
-#: shell/report.c:688
+#: shell/report.c:949
 msgid "Generating report..."
 msgstr ""
 
-#: shell/report.c:698
+#: shell/report.c:959
 msgid "Report saved."
 msgstr ""
 
-#: shell/report.c:700
+#: shell/report.c:961
 msgid "Error while creating the report."
 msgstr ""
 
-#: shell/report.c:802
+#: shell/report.c:1063
 msgid "Generate Report"
 msgstr ""
 
-#: shell/report.c:827
+#: shell/report.c:1088
 msgid ""
 "<big><b>Generate Report</b></big>\n"
 "Please choose the information that you wish to view in your report:"
 msgstr ""
 
-#: shell/report.c:899
+#: shell/report.c:1160
 msgid "Select _None"
 msgstr ""
 
-#: shell/report.c:910
+#: shell/report.c:1171
 msgid "Select _All"
 msgstr ""
 
-#: shell/report.c:945
+#: shell/report.c:1206
 msgid "_Generate"
 msgstr ""
 
-#: shell/shell.c:402
+#: shell/shell.c:407
 #, c-format
 msgid "%s - System Information"
 msgstr ""
 
-#: shell/shell.c:407
+#: shell/shell.c:412
 msgid "System Information"
 msgstr ""
 
-#: shell/shell.c:759
+#: shell/shell.c:781
 msgid "Loading modules..."
 msgstr ""
 
-#: shell/shell.c:1715
+#: shell/shell.c:1827
 #, c-format
 msgid "<b>%s → Summary</b>"
 msgstr ""
 
-#: shell/shell.c:1824
+#: shell/shell.c:1935
 msgid "Updating..."
 msgstr ""
 
@@ -764,47 +1020,91 @@ msgstr ""
 msgid "_Synchronize"
 msgstr ""
 
-#: modules/benchmark/benches.c:74
-msgid "CPU Blowfish"
+#: modules/benchmark/benches.c:82
+msgid "CPU Blowfish (Single-thread)"
 msgstr ""
 
-#: modules/benchmark/benches.c:75
-msgid "CPU CryptoHash"
+#: modules/benchmark/benches.c:84
+msgid "CPU Blowfish (Multi-thread)"
 msgstr ""
 
-#: modules/benchmark/benches.c:76
-msgid "CPU Fibonacci"
+#: modules/benchmark/benches.c:86
+msgid "CPU Blowfish (Multi-core)"
 msgstr ""
 
-#: modules/benchmark/benches.c:77
-msgid "CPU N-Queens"
-msgstr ""
-
-#: modules/benchmark/benches.c:78
+#: modules/benchmark/benches.c:88
 msgid "CPU Zlib"
 msgstr ""
 
-#: modules/benchmark/benches.c:79
+#: modules/benchmark/benches.c:90
+msgid "CPU CryptoHash"
+msgstr ""
+
+#: modules/benchmark/benches.c:92
+msgid "CPU Fibonacci"
+msgstr ""
+
+#: modules/benchmark/benches.c:94
+msgid "CPU N-Queens"
+msgstr ""
+
+#: modules/benchmark/benches.c:96
 msgid "FPU FFT"
 msgstr ""
 
-#: modules/benchmark/benches.c:80
+#: modules/benchmark/benches.c:98
 msgid "FPU Raytracing"
 msgstr ""
 
-#: modules/benchmark/benches.c:82
-msgid "GPU Drawing"
-msgstr ""
-
-#: modules/benchmark/benches.c:91
-msgid "Results in MiB/second. Higher is better."
-msgstr ""
-
-#: modules/benchmark/benches.c:95
-msgid "Results in HIMarks. Higher is better."
+#: modules/benchmark/benches.c:100
+msgid "SysBench CPU (Single-thread)"
 msgstr ""
 
 #: modules/benchmark/benches.c:102
+msgid "SysBench CPU (Multi-thread)"
+msgstr ""
+
+#: modules/benchmark/benches.c:104
+msgid "#SysBench CPU (Four threads)"
+msgstr ""
+
+#: modules/benchmark/benches.c:106
+msgid "#SysBench Memory (Single-thread)"
+msgstr ""
+
+#: modules/benchmark/benches.c:108
+msgid "#SysBench Memory (Two threads)"
+msgstr ""
+
+#: modules/benchmark/benches.c:110
+msgid "SysBench Memory"
+msgstr ""
+
+#: modules/benchmark/benches.c:113
+msgid "GPU Drawing"
+msgstr ""
+
+#: modules/benchmark/benches.c:126
+msgid ""
+"Alexey Kopytov's <i><b>sysbench</b></i> is required.\n"
+"Results in events/second. Higher is better."
+msgstr ""
+
+#: modules/benchmark/benches.c:132
+msgid ""
+"Alexey Kopytov's <i><b>sysbench</b></i> is required.\n"
+"Results in MiB/second. Higher is better."
+msgstr ""
+
+#: modules/benchmark/benches.c:136
+msgid "Results in MiB/second. Higher is better."
+msgstr ""
+
+#: modules/benchmark/benches.c:143
+msgid "Results in HIMarks. Higher is better."
+msgstr ""
+
+#: modules/benchmark/benches.c:149
 msgid "Results in seconds. Lower is better."
 msgstr ""
 
@@ -823,158 +1123,201 @@ msgstr ""
 #.
 #. / Used for an unknown value. Having it in only one place cleans up the .po line references
 #: modules/benchmark/bench_results.c:22 modules/computer.c:41
-#: modules/computer/display.c:41 modules/computer/os.c:279
-#: modules/devices.c:383 modules/devices/gpu.c:42 modules/devices/gpu.c:58
-#: modules/devices/gpu.c:150 modules/devices/gpu.c:151 modules/devices/pci.c:25
-#: modules/devices/pci.c:117 modules/devices/pci.c:118 modules/devices/usb.c:27
+#: modules/computer/display.c:41 modules/computer/display.c:58
+#: modules/computer/os.c:286 modules/computer/os.c:346 modules/devices.c:479
+#: modules/devices/dmi_memory.c:52 modules/devices/dmi_memory.c:53
+#: modules/devices/dmi_memory.c:579 modules/devices/dmi_memory.c:719
+#: modules/devices/dmi_memory.c:855 modules/devices/gpu.c:42
+#: modules/devices/gpu.c:58 modules/devices/gpu.c:112 modules/devices/gpu.c:120
+#: modules/devices/gpu.c:154 modules/devices/gpu.c:155
+#: modules/devices/gpu.c:176 modules/devices/pci.c:25 modules/devices/pci.c:135
+#: modules/devices/pci.c:136 modules/devices/spd-decode.c:306
+#: modules/devices/spd-decode.c:307 modules/devices/spd-decode.c:310
+#: modules/devices/spd-decode.c:311 modules/devices/spd-decode.c:914
+#: modules/devices/spd-decode.c:915 modules/devices/storage.c:186
+#: modules/devices/storage.c:207 modules/devices/usb.c:28
 #: modules/network/net.c:437 includes/cpu_util.h:11
 msgid "(Unknown)"
 msgstr ""
 
-#: modules/benchmark/bench_results.c:47 modules/benchmark/bench_results.c:322
-#: modules/devices/alpha/processor.c:90 modules/devices/arm/processor.c:276
-#: modules/devices/arm/processor.c:289 modules/devices/arm/processor.c:331
-#: modules/devices/arm/processor.c:478 modules/devices.c:310
-#: modules/devices.c:318 modules/devices.c:346
-#: modules/devices/ia64/processor.c:167 modules/devices/ia64/processor.c:196
-#: modules/devices/m68k/processor.c:87 modules/devices/mips/processor.c:77
-#: modules/devices/parisc/processor.c:158
+#: modules/benchmark/bench_results.c:48 modules/benchmark/bench_results.c:326
+#: modules/devices/alpha/processor.c:90 modules/devices/arm/processor.c:290
+#: modules/devices/arm/processor.c:303 modules/devices/arm/processor.c:345
+#: modules/devices/arm/processor.c:500 modules/devices.c:316
+#: modules/devices.c:324 modules/devices.c:352 modules/devices/gpu.c:115
+#: modules/devices/gpu.c:117 modules/devices/gpu.c:123
+#: modules/devices/gpu.c:125 modules/devices/gpu.c:179
+#: modules/devices/gpu.c:181 modules/devices/ia64/processor.c:167
+#: modules/devices/ia64/processor.c:196 modules/devices/m68k/processor.c:87
+#: modules/devices/mips/processor.c:77 modules/devices/parisc/processor.c:158
 #: modules/devices/parisc/processor.c:191 modules/devices/ppc/processor.c:160
 #: modules/devices/ppc/processor.c:187 modules/devices/riscv/processor.c:186
 #: modules/devices/riscv/processor.c:214 modules/devices/s390/processor.c:160
 #: modules/devices/sh/processor.c:87 modules/devices/sh/processor.c:88
 #: modules/devices/sh/processor.c:89 modules/devices/x86/processor.c:318
-#: modules/devices/x86/processor.c:331 modules/devices/x86/processor.c:655
-#: modules/devices/x86/processor.c:726
+#: modules/devices/x86/processor.c:331 modules/devices/x86/processor.c:657
+#: modules/devices/x86/processor.c:780
 msgid "MHz"
 msgstr ""
 
-#: modules/benchmark/bench_results.c:374 modules/benchmark/bench_results.c:441
+#: modules/benchmark/bench_results.c:391 modules/benchmark/bench_results.c:481
 msgid "kiB"
 msgstr ""
 
-#: modules/benchmark/bench_results.c:389 modules/benchmark/bench_results.c:426
+#: modules/benchmark/bench_results.c:413 modules/benchmark/bench_results.c:463
 msgid "Benchmark Result"
 msgstr ""
 
-#: modules/benchmark/bench_results.c:390 modules/benchmark/bench_results.c:428
+#: modules/benchmark/bench_results.c:414 modules/benchmark/bench_results.c:465
 msgid "Threads"
 msgstr ""
 
-#: modules/benchmark/bench_results.c:391 modules/benchmark/bench_results.c:431
+#: modules/benchmark/bench_results.c:415 modules/benchmark/bench_results.c:467
+msgid "Elapsed Time"
+msgstr ""
+
+#: modules/benchmark/bench_results.c:415 modules/benchmark/bench_results.c:467
+msgid "seconds"
+msgstr ""
+
+#: modules/benchmark/bench_results.c:416 modules/computer/languages.c:101
+#: modules/devices/arm/processor.c:355 modules/devices/gpu.c:147
+#: modules/devices/ia64/processor.c:166 modules/devices/pci.c:132
+#: modules/devices/ppc/processor.c:159
+msgid "Revision"
+msgstr ""
+
+#: modules/benchmark/bench_results.c:416
+msgid "#Revision"
+msgstr ""
+
+#: modules/benchmark/bench_results.c:417 modules/benchmark/bench_results.c:468
+msgid "Extra Information"
+msgstr ""
+
+#: modules/benchmark/bench_results.c:417 modules/benchmark/bench_results.c:468
+msgid "#Extra"
+msgstr ""
+
+#: modules/benchmark/bench_results.c:418 modules/benchmark/bench_results.c:469
+msgid "User Note"
+msgstr ""
+
+#: modules/benchmark/bench_results.c:418 modules/benchmark/bench_results.c:469
+msgid "#User Note"
+msgstr ""
+
+#: modules/benchmark/bench_results.c:420 modules/benchmark/bench_results.c:471
 msgid "Note"
 msgstr ""
 
-#: modules/benchmark/bench_results.c:392 modules/benchmark/bench_results.c:432
+#: modules/benchmark/bench_results.c:421 modules/benchmark/bench_results.c:472
 msgid ""
 "This result is from an old version of HardInfo. Results might not be "
 "comparable to current version. Some details are missing."
 msgstr ""
 
-#: modules/benchmark/bench_results.c:393 modules/benchmark/bench_results.c:433
+#: modules/benchmark/bench_results.c:422 modules/benchmark/bench_results.c:473
 #: modules/devices/devicetree/pmac_data.c:81 modules/devices/sh/processor.c:85
 msgid "Machine"
 msgstr ""
 
-#: modules/benchmark/bench_results.c:394 modules/benchmark/bench_results.c:434
-#: modules/devices/devicetree.c:206 modules/devices/dmi.c:45
+#: modules/benchmark/bench_results.c:423 modules/benchmark/bench_results.c:474
+#: modules/devices/devicetree.c:208 modules/devices/dmi.c:47
 msgid "Board"
 msgstr ""
 
-#: modules/benchmark/bench_results.c:395 modules/benchmark/bench_results.c:435
+#: modules/benchmark/bench_results.c:424 modules/benchmark/bench_results.c:475
 msgid "CPU Name"
 msgstr ""
 
-#: modules/benchmark/bench_results.c:396 modules/benchmark/bench_results.c:436
+#: modules/benchmark/bench_results.c:425 modules/benchmark/bench_results.c:476
 msgid "CPU Description"
 msgstr ""
 
-#: modules/benchmark/bench_results.c:397 modules/benchmark/bench_results.c:437
-#: modules/benchmark.c:390
+#: modules/benchmark/bench_results.c:426 modules/benchmark/bench_results.c:477
+#: modules/benchmark.c:442
 msgid "CPU Config"
 msgstr ""
 
-#: modules/benchmark/bench_results.c:398 modules/benchmark/bench_results.c:438
+#: modules/benchmark/bench_results.c:427 modules/benchmark/bench_results.c:478
 msgid "Threads Available"
 msgstr ""
 
-#: modules/benchmark/bench_results.c:399 modules/benchmark/bench_results.c:439
+#: modules/benchmark/bench_results.c:428 modules/benchmark/bench_results.c:479
 msgid "GPU"
 msgstr ""
 
-#: modules/benchmark/bench_results.c:400 modules/benchmark/bench_results.c:440
-#: modules/computer.c:479
+#: modules/benchmark/bench_results.c:429 modules/benchmark/bench_results.c:480
+#: modules/computer.c:542
 msgid "OpenGL Renderer"
 msgstr ""
 
-#: modules/benchmark/bench_results.c:401 modules/benchmark/bench_results.c:441
-#: modules/computer.c:110 modules/computer.c:468 modules/devices.c:99
+#: modules/benchmark/bench_results.c:430 modules/benchmark/bench_results.c:481
+#: modules/computer.c:123 modules/computer.c:531 modules/computer.c:1000
+#: modules/devices/gpu.c:150
 msgid "Memory"
 msgstr ""
 
-#: modules/benchmark/bench_results.c:427
+#: modules/benchmark/bench_results.c:464
 msgid "Benchmark"
 msgstr ""
 
-#: modules/benchmark/bench_results.c:429
+#: modules/benchmark/bench_results.c:466 modules/devices/dmi_memory.c:879
+#: modules/devices/firmware.c:244 modules/devices/x86/processor.c:691
 msgid "Result"
 msgstr ""
 
-#: modules/benchmark/bench_results.c:430
-msgid "Elapsed Time"
-msgstr ""
-
-#: modules/benchmark/bench_results.c:442
+#: modules/benchmark/bench_results.c:483
 msgid "Handles"
 msgstr ""
 
-#: modules/benchmark/bench_results.c:443
+#: modules/benchmark/bench_results.c:484
 msgid "mid"
 msgstr ""
 
-#: modules/benchmark/bench_results.c:444
+#: modules/benchmark/bench_results.c:485
 msgid "cfg_val"
 msgstr ""
 
-#: modules/benchmark.c:390
+#: modules/benchmark.c:442
 msgid "Results"
 msgstr ""
 
-#: modules/benchmark.c:390 modules/computer.c:811
-#: modules/devices/sparc/processor.c:75
+#: modules/benchmark.c:442 modules/devices/sparc/processor.c:75
 msgid "CPU"
 msgstr ""
 
-#: modules/benchmark.c:460
+#: modules/benchmark.c:513
 #, c-format
 msgid "Benchmarking: <b>%s</b>."
 msgstr ""
 
-#: modules/benchmark.c:479 modules/benchmark.c:498
-msgid "Cancel"
-msgstr ""
-
-#: modules/benchmark.c:483 modules/benchmark.c:495
+#: modules/benchmark.c:527
 msgid "Benchmarking. Please do not move your mouse or press any keys."
 msgstr ""
 
-#: modules/benchmark.c:567
+#: modules/benchmark.c:530
+msgid "Cancel"
+msgstr ""
+
+#: modules/benchmark.c:601
 msgid "Benchmarks"
 msgstr ""
 
-#: modules/benchmark.c:585
+#: modules/benchmark.c:619
 msgid "Perform tasks and compare with other systems"
 msgstr ""
 
-#: modules/benchmark.c:692
+#: modules/benchmark.c:730
 msgid "Send benchmark results"
 msgstr ""
 
-#: modules/benchmark.c:697
+#: modules/benchmark.c:735
 msgid "Receive benchmark results"
 msgstr ""
 
-#: modules/computer/alsa.c:26 modules/computer.c:483
+#: modules/computer/alsa.c:26 modules/computer.c:546
 msgid "Audio Devices"
 msgstr ""
 
@@ -982,499 +1325,605 @@ msgstr ""
 msgid "Audio Adapter"
 msgstr ""
 
-#: modules/computer.c:76
+#: modules/computer.c:80 modules/devices/firmware.c:104
 msgid "Summary"
 msgstr ""
 
-#: modules/computer.c:77 modules/computer.c:471 modules/computer.c:810
+#: modules/computer.c:81 modules/computer.c:534 modules/computer.c:999
 msgid "Operating System"
 msgstr ""
 
-#: modules/computer.c:78 modules/devices/gpu.c:151 modules/devices/pci.c:118
+#: modules/computer.c:82
+msgid "Security"
+msgstr ""
+
+#: modules/computer.c:83 modules/devices/gpu.c:155 modules/devices/pci.c:136
 msgid "Kernel Modules"
 msgstr ""
 
-#: modules/computer.c:79 modules/computer.c:540
+#: modules/computer.c:84 modules/computer.c:678
 msgid "Boots"
 msgstr ""
 
-#: modules/computer.c:80
+#: modules/computer.c:85
 msgid "Languages"
 msgstr ""
 
-#: modules/computer.c:81
+#: modules/computer.c:86
+msgid "Memory Usage"
+msgstr ""
+
+#: modules/computer.c:87
 msgid "Filesystems"
 msgstr ""
 
-#: modules/computer.c:82 modules/computer.c:476
+#: modules/computer.c:88 modules/computer.c:539
 msgid "Display"
 msgstr ""
 
-#: modules/computer.c:83 modules/computer/environment.c:32
+#: modules/computer.c:89 modules/computer/environment.c:32
 msgid "Environment Variables"
 msgstr ""
 
-#: modules/computer.c:85
+#: modules/computer.c:91
 msgid "Development"
 msgstr ""
 
-#: modules/computer.c:87 modules/computer.c:661
+#: modules/computer.c:93 modules/computer.c:802
 msgid "Users"
 msgstr ""
 
-#: modules/computer.c:88
+#: modules/computer.c:94
 msgid "Groups"
 msgstr ""
 
-#: modules/computer.c:112
+#: modules/computer.c:125
 #, c-format
 msgid "%dMB (%dMB used)"
 msgstr ""
 
-#: modules/computer.c:114 modules/computer.c:514
+#: modules/computer.c:127 modules/computer.c:594
 msgid "Uptime"
 msgstr ""
 
-#: modules/computer.c:116 modules/computer.c:473
+#: modules/computer.c:129 modules/computer.c:536
 msgid "Date/Time"
 msgstr ""
 
-#: modules/computer.c:121 modules/computer.c:515
+#: modules/computer.c:134 modules/computer.c:595
 msgid "Load Average"
 msgstr ""
 
-#: modules/computer.c:123 modules/computer.c:516
-msgid "Available entropy in /dev/random"
-msgstr ""
-
-#: modules/computer.c:211
+#: modules/computer.c:247
 msgid "Scripting Languages"
 msgstr ""
 
-#: modules/computer.c:212
+#: modules/computer.c:248
 msgid "Gambas3 (gbr3)"
 msgstr ""
 
-#: modules/computer.c:213
-msgid "Python"
+#: modules/computer.c:249
+msgid "Python (default)"
 msgstr ""
 
-#: modules/computer.c:214
+#: modules/computer.c:250
 msgid "Python2"
 msgstr ""
 
-#: modules/computer.c:215
+#: modules/computer.c:251
 msgid "Python3"
 msgstr ""
 
-#: modules/computer.c:216
+#: modules/computer.c:252
 msgid "Perl"
 msgstr ""
 
-#: modules/computer.c:217
+#: modules/computer.c:253
 msgid "Perl6 (VM)"
 msgstr ""
 
-#: modules/computer.c:218
+#: modules/computer.c:254
 msgid "Perl6"
 msgstr ""
 
-#: modules/computer.c:219
+#: modules/computer.c:255
 msgid "PHP"
 msgstr ""
 
-#: modules/computer.c:220
+#: modules/computer.c:256
 msgid "Ruby"
 msgstr ""
 
-#: modules/computer.c:221
+#: modules/computer.c:257
 msgid "Bash"
 msgstr ""
 
-#: modules/computer.c:222
+#: modules/computer.c:258
+msgid "JavaScript (Node.js)"
+msgstr ""
+
+#: modules/computer.c:259
+msgid "awk"
+msgstr ""
+
+#: modules/computer.c:260
 msgid "Compilers"
 msgstr ""
 
-#: modules/computer.c:223
+#: modules/computer.c:261
 msgid "C (GCC)"
 msgstr ""
 
-#: modules/computer.c:224
+#: modules/computer.c:262
 msgid "C (Clang)"
 msgstr ""
 
-#: modules/computer.c:225
+#: modules/computer.c:263
 msgid "D (dmd)"
 msgstr ""
 
-#: modules/computer.c:226
+#: modules/computer.c:264
 msgid "Gambas3 (gbc3)"
 msgstr ""
 
-#: modules/computer.c:227
+#: modules/computer.c:265
 msgid "Java"
 msgstr ""
 
-#: modules/computer.c:228
-msgid "CSharp (Mono, old)"
+#: modules/computer.c:266
+msgid "C♯ (mcs)"
 msgstr ""
 
-#: modules/computer.c:229
-msgid "CSharp (Mono)"
-msgstr ""
-
-#: modules/computer.c:230
+#: modules/computer.c:267
 msgid "Vala"
 msgstr ""
 
-#: modules/computer.c:231
+#: modules/computer.c:268
 msgid "Haskell (GHC)"
 msgstr ""
 
-#: modules/computer.c:232
+#: modules/computer.c:269
 msgid "FreePascal"
 msgstr ""
 
-#: modules/computer.c:233
+#: modules/computer.c:270
 msgid "Go"
 msgstr ""
 
-#: modules/computer.c:234
+#: modules/computer.c:271
+msgid "Rust"
+msgstr ""
+
+#: modules/computer.c:272
 msgid "Tools"
 msgstr ""
 
-#: modules/computer.c:235
+#: modules/computer.c:273
 msgid "make"
 msgstr ""
 
-#: modules/computer.c:236
+#: modules/computer.c:274
+msgid "ninja"
+msgstr ""
+
+#: modules/computer.c:275
 msgid "GDB"
 msgstr ""
 
-#: modules/computer.c:237
+#: modules/computer.c:276
+msgid "LLDB"
+msgstr ""
+
+#: modules/computer.c:277
 msgid "strace"
 msgstr ""
 
-#: modules/computer.c:238
+#: modules/computer.c:278
 msgid "valgrind"
 msgstr ""
 
-#: modules/computer.c:239
+#: modules/computer.c:279
 msgid "QMake"
 msgstr ""
 
-#: modules/computer.c:240
+#: modules/computer.c:280
 msgid "CMake"
 msgstr ""
 
-#: modules/computer.c:241
+#: modules/computer.c:281
 msgid "Gambas3 IDE"
 msgstr ""
 
 #: modules/computer.c:282
+msgid "Radare2"
+msgstr ""
+
+#: modules/computer.c:283
+msgid "ltrace"
+msgstr ""
+
+#: modules/computer.c:324
 msgid "Not found"
 msgstr ""
 
-#: modules/computer.c:287
+#: modules/computer.c:329
 #, c-format
 msgid "Detecting version: %s"
 msgstr ""
 
-#: modules/computer.c:304
+#: modules/computer.c:347
 msgid "Program"
 msgstr ""
 
-#: modules/computer.c:324
+#: modules/computer.c:365
+msgid "Field"
+msgstr ""
+
+#: modules/computer.c:365 modules/computer.c:667 modules/computer/modules.c:149
+#: modules/computer/modules.c:150 modules/devices/arm/processor.c:470
+msgid "Description"
+msgstr ""
+
+#: modules/computer.c:365 modules/devices.c:703
+msgid "Value"
+msgstr ""
+
+#: modules/computer.c:385
 msgid "Single-board computer"
 msgstr ""
 
 #. /proc/apm
-#: modules/computer.c:373
+#: modules/computer.c:434
 msgid "Unknown physical machine type"
 msgstr ""
 
-#: modules/computer.c:393 modules/computer.c:394
+#: modules/computer.c:454 modules/computer.c:455
 msgid "Virtual (VMware)"
 msgstr ""
 
-#: modules/computer.c:396 modules/computer.c:397 modules/computer.c:398
-#: modules/computer.c:399
+#: modules/computer.c:457 modules/computer.c:458 modules/computer.c:459
+#: modules/computer.c:460
 msgid "Virtual (QEMU)"
 msgstr ""
 
-#: modules/computer.c:401 modules/computer.c:402
+#: modules/computer.c:462 modules/computer.c:463
 msgid "Virtual (Unknown)"
 msgstr ""
 
-#: modules/computer.c:404 modules/computer.c:405 modules/computer.c:406
-#: modules/computer.c:427
+#: modules/computer.c:465 modules/computer.c:466 modules/computer.c:467
+#: modules/computer.c:488
 msgid "Virtual (VirtualBox)"
 msgstr ""
 
-#: modules/computer.c:408 modules/computer.c:409 modules/computer.c:410
-#: modules/computer.c:421
+#: modules/computer.c:469 modules/computer.c:470 modules/computer.c:471
+#: modules/computer.c:482
 msgid "Virtual (Xen)"
 msgstr ""
 
-#: modules/computer.c:412
+#: modules/computer.c:473
 msgid "Virtual (hypervisor present)"
 msgstr ""
 
-#: modules/computer.c:465 modules/computer.c:769
+#: modules/computer.c:528 modules/computer.c:953
 msgid "Computer"
 msgstr ""
 
-#: modules/computer.c:466 modules/devices/alpha/processor.c:87
-#: modules/devices/arm/processor.c:327 modules/devices.c:98
-#: modules/devices/ia64/processor.c:159 modules/devices/m68k/processor.c:83
-#: modules/devices/mips/processor.c:74 modules/devices/parisc/processor.c:154
-#: modules/devices/ppc/processor.c:157 modules/devices/riscv/processor.c:181
-#: modules/devices/s390/processor.c:131 modules/devices/sh/processor.c:83
-#: modules/devices/sparc/processor.c:74 modules/devices/x86/processor.c:644
-msgid "Processor"
-msgstr ""
-
-#: modules/computer.c:469
+#: modules/computer.c:532
 msgid "Machine Type"
 msgstr ""
 
-#: modules/computer.c:472 modules/computer.c:508
+#: modules/computer.c:535 modules/computer.c:588
 msgid "User Name"
 msgstr ""
 
-#: modules/computer.c:477
+#: modules/computer.c:540
 msgid "Resolution"
 msgstr ""
 
-#: modules/computer.c:477 modules/computer.c:607
+#: modules/computer.c:540 modules/computer.c:748
 #, c-format
 msgid "%dx%d pixels"
 msgstr ""
 
-#: modules/computer.c:480
+#: modules/computer.c:543
 msgid "Session Display Server"
 msgstr ""
 
-#: modules/computer.c:485 modules/devices.c:106
+#: modules/computer.c:548 modules/devices.c:104
 msgid "Input Devices"
 msgstr ""
 
-#: modules/computer.c:500
+#: modules/computer.c:572
 msgid "Kernel"
 msgstr ""
 
-#: modules/computer.c:502
+#: modules/computer.c:573
+msgid "Command Line"
+msgstr ""
+
+#: modules/computer.c:575
 msgid "C Library"
 msgstr ""
 
-#: modules/computer.c:503
+#: modules/computer.c:576
 msgid "Distribution"
 msgstr ""
 
-#: modules/computer.c:506
+#: modules/computer.c:582
+msgid "Spin/Flavor"
+msgstr ""
+
+#: modules/computer.c:586
 msgid "Current Session"
 msgstr ""
 
-#: modules/computer.c:507
+#: modules/computer.c:587
 msgid "Computer Name"
 msgstr ""
 
-#: modules/computer.c:509 modules/computer/languages.c:108
+#: modules/computer.c:589 modules/computer/languages.c:99
 msgid "Language"
 msgstr ""
 
-#: modules/computer.c:510 modules/computer/users.c:50
+#: modules/computer.c:590 modules/computer/users.c:50
 msgid "Home Directory"
 msgstr ""
 
-#: modules/computer.c:513
-msgid "Misc"
-msgstr ""
-
-#: modules/computer.c:526
-msgid "Loaded Modules"
-msgstr ""
-
-#: modules/computer.c:529 modules/computer/modules.c:145
-#: modules/computer/modules.c:147 modules/devices/arm/processor.c:448
-#: modules/devices.c:575
-msgid "Description"
-msgstr ""
-
-#: modules/computer.c:542
-msgid "Date & Time"
-msgstr ""
-
-#: modules/computer.c:543
-msgid "Kernel Version"
-msgstr ""
-
-#: modules/computer.c:553
-msgid "Available Languages"
-msgstr ""
-
-#: modules/computer.c:555
-msgid "Language Code"
-msgstr ""
-
-#: modules/computer.c:567
-msgid "Mounted File Systems"
-msgstr ""
-
-#: modules/computer.c:569 modules/computer/filesystem.c:85
-msgid "Mount Point"
-msgstr ""
-
-#: modules/computer.c:570
-msgid "Usage"
-msgstr ""
-
-#: modules/computer.c:571 modules/devices/gpu.c:93 modules/devices/gpu.c:101
-#: modules/devices/gpu.c:187 modules/devices/pci.c:70 modules/devices/pci.c:78
-#: modules/devices/pci.c:122 modules/devices/usb.c:72
-msgid "Device"
-msgstr ""
-
-#: modules/computer.c:590
-msgid "Session"
-msgstr ""
-
-#: modules/computer.c:591 modules/devices.c:614 modules/devices/dmi.c:53
-#: modules/devices/inputdevices.c:117
-msgid "Type"
+#: modules/computer.c:591
+msgid "Desktop Environment"
 msgstr ""
 
 #: modules/computer.c:594
-msgid "Wayland"
+msgid "Misc"
 msgstr ""
 
-#: modules/computer.c:595 modules/computer.c:600
-msgid "Current Display Name"
+#: modules/computer.c:607
+msgid "HardInfo"
 msgstr ""
 
-#: modules/computer.c:599
-msgid "X Server"
+#: modules/computer.c:608
+msgid "HardInfo running as"
 msgstr ""
 
-#: modules/computer.c:601 modules/computer.c:641 modules/devices/dmi.c:39
-#: modules/devices/dmi.c:43 modules/devices/dmi.c:47 modules/devices/dmi.c:52
-#: modules/devices/gpu.c:92 modules/devices/gpu.c:100 modules/devices/gpu.c:186
-#: modules/devices/ia64/processor.c:161 modules/devices/inputdevices.c:119
-#: modules/devices/pci.c:69 modules/devices/pci.c:77 modules/devices/usb.c:64
-#: modules/devices/x86/processor.c:651
-msgid "Vendor"
+#: modules/computer.c:609
+msgid "Superuser"
 msgstr ""
 
-#: modules/computer.c:603
-msgid "Release Number"
+#: modules/computer.c:609
+msgid "User"
 msgstr ""
 
-#: modules/computer.c:611
-msgid "Screens"
+#: modules/computer.c:613
+msgid "Health"
 msgstr ""
 
-#: modules/computer.c:617
-msgid "Disconnected"
+#: modules/computer.c:614
+msgid "Available entropy in /dev/random"
+msgstr ""
+
+#: modules/computer.c:618
+msgid "Hardening Features"
+msgstr ""
+
+#: modules/computer.c:619
+msgid "ASLR"
 msgstr ""
 
 #: modules/computer.c:620
+msgid "dmesg"
+msgstr ""
+
+#: modules/computer.c:624
+msgid "Linux Security Modules"
+msgstr ""
+
+#: modules/computer.c:625
+msgid "Modules available"
+msgstr ""
+
+#: modules/computer.c:626
+msgid "SELinux status"
+msgstr ""
+
+#: modules/computer.c:632
+msgid "CPU Vulnerabilities"
+msgstr ""
+
+#: modules/computer.c:664
+msgid "Loaded Modules"
+msgstr ""
+
+#: modules/computer.c:680
+msgid "Date & Time"
+msgstr ""
+
+#: modules/computer.c:681
+msgid "Kernel Version"
+msgstr ""
+
+#: modules/computer.c:691
+msgid "Available Languages"
+msgstr ""
+
+#: modules/computer.c:693
+msgid "Language Code"
+msgstr ""
+
+#: modules/computer.c:705
+msgid "Mounted File Systems"
+msgstr ""
+
+#: modules/computer.c:707 modules/computer/filesystem.c:85
+msgid "Mount Point"
+msgstr ""
+
+#: modules/computer.c:708
+msgid "Usage"
+msgstr ""
+
+#: modules/computer.c:709 modules/devices/gpu.c:75 modules/devices/gpu.c:83
+#: modules/devices/gpu.c:225 modules/devices/pci.c:88 modules/devices/pci.c:96
+#: modules/devices/pci.c:140 modules/devices/usb.c:169
+#: modules/devices/usb.c:181
+msgid "Device"
+msgstr ""
+
+#: modules/computer.c:731
+msgid "Session"
+msgstr ""
+
+#: modules/computer.c:732 modules/devices.c:703 modules/devices/dmi.c:55
+#: modules/devices/dmi_memory.c:603 modules/devices/dmi_memory.c:749
+#: modules/devices/inputdevices.c:112 modules/devices/x86/processor.c:714
+msgid "Type"
+msgstr ""
+
+#: modules/computer.c:735
+msgid "Wayland"
+msgstr ""
+
+#: modules/computer.c:736 modules/computer.c:741
+msgid "Current Display Name"
+msgstr ""
+
+#: modules/computer.c:740
+msgid "X Server"
+msgstr ""
+
+#: modules/computer.c:742 modules/computer.c:782 modules/devices/dmi.c:39
+#: modules/devices/dmi.c:45 modules/devices/dmi.c:49 modules/devices/dmi.c:54
+#: modules/devices/dmi_memory.c:750 modules/devices/dmi_memory.c:895
+#: modules/devices/firmware.c:105 modules/devices/firmware.c:167
+#: modules/devices/firmware.c:189 modules/devices/firmware.c:226
+#: modules/devices/gpu.c:74 modules/devices/gpu.c:82 modules/devices/gpu.c:224
+#: modules/devices/ia64/processor.c:161 modules/devices/inputdevices.c:114
+#: modules/devices/pci.c:87 modules/devices/pci.c:95 modules/devices/usb.c:168
+#: modules/devices/x86/processor.c:653
+msgid "Vendor"
+msgstr ""
+
+#: modules/computer.c:744
+msgid "Release Number"
+msgstr ""
+
+#: modules/computer.c:752
+msgid "Screens"
+msgstr ""
+
+#: modules/computer.c:758
+msgid "Disconnected"
+msgstr ""
+
+#: modules/computer.c:761
 msgid "Connected"
 msgstr ""
 
-#: modules/computer.c:624 modules/computer/os.c:78 modules/computer/os.c:234
-#: modules/computer/os.c:392 modules/devices.c:344 modules/devices.c:396
-#: modules/devices/printers.c:99 modules/devices/printers.c:106
-#: modules/devices/printers.c:116 modules/devices/printers.c:131
-#: modules/devices/printers.c:140 modules/devices/printers.c:243
-msgid "Unknown"
-msgstr ""
-
-#: modules/computer.c:628
+#: modules/computer.c:769
 msgid "Unused"
 msgstr ""
 
-#: modules/computer.c:629
+#: modules/computer.c:770
 #, c-format
 msgid "%dx%d pixels, offset (%d, %d)"
 msgstr ""
 
-#: modules/computer.c:638
+#: modules/computer.c:779
 msgid "Outputs (XRandR)"
 msgstr ""
 
-#: modules/computer.c:640
+#: modules/computer.c:781
 msgid "OpenGL (GLX)"
 msgstr ""
 
-#: modules/computer.c:642
+#: modules/computer.c:783
 msgid "Renderer"
 msgstr ""
 
-#: modules/computer.c:643
+#: modules/computer.c:784
 msgid "Direct Rendering"
 msgstr ""
 
-#: modules/computer.c:645
+#: modules/computer.c:786
 msgid "Version (Compatibility)"
 msgstr ""
 
-#: modules/computer.c:646
+#: modules/computer.c:787
 msgid "Shading Language Version (Compatibility)"
 msgstr ""
 
-#: modules/computer.c:647
+#: modules/computer.c:788
 msgid "Version (Core)"
 msgstr ""
 
-#: modules/computer.c:648
+#: modules/computer.c:789
 msgid "Shading Language Version (Core)"
 msgstr ""
 
-#: modules/computer.c:649
+#: modules/computer.c:790
 msgid "Version (ES)"
 msgstr ""
 
-#: modules/computer.c:650
+#: modules/computer.c:791
 msgid "Shading Language Version (ES)"
 msgstr ""
 
-#: modules/computer.c:651
+#: modules/computer.c:792
 msgid "GLX Version"
 msgstr ""
 
-#: modules/computer.c:672
+#: modules/computer.c:813
 msgid "Group"
 msgstr ""
 
-#: modules/computer.c:675 modules/computer/users.c:49
+#: modules/computer.c:816 modules/computer/users.c:49
 msgid "Group ID"
 msgstr ""
 
-#: modules/computer.c:811
-msgid "RAM"
+#. / <value> <unit> "usable memory"
+#: modules/computer.c:909
+#, c-format
+msgid "%0.1f %s available to Linux"
 msgstr ""
 
-#: modules/computer.c:811 modules/devices/devicetree/pmac_data.c:82
+#: modules/computer.c:911 modules/devices/dmi_memory.c:661
+#: modules/devices/dmi_memory.c:809 modules/devices/dmi_memory.c:936
+msgid "GiB"
+msgstr ""
+
+#: modules/computer.c:913 modules/devices/dmi_memory.c:581
+#: modules/devices/dmi_memory.c:663 modules/devices/dmi_memory.c:723
+#: modules/devices/dmi_memory.c:811 modules/devices/dmi_memory.c:857
+#: modules/devices/dmi_memory.c:938 modules/network/net.c:395
+#: modules/network/net.c:417 modules/network/net.c:418
+msgid "MiB"
+msgstr ""
+
+#: modules/computer.c:915 modules/computer/memory_usage.c:77
+#: modules/computer/modules.c:149
+msgid "KiB"
+msgstr ""
+
+#: modules/computer.c:972 modules/devices/devicetree/pmac_data.c:82
 msgid "Motherboard"
 msgstr ""
 
-#: modules/computer.c:811
+#: modules/computer.c:1000
 msgid "Graphics"
 msgstr ""
 
-#: modules/computer.c:812 modules/devices.c:107
+#: modules/computer.c:1001 modules/devices.c:105
 msgid "Storage"
 msgstr ""
 
-#: modules/computer.c:812 modules/devices.c:103
+#: modules/computer.c:1001 modules/devices.c:101
 msgid "Printers"
 msgstr ""
 
-#: modules/computer.c:812
+#: modules/computer.c:1001
 msgid "Audio"
 msgstr ""
 
-#: modules/computer.c:857
+#: modules/computer.c:1050
 msgid "Gathers high-level computer information"
 msgstr ""
 
@@ -1494,7 +1943,9 @@ msgstr ""
 msgid "Read-Only"
 msgstr ""
 
-#: modules/computer/filesystem.c:86 modules/devices/spd-decode.c:1510
+#: modules/computer/filesystem.c:86 modules/devices/dmi_memory.c:609
+#: modules/devices/dmi_memory.c:754 modules/devices/dmi_memory.c:786
+#: modules/devices/dmi_memory.c:825 modules/devices/dmi_memory.c:894
 msgid "Size"
 msgstr ""
 
@@ -1506,37 +1957,32 @@ msgstr ""
 msgid "Available"
 msgstr ""
 
-#: modules/computer/languages.c:103
+#: modules/computer/languages.c:94
 msgid "Locale Information"
 msgstr ""
 
-#: modules/computer/languages.c:105
+#: modules/computer/languages.c:96 modules/devices/dmi_memory.c:599
+#: modules/devices/gpu.c:204
 msgid "Source"
 msgstr ""
 
-#: modules/computer/languages.c:106
+#: modules/computer/languages.c:97
 msgid "Address"
 msgstr ""
 
-#: modules/computer/languages.c:107
+#: modules/computer/languages.c:98
 msgid "E-mail"
 msgstr ""
 
-#: modules/computer/languages.c:109
+#: modules/computer/languages.c:100
 msgid "Territory"
 msgstr ""
 
-#: modules/computer/languages.c:110 modules/devices/arm/processor.c:341
-#: modules/devices/gpu.c:146 modules/devices/ia64/processor.c:166
-#: modules/devices/pci.c:114 modules/devices/ppc/processor.c:159
-msgid "Revision"
-msgstr ""
-
-#: modules/computer/languages.c:111 modules/devices/dmi.c:42
+#: modules/computer/languages.c:102 modules/devices/dmi.c:44
 msgid "Date"
 msgstr ""
 
-#: modules/computer/languages.c:112
+#: modules/computer/languages.c:103
 msgid "Codeset"
 msgstr ""
 
@@ -1544,105 +1990,187 @@ msgstr ""
 msgid "Couldn't obtain load average"
 msgstr ""
 
-#: modules/computer/modules.c:125 modules/computer/modules.c:126
-#: modules/computer/modules.c:127 modules/computer/modules.c:128
-#: modules/computer/modules.c:129 modules/devices/dmi.c:115
+#: modules/computer/memory_usage.c:106
+msgid "Total Memory"
+msgstr ""
+
+#: modules/computer/memory_usage.c:107
+msgid "Free Memory"
+msgstr ""
+
+#: modules/computer/memory_usage.c:108
+msgid "Cached Swap"
+msgstr ""
+
+#: modules/computer/memory_usage.c:109
+msgid "High Memory"
+msgstr ""
+
+#: modules/computer/memory_usage.c:110
+msgid "Free High Memory"
+msgstr ""
+
+#: modules/computer/memory_usage.c:111
+msgid "Low Memory"
+msgstr ""
+
+#: modules/computer/memory_usage.c:112
+msgid "Free Low Memory"
+msgstr ""
+
+#: modules/computer/memory_usage.c:113
+msgid "Virtual Memory"
+msgstr ""
+
+#: modules/computer/memory_usage.c:114
+msgid "Free Virtual Memory"
+msgstr ""
+
+#: modules/computer/modules.c:117 modules/computer/modules.c:118
+#: modules/computer/modules.c:119 modules/computer/modules.c:120
+#: modules/computer/modules.c:121 modules/computer/modules.c:122
+#: modules/devices/dmi.c:111 modules/devices/dmi_memory.c:881
+#: modules/devices/firmware.c:244 modules/devices/x86/processor.c:693
 msgid "(Not available)"
 msgstr ""
 
-#: modules/computer/modules.c:142
+#: modules/computer/modules.c:148
 msgid "Module Information"
 msgstr ""
 
-#: modules/computer/modules.c:143
+#: modules/computer/modules.c:148 modules/devices/gpu.c:230
 msgid "Path"
 msgstr ""
 
-#: modules/computer/modules.c:144
+#: modules/computer/modules.c:148
 msgid "Used Memory"
 msgstr ""
 
-#: modules/computer/modules.c:144 modules/devices/devmemory.c:72
-msgid "KiB"
-msgstr ""
-
-#: modules/computer/modules.c:148
+#: modules/computer/modules.c:150
 msgid "Version Magic"
 msgstr ""
 
-#: modules/computer/modules.c:149
+#: modules/computer/modules.c:151
+msgid "In Linus' Tree"
+msgstr ""
+
+#: modules/computer/modules.c:152
+msgid "Retpoline Enabled"
+msgstr ""
+
+#: modules/computer/modules.c:152
 msgid "Copyright"
 msgstr ""
 
-#: modules/computer/modules.c:150
+#: modules/computer/modules.c:152
 msgid "Author"
 msgstr ""
 
-#: modules/computer/modules.c:151
+#: modules/computer/modules.c:153
 msgid "License"
 msgstr ""
 
-#: modules/computer/modules.c:158
+#: modules/computer/modules.c:159
 msgid "Dependencies"
 msgstr ""
 
-#: modules/computer/os.c:35 modules/computer/os.c:36 modules/computer/os.c:37
-#: modules/computer/os.c:38
+#: modules/computer/os.c:36 modules/computer/os.c:37 modules/computer/os.c:38
+#: modules/computer/os.c:39
 msgid "GNU C Library"
 msgstr ""
 
-#: modules/computer/os.c:39
+#: modules/computer/os.c:40
 msgid "uClibc or uClibc-ng"
 msgstr ""
 
-#: modules/computer/os.c:40
+#: modules/computer/os.c:41
 msgid "diet libc"
 msgstr ""
 
-#: modules/computer/os.c:112 modules/computer/os.c:115
+#: modules/computer/os.c:113 modules/computer/os.c:116
 msgid "GNOME Shell "
 msgstr ""
 
-#: modules/computer/os.c:123 modules/computer/os.c:126
+#: modules/computer/os.c:124 modules/computer/os.c:127
 msgid "Version: "
 msgstr ""
 
-#: modules/computer/os.c:157
+#: modules/computer/os.c:146 modules/computer/os.c:149
+msgid "MATE Desktop Environment "
+msgstr ""
+
+#: modules/computer/os.c:180
 #, c-format
 msgid "Unknown (Window Manager: %s)"
 msgstr ""
 
 #. /{desktop environment} on {session type}
-#: modules/computer/os.c:168
+#: modules/computer/os.c:191
 #, c-format
 msgid "%s on %s"
 msgstr ""
 
-#: modules/computer/os.c:232
+#: modules/computer/os.c:261
 msgid "Terminal"
 msgstr ""
 
+#: modules/computer/os.c:278
+msgid "User access allowed"
+msgstr ""
+
+#: modules/computer/os.c:280
+msgid "User access forbidden"
+msgstr ""
+
+#: modules/computer/os.c:282
+msgid "Access allowed (running as superuser)"
+msgstr ""
+
+#: modules/computer/os.c:284
+msgid "Access forbidden? (running as superuser)"
+msgstr ""
+
+#: modules/computer/os.c:294 modules/computer/os.c:560
+msgid "Disabled"
+msgstr ""
+
+#: modules/computer/os.c:296
+msgid "Partially enabled (mmap base+stack+VDSO base)"
+msgstr ""
+
+#: modules/computer/os.c:298
+msgid "Fully enabled (mmap base+stack+VDSO base+heap)"
+msgstr ""
+
 #. /bits of entropy for rng (0)
-#: modules/computer/os.c:241
+#: modules/computer/os.c:308
 msgid "(None or not available)"
 msgstr ""
 
 #. /bits of entropy for rng (low/poor value)
-#: modules/computer/os.c:242
+#: modules/computer/os.c:309
 #, c-format
 msgid "%d bits (low)"
 msgstr ""
 
 #. /bits of entropy for rng (medium value)
-#: modules/computer/os.c:243
+#: modules/computer/os.c:310
 #, c-format
 msgid "%d bits (medium)"
 msgstr ""
 
 #. /bits of entropy for rng (high/good value)
-#: modules/computer/os.c:244
+#: modules/computer/os.c:311
 #, c-format
 msgid "%d bits (healthy)"
+msgstr ""
+
+#: modules/computer/os.c:555
+msgid "Not installed"
+msgstr ""
+
+#: modules/computer/os.c:558
+msgid "Enabled"
 msgstr ""
 
 #: modules/computer/users.c:47
@@ -1657,13 +2185,12 @@ msgstr ""
 msgid "Default Shell"
 msgstr ""
 
-#: modules/devices/alpha/processor.c:88 modules/devices/devicetree.c:161
-#: modules/devices/devicetree.c:207 modules/devices/devicetree/pmac_data.c:80
-#: modules/devices/gpu.c:124 modules/devices/ia64/processor.c:165
+#: modules/devices/alpha/processor.c:88 modules/devices/devicetree.c:163
+#: modules/devices/devicetree.c:209 modules/devices/devicetree/pmac_data.c:80
+#: modules/devices/gpu.c:106 modules/devices/ia64/processor.c:165
 #: modules/devices/m68k/processor.c:84 modules/devices/mips/processor.c:75
 #: modules/devices/parisc/processor.c:155 modules/devices/ppc/processor.c:158
 #: modules/devices/riscv/processor.c:182 modules/devices/s390/processor.c:132
-#: modules/devices/spd-decode.c:1510
 msgid "Model"
 msgstr ""
 
@@ -1671,28 +2198,28 @@ msgstr ""
 msgid "Platform String"
 msgstr ""
 
-#: modules/devices/alpha/processor.c:90 modules/devices/arm/processor.c:331
+#: modules/devices/alpha/processor.c:90 modules/devices/arm/processor.c:345
 #: modules/devices/ia64/processor.c:167 modules/devices/m68k/processor.c:87
 #: modules/devices/mips/processor.c:77 modules/devices/parisc/processor.c:158
 #: modules/devices/ppc/processor.c:160 modules/devices/riscv/processor.c:186
-#: modules/devices/sh/processor.c:87 modules/devices/x86/processor.c:655
+#: modules/devices/sh/processor.c:87 modules/devices/x86/processor.c:657
 msgid "Frequency"
 msgstr ""
 
-#: modules/devices/alpha/processor.c:91 modules/devices/arm/processor.c:332
+#: modules/devices/alpha/processor.c:91 modules/devices/arm/processor.c:346
 #: modules/devices/ia64/processor.c:168 modules/devices/m68k/processor.c:88
 #: modules/devices/mips/processor.c:78 modules/devices/parisc/processor.c:159
 #: modules/devices/ppc/processor.c:161 modules/devices/s390/processor.c:134
-#: modules/devices/sh/processor.c:90 modules/devices/x86/processor.c:656
+#: modules/devices/sh/processor.c:90 modules/devices/x86/processor.c:658
 msgid "BogoMips"
 msgstr ""
 
-#: modules/devices/alpha/processor.c:92 modules/devices/arm/processor.c:333
+#: modules/devices/alpha/processor.c:92 modules/devices/arm/processor.c:347
 #: modules/devices/ia64/processor.c:169 modules/devices/m68k/processor.c:89
 #: modules/devices/mips/processor.c:79 modules/devices/parisc/processor.c:160
 #: modules/devices/ppc/processor.c:162 modules/devices/riscv/processor.c:187
 #: modules/devices/s390/processor.c:135 modules/devices/sh/processor.c:91
-#: modules/devices/sparc/processor.c:77 modules/devices/x86/processor.c:657
+#: modules/devices/sparc/processor.c:77 modules/devices/x86/processor.c:659
 msgid "Byte Order"
 msgstr ""
 
@@ -1866,76 +2393,77 @@ msgctxt "arm-flag"
 msgid "Advanced SIMD/NEON on AArch64 (arch>8)"
 msgstr ""
 
-#: modules/devices/arm/processor.c:142
+#: modules/devices/arm/processor.c:143
 msgid "ARM Processor"
 msgstr ""
 
-#: modules/devices/arm/processor.c:200 modules/devices/riscv/processor.c:147
-#: modules/devices/x86/processor.c:606
+#: modules/devices/arm/processor.c:214 modules/devices/riscv/processor.c:147
+#: modules/devices/x86/processor.c:608
 msgid "Empty List"
 msgstr ""
 
-#: modules/devices/arm/processor.c:226 modules/devices/x86/processor.c:268
+#: modules/devices/arm/processor.c:240 modules/devices/gpu.c:148
+#: modules/devices/gpu.c:226 modules/devices/x86/processor.c:268
 msgid "Clocks"
 msgstr ""
 
-#: modules/devices/arm/processor.c:272 modules/devices/arm/processor.c:285
+#: modules/devices/arm/processor.c:286 modules/devices/arm/processor.c:299
 #: modules/devices/x86/processor.c:314 modules/devices/x86/processor.c:327
 #, c-format
 msgid "%.2f-%.2f %s=%dx\n"
 msgstr ""
 
-#: modules/devices/arm/processor.c:328
+#: modules/devices/arm/processor.c:342
 msgid "Linux Name"
 msgstr ""
 
-#: modules/devices/arm/processor.c:329
+#: modules/devices/arm/processor.c:343
 msgid "Decoded Name"
 msgstr ""
 
-#: modules/devices/arm/processor.c:330 modules/network/net.c:453
+#: modules/devices/arm/processor.c:344 modules/network/net.c:453
 msgid "Mode"
 msgstr ""
 
-#: modules/devices/arm/processor.c:336
+#: modules/devices/arm/processor.c:350
 msgid "ARM"
 msgstr ""
 
-#: modules/devices/arm/processor.c:337
+#: modules/devices/arm/processor.c:351
 msgid "Implementer"
 msgstr ""
 
-#: modules/devices/arm/processor.c:338
+#: modules/devices/arm/processor.c:352 modules/devices/dmi_memory.c:896
 msgid "Part"
 msgstr ""
 
-#: modules/devices/arm/processor.c:339 modules/devices/ia64/processor.c:162
+#: modules/devices/arm/processor.c:353 modules/devices/ia64/processor.c:162
 #: modules/devices/parisc/processor.c:156 modules/devices/riscv/processor.c:183
 msgid "Architecture"
 msgstr ""
 
-#: modules/devices/arm/processor.c:340
+#: modules/devices/arm/processor.c:354
 msgid "Variant"
 msgstr ""
 
-#: modules/devices/arm/processor.c:342 modules/devices/riscv/processor.c:190
-#: modules/devices/sparc/processor.c:78 modules/devices/x86/processor.c:663
+#: modules/devices/arm/processor.c:356 modules/devices/riscv/processor.c:190
+#: modules/devices/sparc/processor.c:78 modules/devices/x86/processor.c:665
 msgid "Capabilities"
 msgstr ""
 
-#: modules/devices/arm/processor.c:446
+#: modules/devices/arm/processor.c:468
 msgid "SOC/Package"
 msgstr ""
 
-#: modules/devices/arm/processor.c:450 modules/devices/x86/processor.c:698
+#: modules/devices/arm/processor.c:472 modules/devices/x86/processor.c:751
 msgid "Logical CPU Config"
 msgstr ""
 
-#: modules/devices/arm/processor.c:467
+#: modules/devices/arm/processor.c:489
 msgid "SOC/Package Information"
 msgstr ""
 
-#: modules/devices/battery.c:181
+#: modules/devices/battery.c:178
 #, c-format
 msgid ""
 "\n"
@@ -1948,7 +2476,7 @@ msgid ""
 "Serial Number=%s\n"
 msgstr ""
 
-#: modules/devices/battery.c:258
+#: modules/devices/battery.c:255
 #, c-format
 msgid ""
 "\n"
@@ -1961,7 +2489,7 @@ msgid ""
 "Serial Number=%s\n"
 msgstr ""
 
-#: modules/devices/battery.c:346
+#: modules/devices/battery.c:343
 #, c-format
 msgid ""
 "\n"
@@ -1973,7 +2501,7 @@ msgid ""
 "APM BIOS version=%s\n"
 msgstr ""
 
-#: modules/devices/battery.c:358
+#: modules/devices/battery.c:355
 #, c-format
 msgid ""
 "\n"
@@ -1984,63 +2512,67 @@ msgid ""
 "APM BIOS version=%s\n"
 msgstr ""
 
-#: modules/devices/battery.c:385
+#: modules/devices/battery.c:382
 msgid ""
 "[No batteries]\n"
 "No batteries found on this system=\n"
 msgstr ""
 
-#: modules/devices.c:100
+#: modules/devices.c:97
 msgid "Graphics Processors"
 msgstr ""
 
-#: modules/devices.c:101 modules/devices/pci.c:143
+#: modules/devices.c:98 modules/devices/pci.c:163
 msgid "PCI Devices"
 msgstr ""
 
-#: modules/devices.c:102 modules/devices/usb.c:92
+#: modules/devices.c:99 modules/devices/usb.c:210
 msgid "USB Devices"
 msgstr ""
 
-#: modules/devices.c:104
+#: modules/devices.c:100
+msgid "Firmware"
+msgstr ""
+
+#: modules/devices.c:102
 msgid "Battery"
 msgstr ""
 
-#: modules/devices.c:105
+#: modules/devices.c:103
 msgid "Sensors"
 msgstr ""
 
-#: modules/devices.c:109
-msgid "DMI"
+#: modules/devices.c:106
+msgid "System DMI"
 msgstr ""
 
-#: modules/devices.c:110
-msgid "Memory SPD"
+#: modules/devices.c:107
+msgid "Memory Devices"
 msgstr ""
 
-#: modules/devices.c:115
+#: modules/devices.c:111
 msgid "Device Tree"
 msgstr ""
 
-#: modules/devices.c:117
+#: modules/devices.c:113
 msgid "Resources"
 msgstr ""
 
-#: modules/devices.c:162
+#: modules/devices.c:168
 #, c-format
 msgid "%d physical processor"
 msgid_plural "%d physical processors"
 msgstr[0] ""
 msgstr[1] ""
 
-#: modules/devices.c:163
+#: modules/devices.c:169
 #, c-format
 msgid "%d core"
 msgid_plural "%d cores"
 msgstr[0] ""
 msgstr[1] ""
 
-#: modules/devices.c:164
+#: modules/devices.c:170
 #, c-format
 msgid "%d thread"
 msgid_plural "%d threads"
@@ -2048,106 +2580,102 @@ msgstr[0] ""
 msgstr[1] ""
 
 #. /NP procs; NC cores; NT threads
-#: modules/devices.c:165
+#: modules/devices.c:171
 #, c-format
 msgid "%s; %s; %s"
 msgstr ""
 
-#: modules/devices.c:575
-msgid "Field"
-msgstr ""
-
-#: modules/devices.c:575 modules/devices.c:614
-msgid "Value"
-msgstr ""
-
-#: modules/devices.c:614
+#: modules/devices.c:703
 msgid "Sensor"
 msgstr ""
 
-#: modules/devices.c:661
+#: modules/devices.c:750 modules/devices/dmi_memory.c:826
 msgid "Devices"
 msgstr ""
 
-#: modules/devices.c:673
+#: modules/devices.c:762
 msgid "Update PCI ID listing"
 msgstr ""
 
-#: modules/devices.c:685
+#: modules/devices.c:774
 msgid "Update CPU feature database"
 msgstr ""
 
-#: modules/devices.c:713
+#: modules/devices.c:802
 msgid "Gathers information about hardware devices"
 msgstr ""
 
-#: modules/devices.c:732
+#: modules/devices.c:821
 msgid "Resource information requires superuser privileges"
 msgstr ""
 
-#: modules/devices/devicetree.c:50
+#: modules/devices.c:827
+msgid ""
+"Any NVMe storage devices present are not listed.\n"
+"<b><i>udisksd</i></b> is required for NVMe devices."
+msgstr ""
+
+#: modules/devices/devicetree.c:52
 msgid "Properties"
 msgstr ""
 
-#: modules/devices/devicetree.c:51
+#: modules/devices/devicetree.c:53
 msgid "Children"
 msgstr ""
 
-#: modules/devices/devicetree.c:87
+#: modules/devices/devicetree.c:89
 msgid "Node"
 msgstr ""
 
-#: modules/devices/devicetree.c:88
+#: modules/devices/devicetree.c:90
 msgid "Node Path"
 msgstr ""
 
-#: modules/devices/devicetree.c:89
+#: modules/devices/devicetree.c:91
 msgid "Alias"
 msgstr ""
 
-#: modules/devices/devicetree.c:89 modules/devices/devicetree.c:90
-msgid "(None)"
-msgstr ""
-
-#: modules/devices/devicetree.c:90
+#: modules/devices/devicetree.c:92
 msgid "Symbol"
 msgstr ""
 
-#: modules/devices/devicetree.c:143 modules/devices/devicetree/pmac_data.c:79
+#: modules/devices/devicetree.c:145 modules/devices/devicetree/pmac_data.c:79
 msgid "Platform"
 msgstr ""
 
-#: modules/devices/devicetree.c:144 modules/devices/devicetree.c:209
+#: modules/devices/devicetree.c:146 modules/devices/devicetree.c:211
+#: modules/devices/gpu.c:231
 msgid "Compatible"
 msgstr ""
 
-#: modules/devices/devicetree.c:145
+#: modules/devices/devicetree.c:147
 msgid "GPU-compatible"
 msgstr ""
 
-#: modules/devices/devicetree.c:160
+#: modules/devices/devicetree.c:162
 msgid "Raspberry Pi or Compatible"
 msgstr ""
 
-#: modules/devices/devicetree.c:162 modules/devices/devicetree.c:189
-#: modules/devices/devicetree.c:208 modules/devices/devicetree/rpi_data.c:161
-#: modules/devices/dmi.c:49 modules/devices/dmi.c:55
+#: modules/devices/devicetree.c:164 modules/devices/devicetree.c:191
+#: modules/devices/devicetree.c:210 modules/devices/devicetree/rpi_data.c:168
+#: modules/devices/dmi.c:41 modules/devices/dmi.c:51 modules/devices/dmi.c:57
+#: modules/devices/usb.c:178
 msgid "Serial Number"
 msgstr ""
 
-#: modules/devices/devicetree.c:163 modules/devices/devicetree/rpi_data.c:158
+#: modules/devices/devicetree.c:165 modules/devices/devicetree/rpi_data.c:165
 msgid "RCode"
 msgstr ""
 
-#: modules/devices/devicetree.c:163
+#: modules/devices/devicetree.c:165
 msgid "No revision code available; unable to lookup model details."
 msgstr ""
 
-#: modules/devices/devicetree.c:188
+#: modules/devices/devicetree.c:190
 msgid "More"
 msgstr ""
 
-#: modules/devices/devicetree.c:268
+#: modules/devices/devicetree.c:271
 msgid "Messages"
 msgstr ""
 
@@ -2171,87 +2699,51 @@ msgstr ""
 msgid "PMAC Generation"
 msgstr ""
 
-#: modules/devices/devicetree/rpi_data.c:153
-#: modules/devices/devicetree/rpi_data.c:154
+#: modules/devices/devicetree/rpi_data.c:160
+#: modules/devices/devicetree/rpi_data.c:161
 msgid "Raspberry Pi"
 msgstr ""
 
-#: modules/devices/devicetree/rpi_data.c:154
+#: modules/devices/devicetree/rpi_data.c:161
 msgid "Board Name"
 msgstr ""
 
-#: modules/devices/devicetree/rpi_data.c:155
+#: modules/devices/devicetree/rpi_data.c:162
 msgid "PCB Revision"
 msgstr ""
 
-#: modules/devices/devicetree/rpi_data.c:156
+#: modules/devices/devicetree/rpi_data.c:163
 msgid "Introduction"
 msgstr ""
 
-#: modules/devices/devicetree/rpi_data.c:157 modules/devices/spd-decode.c:1510
+#: modules/devices/devicetree/rpi_data.c:164 modules/devices/usb.c:170
 msgid "Manufacturer"
 msgstr ""
 
-#: modules/devices/devicetree/rpi_data.c:159
+#: modules/devices/devicetree/rpi_data.c:166
 msgid "SOC (spec)"
 msgstr ""
 
-#: modules/devices/devicetree/rpi_data.c:160
+#: modules/devices/devicetree/rpi_data.c:167
 msgid "Memory (spec)"
 msgstr ""
 
-#: modules/devices/devicetree/rpi_data.c:162
+#: modules/devices/devicetree/rpi_data.c:169
 msgid "Permanent overvolt bit"
 msgstr ""
 
-#: modules/devices/devicetree/rpi_data.c:162
+#: modules/devices/devicetree/rpi_data.c:169
 msgctxt "rpi-ov-bit"
 msgid "Set"
 msgstr ""
 
-#: modules/devices/devicetree/rpi_data.c:162
+#: modules/devices/devicetree/rpi_data.c:169
 msgctxt "rpi-ov-bit"
 msgid "Not set"
 msgstr ""
 
-#: modules/devices/devmemory.c:101
-msgid "Total Memory"
-msgstr ""
-
-#: modules/devices/devmemory.c:102
-msgid "Free Memory"
-msgstr ""
-
-#: modules/devices/devmemory.c:103
-msgid "Cached Swap"
-msgstr ""
-
-#: modules/devices/devmemory.c:104
-msgid "High Memory"
-msgstr ""
-
-#: modules/devices/devmemory.c:105
-msgid "Free High Memory"
-msgstr ""
-
-#: modules/devices/devmemory.c:106
-msgid "Low Memory"
-msgstr ""
-
-#: modules/devices/devmemory.c:107
-msgid "Free Low Memory"
-msgstr ""
-
-#: modules/devices/devmemory.c:108
-msgid "Virtual Memory"
-msgstr ""
-
-#: modules/devices/devmemory.c:109
-msgid "Free Virtual Memory"
-msgstr ""
-
-#: modules/devices/dmi.c:36 modules/devices/inputdevices.c:120
-#: modules/devices/usb.c:63
+#: modules/devices/dmi.c:36 modules/devices/inputdevices.c:115
+#: modules/devices/usb.c:167
 msgid "Product"
 msgstr ""
 
@@ -2260,90 +2752,400 @@ msgstr ""
 msgid "Family"
 msgstr ""
 
-#: modules/devices/dmi.c:41
+#: modules/devices/dmi.c:42
+msgid "SKU"
+msgstr ""
+
+#: modules/devices/dmi.c:43
 msgid "BIOS"
 msgstr ""
 
-#: modules/devices/dmi.c:50 modules/devices/dmi.c:56
+#: modules/devices/dmi.c:52 modules/devices/dmi.c:58
 msgid "Asset Tag"
 msgstr ""
 
-#: modules/devices/dmi.c:51
-msgid "Chassis"
-msgstr ""
-
-#: modules/devices/dmi.c:116
+#: modules/devices/dmi.c:115 modules/devices/dmi_memory.c:882
+#: modules/devices/x86/processor.c:694
 msgid "(Not available; Perhaps try running HardInfo as root.)"
 msgstr ""
 
-#: modules/devices/gpu.c:102 modules/devices/pci.c:79
+#: modules/devices/dmi.c:156
+msgid "DMI Unavailable"
+msgstr ""
+
+#: modules/devices/dmi.c:158
+msgid "DMI is not avaliable. Perhaps this platform does not provide DMI."
+msgstr ""
+
+#: modules/devices/dmi.c:159
+msgid "DMI is not available; Perhaps try running HardInfo as root."
+msgstr ""
+
+#: modules/devices/dmi_memory.c:598
+msgid "Serial Presence Detect (SPD)"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:601
+msgid "SPD Revision"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:602 modules/devices/dmi_memory.c:748
+msgid "Form Factor"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:604
+msgid "Module Vendor"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:606
+msgid "DRAM Vendor"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:608 modules/devices/dmi_memory.c:753
+msgid "Part Number"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:610
+msgid "Manufacturing Date (Week / Year)"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:644 modules/devices/dmi_memory.c:879
+msgid "Memory Device List"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:686
+msgid "Memory Array"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:687 modules/devices/x86/processor.c:713
+msgid "DMI Handle"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:688 modules/devices/dmi_memory.c:746
+#: modules/devices/dmi_memory.c:784 modules/devices/dmi_memory.c:893
+msgid "Locator"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:689
+msgid "Use"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:690
+msgid "Error Correction Type"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:691
+msgid "Size (Present / Max)"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:692
+msgid "Devices (Populated / Sockets)"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:693 modules/devices/dmi_memory.c:827
+msgid "Types Present"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:744 modules/devices/dmi_memory.c:782
+msgid "Memory Socket"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:745 modules/devices/dmi_memory.c:783
+msgid "DMI Handles (Array, Socket)"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:747 modules/devices/dmi_memory.c:785
+msgid "Bank Locator"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:755
+msgid "Rated Speed"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:756
+msgid "Configured Speed"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:757
+msgid "Data Width/Total Width"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:758
+msgid "Rank"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:759
+msgid "Minimum Voltage"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:760
+msgid "Maximum Voltage"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:761
+msgid "Configured Voltage"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:786 modules/devices/dmi_memory.c:793
+msgid "(Empty)"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:824
+msgid "Serial Presence Detect (SPD) Summary"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:947
+msgid " <b><i>dmidecode</i></b> utility available"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:948
+msgid " ... <i>and</i> HardInfo running with superuser privileges"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:949
+msgid " <b><i>eeprom</i></b> module loaded (for SDR, DDR, DDR2, DDR3)"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:950
+msgid ""
+" ... <i>or</i> <b><i>ee1004</i></b> module loaded <b>and configured!</b> "
+"(for DDR4)"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:961
+msgid "Memory information requires <b>one or both</b> of the following:"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:982
+msgid ""
+"\"More often than not, information contained in the DMI tables is "
+"inaccurate,\n"
+"incomplete or simply wrong.\" -<i><b>dmidecode</b></i> manual page"
+msgstr ""
+
+#: modules/devices/firmware.c:69
+msgid "Device cannot be removed easily"
+msgstr ""
+
+#: modules/devices/firmware.c:70
+msgid "Device is updatable in this or any other mode"
+msgstr ""
+
+#: modules/devices/firmware.c:71
+msgid "Update can only be done from offline mode"
+msgstr ""
+
+#: modules/devices/firmware.c:72
+msgid "Requires AC power"
+msgstr ""
+
+#: modules/devices/firmware.c:73
+msgid "Is locked and can be unlocked"
+msgstr ""
+
+#: modules/devices/firmware.c:74
+msgid "Is found in current metadata"
+msgstr ""
+
+#: modules/devices/firmware.c:75
+msgid "Requires a bootloader mode to be manually enabled by the user"
+msgstr ""
+
+#: modules/devices/firmware.c:76
+msgid "Has been registered with other plugins"
+msgstr ""
+
+#: modules/devices/firmware.c:77
+msgid "Requires a reboot to apply firmware or to reload hardware"
+msgstr ""
+
+#: modules/devices/firmware.c:78
+msgid "Requires system shutdown to apply firmware"
+msgstr ""
+
+#: modules/devices/firmware.c:79
+msgid "Has been reported to a metadata server"
+msgstr ""
+
+#: modules/devices/firmware.c:80
+msgid "User has been notified"
+msgstr ""
+
+#: modules/devices/firmware.c:81
+msgid "Always use the runtime version rather than the bootloader"
+msgstr ""
+
+#: modules/devices/firmware.c:82
+msgid "Install composite firmware on the parent before the child"
+msgstr ""
+
+#: modules/devices/firmware.c:83
+msgid "Is currently in bootloader mode"
+msgstr ""
+
+#: modules/devices/firmware.c:84
+msgid "The hardware is waiting to be replugged"
+msgstr ""
+
+#: modules/devices/firmware.c:85
+msgid "Ignore validation safety checks when flashing this device"
+msgstr ""
+
+#: modules/devices/firmware.c:86
+msgid "Requires the update to be retried with a new plugin"
+msgstr ""
+
+#: modules/devices/firmware.c:87
+msgid "Do not add instance IDs from the device baseclass"
+msgstr ""
+
+#: modules/devices/firmware.c:88
+msgid "Device update needs to be separately activated"
+msgstr ""
+
+#: modules/devices/firmware.c:89
+msgid ""
+"Ensure the version is a valid semantic version, e.g. numbers separated with "
+"dots"
+msgstr ""
+
+#: modules/devices/firmware.c:90
+msgid "Extra metadata can be exposed about this device"
+msgstr ""
+
+#: modules/devices/firmware.c:104
+msgid "DeviceId"
+msgstr ""
+
+#: modules/devices/firmware.c:104
+msgid "Guid"
+msgstr ""
+
+#: modules/devices/firmware.c:104
+msgid "Plugin"
+msgstr ""
+
+#: modules/devices/firmware.c:104 modules/network.c:380
+msgid "Flags"
+msgstr ""
+
+#: modules/devices/firmware.c:105
+msgid "VendorId"
+msgstr ""
+
+#: modules/devices/firmware.c:105
+msgid "VersionBootloader"
+msgstr ""
+
+#: modules/devices/firmware.c:106
+msgid "Icon"
+msgstr ""
+
+#: modules/devices/firmware.c:106
+msgid "InstallDuration"
+msgstr ""
+
+#: modules/devices/firmware.c:106
+msgid "Created"
+msgstr ""
+
+#: modules/devices/firmware.c:243
+msgid "Firmware List"
+msgstr ""
+
+#: modules/devices/firmware.c:256
+msgid "Requires the <i><b>fwupdmgr</b></i> utility."
+msgstr ""
+
+#: modules/devices/gpu.c:84 modules/devices/pci.c:97
 msgid "SVendor"
 msgstr ""
 
-#: modules/devices/gpu.c:103 modules/devices/pci.c:80
+#: modules/devices/gpu.c:85 modules/devices/pci.c:98
 msgid "SDevice"
 msgstr ""
 
-#: modules/devices/gpu.c:111 modules/devices/pci.c:90
+#: modules/devices/gpu.c:93 modules/devices/pci.c:108
 msgid "PCI Express"
 msgstr ""
 
-#: modules/devices/gpu.c:112 modules/devices/pci.c:92
+#: modules/devices/gpu.c:94 modules/devices/pci.c:110
 msgid "Maximum Link Width"
 msgstr ""
 
-#: modules/devices/gpu.c:113 modules/devices/pci.c:94
+#: modules/devices/gpu.c:95 modules/devices/pci.c:112
 msgid "Maximum Link Speed"
 msgstr ""
 
-#: modules/devices/gpu.c:113 modules/devices/pci.c:93 modules/devices/pci.c:94
+#: modules/devices/gpu.c:95 modules/devices/pci.c:111 modules/devices/pci.c:112
 msgid "GT/s"
 msgstr ""
 
-#: modules/devices/gpu.c:123
+#: modules/devices/gpu.c:105
 msgid "NVIDIA"
 msgstr ""
 
-#: modules/devices/gpu.c:125
+#: modules/devices/gpu.c:107
 msgid "BIOS Version"
 msgstr ""
 
-#: modules/devices/gpu.c:126
+#: modules/devices/gpu.c:108
 msgid "UUID"
 msgstr ""
 
-#: modules/devices/gpu.c:141 modules/devices/gpu.c:183
-#: modules/devices/inputdevices.c:115 modules/devices/pci.c:111
-#: modules/devices/usb.c:62
+#: modules/devices/gpu.c:142 modules/devices/gpu.c:222
+#: modules/devices/inputdevices.c:110 modules/devices/pci.c:129
+#: modules/devices/usb.c:166
 msgid "Device Information"
 msgstr ""
 
-#: modules/devices/gpu.c:142 modules/devices/gpu.c:184
+#: modules/devices/gpu.c:143 modules/devices/gpu.c:223
 msgid "Location"
 msgstr ""
 
-#: modules/devices/gpu.c:143
+#: modules/devices/gpu.c:144
 msgid "DRM Device"
 msgstr ""
 
-#: modules/devices/gpu.c:144 modules/devices/pci.c:112 modules/devices/usb.c:67
+#: modules/devices/gpu.c:145 modules/devices/pci.c:130
+#: modules/devices/usb.c:133 modules/devices/usb.c:174
 msgid "Class"
 msgstr ""
 
-#: modules/devices/gpu.c:150 modules/devices/pci.c:117
+#: modules/devices/gpu.c:154 modules/devices/pci.c:135
 msgid "In Use"
 msgstr ""
 
-#: modules/devices/gpu.c:174
+#: modules/devices/gpu.c:185
 msgid "Unknown integrated GPU"
 msgstr ""
 
-#: modules/devices/gpu.c:185
-msgid "DT Compatibility"
+#: modules/devices/gpu.c:191
+msgid "clock-frequency property"
 msgstr ""
 
-#: modules/devices/gpu.c:201
+#: modules/devices/gpu.c:192
+msgid "Operating Points (OPPv1)"
+msgstr ""
+
+#: modules/devices/gpu.c:193
+msgid "Operating Points (OPPv2)"
+msgstr ""
+
+#: modules/devices/gpu.c:229
+msgid "Device Tree Node"
+msgstr ""
+
+#: modules/devices/gpu.c:232 modules/network/net.c:454
+msgid "Status"
+msgstr ""
+
+#: modules/devices/gpu.c:249
 msgid "GPUs"
+msgstr ""
+
+#: modules/devices/gpu.c:273
+msgid "No GPU devices found"
 msgstr ""
 
 #: modules/devices/ia64/processor.c:108
@@ -2362,16 +3164,16 @@ msgstr ""
 msgid "Features"
 msgstr ""
 
-#: modules/devices/inputdevices.c:118 modules/devices/pci.c:121
-#: modules/devices/usb.c:71
+#: modules/devices/inputdevices.c:113 modules/devices/pci.c:139
+#: modules/devices/usb.c:180
 msgid "Bus"
 msgstr ""
 
-#: modules/devices/inputdevices.c:124
+#: modules/devices/inputdevices.c:119
 msgid "Connected to"
 msgstr ""
 
-#: modules/devices/inputdevices.c:128
+#: modules/devices/inputdevices.c:123
 msgid "InfraRed port"
 msgstr ""
 
@@ -2395,10 +3197,6 @@ msgstr ""
 msgid "PA-RISC Processor"
 msgstr ""
 
-#: modules/devices/parisc/processor.c:157
-msgid "System"
-msgstr ""
-
 #: modules/devices/parisc/processor.c:161
 msgid "HVersion"
 msgstr ""
@@ -2407,31 +3205,27 @@ msgstr ""
 msgid "SVersion"
 msgstr ""
 
-#: modules/devices/parisc/processor.c:163 modules/devices/x86/processor.c:660
-msgid "Cache"
-msgstr ""
-
-#: modules/devices/pci.c:91
+#: modules/devices/pci.c:109
 msgid "Link Width"
 msgstr ""
 
-#: modules/devices/pci.c:93
+#: modules/devices/pci.c:111
 msgid "Link Speed"
 msgstr ""
 
-#: modules/devices/pci.c:119 modules/devices/usb.c:70
+#: modules/devices/pci.c:137 modules/devices/usb.c:179
 msgid "Connection"
 msgstr ""
 
-#: modules/devices/pci.c:120
+#: modules/devices/pci.c:138
 msgid "Domain"
 msgstr ""
 
-#: modules/devices/pci.c:123
+#: modules/devices/pci.c:141
 msgid "Function"
 msgstr ""
 
-#: modules/devices/pci.c:161
+#: modules/devices/pci.c:185
 msgid "No PCI devices found"
 msgstr ""
 
@@ -2635,52 +3429,222 @@ msgstr ""
 msgid "Module Frequency"
 msgstr ""
 
-#: modules/devices/spd-decode.c:1475
+#: modules/devices/spd-decode.c:306
+msgid "Row address bits"
+msgstr ""
+
+#: modules/devices/spd-decode.c:307
+msgid "Column address bits"
+msgstr ""
+
+#: modules/devices/spd-decode.c:308
+msgid "Number of rows"
+msgstr ""
+
+#: modules/devices/spd-decode.c:309
+msgid "Data width"
+msgstr ""
+
+#: modules/devices/spd-decode.c:310
+msgid "Interface signal levels"
+msgstr ""
+
+#: modules/devices/spd-decode.c:311
+msgid "Configuration type"
+msgstr ""
+
+#: modules/devices/spd-decode.c:312
+msgid "Refresh"
+msgstr ""
+
+#: modules/devices/spd-decode.c:313 modules/devices/spd-decode.c:397
+#: modules/devices/spd-decode.c:492 modules/devices/spd-decode.c:617
+msgid "Timings"
+msgstr ""
+
+#: modules/devices/spd-decode.c:593
+msgid "Ranks"
+msgstr ""
+
+#: modules/devices/spd-decode.c:594
+msgid "IO Pins per Chip"
+msgstr ""
+
+#: modules/devices/spd-decode.c:595
+msgid "Die count"
+msgstr ""
+
+#: modules/devices/spd-decode.c:595
+msgid "(Unspecified)"
+msgstr ""
+
+#: modules/devices/spd-decode.c:596
+msgid "Thermal Sensor"
+msgstr ""
+
+#: modules/devices/spd-decode.c:596
+msgid "Present"
+msgstr ""
+
+#: modules/devices/spd-decode.c:596
+msgid "Not present"
+msgstr ""
+
+#: modules/devices/spd-decode.c:597
+msgid "Supported Voltages"
+msgstr ""
+
+#: modules/devices/spd-decode.c:601
+msgid "Supported CAS Latencies"
+msgstr ""
+
+#: modules/devices/spd-decode.c:638
+msgid "Invalid"
+msgstr ""
+
+#: modules/devices/spd-decode.c:870
+msgid "XMP Profile"
+msgstr ""
+
+#: modules/devices/spd-decode.c:871 modules/devices/usb.c:173
+msgid "Speed"
+msgstr ""
+
+#: modules/devices/spd-decode.c:872 modules/devices/spd-decode.c:914
+#: modules/devices/x86/processor.c:715
+msgid "Voltage"
+msgstr ""
+
+#: modules/devices/spd-decode.c:873
+msgid "XMP Timings"
+msgstr ""
+
+#: modules/devices/spd-decode.c:915
+msgid "XMP"
+msgstr ""
+
+#: modules/devices/spd-decode.c:916
+msgid "JEDEC Timings"
+msgstr ""
+
+#: modules/devices/storage.c:80
 msgid ""
-"[SPD]\n"
-"Please load the eeprom module to obtain information about memory SPD=\n"
-"[$ShellParam$]\n"
-"ReloadInterval=500\n"
+"\n"
+"[UDisks2]\n"
 msgstr ""
 
-#: modules/devices/spd-decode.c:1480
+#: modules/devices/storage.c:138
+msgid "Removable"
+msgstr ""
+
+#: modules/devices/storage.c:138
+msgid "Fixed"
+msgstr ""
+
+#: modules/devices/storage.c:141
+msgid "Ejectable"
+msgstr ""
+
+#: modules/devices/storage.c:144
+msgid "Self-monitoring (S.M.A.R.T.)"
+msgstr ""
+
+#: modules/devices/storage.c:147 modules/devices/x86/processor.c:663
+msgid "Power Management"
+msgstr ""
+
+#: modules/devices/storage.c:150
+msgid "Advanced Power Management"
+msgstr ""
+
+#: modules/devices/storage.c:153
+msgid "Automatic Acoustic Management"
+msgstr ""
+
+#: modules/devices/storage.c:156
+#, c-format
 msgid ""
-"[SPD]\n"
-"Reading memory SPD not supported on this system=\n"
+"[Drive Information]\n"
+"Model=%s\n"
 msgstr ""
 
-#: modules/devices/spd-decode.c:1509
-msgid "SPD"
+#: modules/devices/storage.c:160 modules/devices/storage.c:347
+#: modules/devices/storage.c:546
+#, c-format
+msgid "Vendor=%s\n"
 msgstr ""
 
-#: modules/devices/spd-decode.c:1510
-msgid "Bank"
+#: modules/devices/storage.c:165
+#, c-format
+msgid ""
+"Revision=%s\n"
+"Block Device=%s\n"
+"Serial=%s\n"
+"Size=%s\n"
+"Features=%s\n"
 msgstr ""
 
-#: modules/devices/storage.c:43
+#: modules/devices/storage.c:179
+#, c-format
+msgid "Rotation Rate=%d RPM\n"
+msgstr ""
+
+#: modules/devices/storage.c:182
+#, c-format
+msgid ""
+"Media=%s\n"
+"Media compatibility=%s\n"
+msgstr ""
+
+#: modules/devices/storage.c:189
+#, c-format
+msgid "Connection bus=%s\n"
+msgstr ""
+
+#: modules/devices/storage.c:192
+#, c-format
+msgid ""
+"[Self-monitoring (S.M.A.R.T.)]\n"
+"Status=%s\n"
+"Bad Sectors=%ld\n"
+"Power on time=%d days %d hours\n"
+"Temperature=%d°C\n"
+msgstr ""
+
+#: modules/devices/storage.c:198
+msgid "Failing"
+msgstr ""
+
+#: modules/devices/storage.c:198
+msgid "OK"
+msgstr ""
+
+#: modules/devices/storage.c:204
+#, c-format
+msgid ""
+"[Partition table]\n"
+"Type=%s\n"
+msgstr ""
+
+#: modules/devices/storage.c:223
+#, c-format
+msgid "Partition %s=%s\n"
+msgstr ""
+
+#: modules/devices/storage.c:273
 msgid ""
 "\n"
 "[SCSI Disks]\n"
 msgstr ""
 
-#: modules/devices/storage.c:114 modules/devices/storage.c:320
+#: modules/devices/storage.c:344 modules/devices/storage.c:543
 #, c-format
 msgid ""
 "[Device Information]\n"
 "Model=%s\n"
 msgstr ""
 
-#: modules/devices/storage.c:119 modules/devices/storage.c:326
-#, c-format
-msgid "Vendor=%s (%s)\n"
-msgstr ""
-
-#: modules/devices/storage.c:124 modules/devices/storage.c:328
-#, c-format
-msgid "Vendor=%s\n"
-msgstr ""
-
-#: modules/devices/storage.c:129
+#: modules/devices/storage.c:351
 #, c-format
 msgid ""
 "Type=%s\n"
@@ -2692,18 +3656,18 @@ msgid ""
 "LUN=%d\n"
 msgstr ""
 
-#: modules/devices/storage.c:174
+#: modules/devices/storage.c:397
 msgid ""
 "\n"
 "[IDE Disks]\n"
 msgstr ""
 
-#: modules/devices/storage.c:257
+#: modules/devices/storage.c:480
 #, c-format
 msgid "Driver=%s\n"
 msgstr ""
 
-#: modules/devices/storage.c:331
+#: modules/devices/storage.c:548
 #, c-format
 msgid ""
 "Device Name=hd%c\n"
@@ -2711,7 +3675,7 @@ msgid ""
 "Cache=%dkb\n"
 msgstr ""
 
-#: modules/devices/storage.c:341
+#: modules/devices/storage.c:558
 #, c-format
 msgid ""
 "[Geometry]\n"
@@ -2719,41 +3683,54 @@ msgid ""
 "Logical=%s\n"
 msgstr ""
 
-#: modules/devices/storage.c:351
+#: modules/devices/storage.c:568
 #, c-format
 msgid ""
 "[Capabilities]\n"
 "%s"
 msgstr ""
 
-#: modules/devices/storage.c:358
+#: modules/devices/storage.c:575
 #, c-format
 msgid ""
 "[Speeds]\n"
 "%s"
 msgstr ""
 
-#: modules/devices/usb.c:65
-msgid "Max Current"
+#: modules/devices/usb.c:132 modules/network.c:310 modules/network.c:363
+#: modules/network.c:380
+msgid "Interface"
 msgstr ""
 
-#: modules/devices/usb.c:65
-msgid "mA"
-msgstr ""
-
-#: modules/devices/usb.c:66
-msgid "USB Version"
-msgstr ""
-
-#: modules/devices/usb.c:68
+#: modules/devices/usb.c:134 modules/devices/usb.c:175
 msgid "Sub-class"
 msgstr ""
 
-#: modules/devices/usb.c:69
+#: modules/devices/usb.c:135 modules/devices/usb.c:176 modules/network.c:347
+msgid "Protocol"
+msgstr ""
+
+#: modules/devices/usb.c:143 modules/network/net.c:451
+msgid "Mb/s"
+msgstr ""
+
+#: modules/devices/usb.c:171
+msgid "Max Current"
+msgstr ""
+
+#: modules/devices/usb.c:171
+msgid "mA"
+msgstr ""
+
+#: modules/devices/usb.c:172
+msgid "USB Version"
+msgstr ""
+
+#: modules/devices/usb.c:177
 msgid "Device Version"
 msgstr ""
 
-#: modules/devices/usb.c:103
+#: modules/devices/usb.c:221
 msgid "No USB devices found."
 msgstr ""
 
@@ -2793,47 +3770,59 @@ msgstr ""
 msgid "Level %d (%s)#%d=%dx %dKB (%dKB), %d-way set-associative, %d sets\n"
 msgstr ""
 
-#: modules/devices/x86/processor.c:645
+#: modules/devices/x86/processor.c:647
 msgid "Model Name"
 msgstr ""
 
-#: modules/devices/x86/processor.c:646
+#: modules/devices/x86/processor.c:648
 msgid "Family, model, stepping"
 msgstr ""
 
-#: modules/devices/x86/processor.c:652
+#: modules/devices/x86/processor.c:654
 msgid "Microcode Version"
 msgstr ""
 
-#: modules/devices/x86/processor.c:653
+#: modules/devices/x86/processor.c:655
 msgid "Configuration"
 msgstr ""
 
-#: modules/devices/x86/processor.c:654
+#: modules/devices/x86/processor.c:656
 msgid "Cache Size"
 msgstr ""
 
-#: modules/devices/x86/processor.c:654
+#: modules/devices/x86/processor.c:656
 msgid "kb"
 msgstr ""
 
-#: modules/devices/x86/processor.c:661
-msgid "Power Management"
-msgstr ""
-
-#: modules/devices/x86/processor.c:662
+#: modules/devices/x86/processor.c:664
 msgid "Bug Workarounds"
 msgstr ""
 
-#: modules/devices/x86/processor.c:695 modules/devices/x86/processor.c:715
+#: modules/devices/x86/processor.c:691
+msgid "Socket Information"
+msgstr ""
+
+#: modules/devices/x86/processor.c:712
+msgid "CPU Socket"
+msgstr ""
+
+#: modules/devices/x86/processor.c:716
+msgid "External Clock"
+msgstr ""
+
+#: modules/devices/x86/processor.c:717
+msgid "Max Frequency"
+msgstr ""
+
+#: modules/devices/x86/processor.c:748 modules/devices/x86/processor.c:769
 msgid "Package Information"
 msgstr ""
 
-#: modules/devices/x86/processor.c:742
+#: modules/devices/x86/processor.c:796
 msgid "Socket:Core"
 msgstr ""
 
-#: modules/devices/x86/processor.c:742
+#: modules/devices/x86/processor.c:796
 msgid "Thread"
 msgstr ""
 
@@ -4173,181 +5162,175 @@ msgctxt "x86-flag"
 msgid "CPU is affected by speculative store bypass attack"
 msgstr ""
 
+#. /bug:l1tf
+#: modules/devices/x86/x86_data.c:286
+msgctxt "x86-flag"
+msgid "CPU is affected by L1 Terminal Fault"
+msgstr ""
+
 #. /x86/kernel/cpu/powerflags.h
 #. /flag:pm:ts
-#: modules/devices/x86/x86_data.c:288
+#: modules/devices/x86/x86_data.c:289
 msgctxt "x86-flag"
 msgid "temperature sensor"
 msgstr ""
 
 #. /flag:pm:fid
-#: modules/devices/x86/x86_data.c:289
+#: modules/devices/x86/x86_data.c:290
 msgctxt "x86-flag"
 msgid "frequency id control"
 msgstr ""
 
 #. /flag:pm:vid
-#: modules/devices/x86/x86_data.c:290
+#: modules/devices/x86/x86_data.c:291
 msgctxt "x86-flag"
 msgid "voltage id control"
 msgstr ""
 
 #. /flag:pm:ttp
-#: modules/devices/x86/x86_data.c:291
+#: modules/devices/x86/x86_data.c:292
 msgctxt "x86-flag"
 msgid "thermal trip"
 msgstr ""
 
 #. /flag:pm:tm
-#: modules/devices/x86/x86_data.c:292
+#: modules/devices/x86/x86_data.c:293
 msgctxt "x86-flag"
 msgid "hardware thermal control"
 msgstr ""
 
 #. /flag:pm:stc
-#: modules/devices/x86/x86_data.c:293
+#: modules/devices/x86/x86_data.c:294
 msgctxt "x86-flag"
 msgid "software thermal control"
 msgstr ""
 
 #. /flag:pm:100mhzsteps
-#: modules/devices/x86/x86_data.c:294
+#: modules/devices/x86/x86_data.c:295
 msgctxt "x86-flag"
 msgid "100 MHz multiplier control"
 msgstr ""
 
 #. /flag:pm:hwpstate
-#: modules/devices/x86/x86_data.c:295
+#: modules/devices/x86/x86_data.c:296
 msgctxt "x86-flag"
 msgid "hardware P-state control"
 msgstr ""
 
 #. /flag:pm:cpb
-#: modules/devices/x86/x86_data.c:296
+#: modules/devices/x86/x86_data.c:297
 msgctxt "x86-flag"
 msgid "core performance boost"
 msgstr ""
 
 #. /flag:pm:eff_freq_ro
-#: modules/devices/x86/x86_data.c:297
+#: modules/devices/x86/x86_data.c:298
 msgctxt "x86-flag"
 msgid "Readonly aperf/mperf"
 msgstr ""
 
 #. /flag:pm:proc_feedback
-#: modules/devices/x86/x86_data.c:298
+#: modules/devices/x86/x86_data.c:299
 msgctxt "x86-flag"
 msgid "processor feedback interface"
 msgstr ""
 
 #. /flag:pm:acc_power
-#: modules/devices/x86/x86_data.c:299
+#: modules/devices/x86/x86_data.c:300
 msgctxt "x86-flag"
 msgid "accumulated power mechanism"
 msgstr ""
 
-#: modules/network.c:59
+#: modules/network.c:61
 msgid "Interfaces"
 msgstr ""
 
-#: modules/network.c:60
+#: modules/network.c:62
 msgid "IP Connections"
 msgstr ""
 
-#: modules/network.c:61
+#: modules/network.c:63
 msgid "Routing Table"
 msgstr ""
 
-#: modules/network.c:62 modules/network.c:303
+#: modules/network.c:64 modules/network.c:309
 msgid "ARP Table"
 msgstr ""
 
-#: modules/network.c:63
+#: modules/network.c:65
 msgid "DNS Servers"
 msgstr ""
 
-#: modules/network.c:64
+#: modules/network.c:66
 msgid "Statistics"
 msgstr ""
 
-#: modules/network.c:65
+#: modules/network.c:67
 msgid "Shared Directories"
 msgstr ""
 
-#: modules/network.c:304 modules/network.c:326 modules/network.c:357
+#: modules/network.c:310 modules/network.c:332 modules/network.c:363
 #: modules/network/net.c:472
 msgid "IP Address"
 msgstr ""
 
-#: modules/network.c:304 modules/network.c:357 modules/network.c:374
-msgid "Interface"
-msgstr ""
-
-#: modules/network.c:304
+#: modules/network.c:310
 msgid "MAC Address"
 msgstr ""
 
-#: modules/network.c:313
+#: modules/network.c:319
 msgid "SAMBA"
 msgstr ""
 
-#: modules/network.c:314
+#: modules/network.c:320
 msgid "NFS"
 msgstr ""
 
-#: modules/network.c:325
+#: modules/network.c:331
 msgid "Name Servers"
 msgstr ""
 
-#: modules/network.c:340
+#: modules/network.c:346
 msgid "Connections"
 msgstr ""
 
-#: modules/network.c:341
+#: modules/network.c:347
 msgid "Local Address"
 msgstr ""
 
-#: modules/network.c:341
-msgid "Protocol"
-msgstr ""
-
-#: modules/network.c:341
+#: modules/network.c:347
 msgid "Foreign Address"
 msgstr ""
 
-#: modules/network.c:341
+#: modules/network.c:347
 msgid "State"
 msgstr ""
 
-#: modules/network.c:357
+#: modules/network.c:363
 msgid "Sent"
 msgstr ""
 
-#: modules/network.c:357
+#: modules/network.c:363
 msgid "Received"
 msgstr ""
 
-#: modules/network.c:373
+#: modules/network.c:379
 msgid "IP routing table"
 msgstr ""
 
-#: modules/network.c:374
+#: modules/network.c:380
 msgid "Destination/Gateway"
 msgstr ""
 
-#: modules/network.c:374
-msgid "Flags"
-msgstr ""
-
-#: modules/network.c:374 modules/network/net.c:473
+#: modules/network.c:380 modules/network/net.c:473
 msgid "Mask"
 msgstr ""
 
-#: modules/network.c:402
+#: modules/network.c:408
 msgid "Network"
 msgstr ""
 
-#: modules/network.c:435
+#: modules/network.c:441
 msgid "Gathers information about this computer's network connection"
 msgstr ""
 
@@ -4517,11 +5500,6 @@ msgstr ""
 msgid "None Found"
 msgstr ""
 
-#: modules/network/net.c:395 modules/network/net.c:417
-#: modules/network/net.c:418
-msgid "MiB"
-msgstr ""
-
 #: modules/network/net.c:409
 msgid "Network Adapter Properties"
 msgstr ""
@@ -4571,16 +5549,8 @@ msgstr ""
 msgid "Bit Rate"
 msgstr ""
 
-#: modules/network/net.c:451
-msgid "Mb/s"
-msgstr ""
-
 #: modules/network/net.c:452
 msgid "Transmission Power"
-msgstr ""
-
-#: modules/network/net.c:454
-msgid "Status"
 msgstr ""
 
 #: modules/network/net.c:455


### PR DESCRIPTION
hardinfo.pot now has 1129 strings, with 66 c-format strings
(d55a8f33188eb35e918d5c6c355d686867315337)
- [ ] de.po : (933 / 1129 remain untranslated, needs work/fuzzy: 2)
- [ ] es.po : (455 / 1129 remain untranslated, needs work/fuzzy: 0)
- [ ] fr.po : (917 / 1129 remain untranslated, needs work/fuzzy: 0)
- [ ] pt_BR.po : (237 / 1129 remain untranslated, needs work/fuzzy: 1)
- [ ] ru.po : (379 / 1129 remain untranslated, needs work/fuzzy: 0)
- [ ] zh_CN.po : (751 / 1129 remain untranslated, needs work/fuzzy: 0)

See #105