### PR TITLE
various: entry hide flag, fix text format report, fix key_*() funcs

### DIFF
--- a/includes/hardinfo.h
+++ b/includes/hardinfo.h
@@ -40,6 +40,7 @@ typedef enum {
   MODULE_FLAG_NONE = 0,
   MODULE_FLAG_NO_REMOTE = 1<<0,
   MODULE_FLAG_HAS_HELP = 1<<1,
+  MODULE_FLAG_HIDE = 1<<2,
 } ModuleEntryFlags;
 
 typedef struct _ModuleEntry		ModuleEntry;

--- a/modules/benchmark/benches.c
+++ b/modules/benchmark/benches.c
@@ -101,16 +101,16 @@ static ModuleEntry entries[] = {
     [BENCHMARK_SBCPU_ALL] =
     {N_("SysBench CPU (Multi-thread)"), "processor.png", callback_benchmark_sbcpu_all, scan_benchmark_sbcpu_all, MODULE_FLAG_NONE},
     [BENCHMARK_SBCPU_QUAD] =
-    {N_("#SysBench CPU (Four threads)"), "processor.png", callback_benchmark_sbcpu_quad, scan_benchmark_sbcpu_quad, MODULE_FLAG_NONE},
+    {N_("#SysBench CPU (Four threads)"), "processor.png", callback_benchmark_sbcpu_quad, scan_benchmark_sbcpu_quad, MODULE_FLAG_HIDE},
     [BENCHMARK_MEMORY_SINGLE] =
-    {N_("#SysBench Memory (Single-thread)"), "memory.png", callback_benchmark_memory_single, scan_benchmark_memory_single, MODULE_FLAG_NONE},
+    {N_("#SysBench Memory (Single-thread)"), "memory.png", callback_benchmark_memory_single, scan_benchmark_memory_single, MODULE_FLAG_HIDE},
     [BENCHMARK_MEMORY_DUAL] =
-    {N_("#SysBench Memory (Two threads)"), "memory.png", callback_benchmark_memory_dual, scan_benchmark_memory_dual, MODULE_FLAG_NONE},
+    {N_("#SysBench Memory (Two threads)"), "memory.png", callback_benchmark_memory_dual, scan_benchmark_memory_dual, MODULE_FLAG_HIDE},
     [BENCHMARK_MEMORY_QUAD] =
     {N_("SysBench Memory"), "memory.png", callback_benchmark_memory_quad, scan_benchmark_memory_quad, MODULE_FLAG_NONE},
 #if !GTK_CHECK_VERSION(3,0,0)
     [BENCHMARK_GUI] =
-    {N_("GPU Drawing"), "module.png", callback_gui, scan_gui, MODULE_FLAG_NO_REMOTE},
+    {N_("GPU Drawing"), "module.png", callback_gui, scan_gui, MODULE_FLAG_NO_REMOTE | MODULE_FLAG_HIDE},
 #else
     [BENCHMARK_GUI] = { "#" },
 #endif

--- a/modules/devices.c
+++ b/modules/devices.c
@@ -106,7 +106,7 @@ static ModuleEntry entries[] = {
     [ENTRY_DMI] = {N_("System DMI"), "computer.png", callback_dmi, scan_dmi, MODULE_FLAG_NONE},
     [ENTRY_DMI_MEM] = {N_("Memory Devices"), "memory.png", callback_dmi_mem, scan_dmi_mem, MODULE_FLAG_NONE},
 #if defined(ARCH_x86) || defined(ARCH_x86_64)
-    [ENTRY_DTREE] = {"#"},
+    [ENTRY_DTREE] = {N_("Device Tree"), "devices.png", callback_dtree, scan_dtree, MODULE_FLAG_HIDE},
 #else
     [ENTRY_DTREE] = {N_("Device Tree"), "devices.png", callback_dtree, scan_dtree, MODULE_FLAG_NONE},
 #endif	/* x86 or x86_64 */

--- a/shell/report.c
+++ b/shell/report.c
@@ -126,6 +126,7 @@ gchar *make_icon_css(const gchar *file) {
 }
 
 void cache_icon(ReportContext *ctx, const gchar *file) {
+    if (!ctx->icon_data) return;
     if (!g_hash_table_lookup(ctx->icon_data, file) )
         g_hash_table_insert(ctx->icon_data, g_strdup(file), make_icon_css(file));
 }
@@ -684,6 +685,7 @@ report_create_inner_from_module_list(ReportContext * ctx, GSList * modules)
 
 	for (entries = module->entries; entries; entries = entries->next) {
 	    ShellModuleEntry *entry = (ShellModuleEntry *) entries->data;
+        if (entry->flags & MODULE_FLAG_HIDE) continue;
 
 	    if (!params.gui_running)
 		fprintf(stderr, "\033[2K\033[40;32;1m %s\033[0m\n",


### PR DESCRIPTION
* fix key_is_highlighted() and key_wants_details() so that they
  don't look for flags in the label.
* fix -r -f text, g_hash-related warnings from icon cache
* add MODULE_FLAG_HIDE flag to hide module entries instead of
  using the '#' at the beginning of string hack, which didn't
  work everywhere, and screwed up translated strings.
* hide GPU Drawing benchmark, at least for now. 
  - doesn't work in GTK3 version
  - no results with which to compare
  - varies wildly, but the details that affect it aren't stored in the bench results
  - See: https://github.com/lpereira/hardinfo/issues/329