### PR TITLE
sysbench memory tweaks

### DIFF
--- a/includes/benchmark.h
+++ b/includes/benchmark.h
@@ -4,6 +4,8 @@
 #include "hardinfo.h"
 #include "util_sysobj.h" /* for SEQ() */
 
+#define BENCH_PTR_BITS ((unsigned int)sizeof(void*) * 8)
+
 extern ProgramParameters params;
 
 enum {

--- a/modules/benchmark/benches.c
+++ b/modules/benchmark/benches.c
@@ -101,11 +101,11 @@ static ModuleEntry entries[] = {
     [BENCHMARK_SBCPU_ALL] =
     {N_("SysBench CPU (Multi-thread)"), "processor.png", callback_benchmark_sbcpu_all, scan_benchmark_sbcpu_all, MODULE_FLAG_NONE},
     [BENCHMARK_SBCPU_QUAD] =
-    {N_("#SysBench CPU (Four threads)"), "processor.png", callback_benchmark_sbcpu_quad, scan_benchmark_sbcpu_quad, MODULE_FLAG_HIDE},
+    {N_("SysBench CPU (Four threads)"), "processor.png", callback_benchmark_sbcpu_quad, scan_benchmark_sbcpu_quad, MODULE_FLAG_HIDE},
     [BENCHMARK_MEMORY_SINGLE] =
-    {N_("#SysBench Memory (Single-thread)"), "memory.png", callback_benchmark_memory_single, scan_benchmark_memory_single, MODULE_FLAG_HIDE},
+    {N_("SysBench Memory (Single-thread)"), "memory.png", callback_benchmark_memory_single, scan_benchmark_memory_single, MODULE_FLAG_NONE},
     [BENCHMARK_MEMORY_DUAL] =
-    {N_("#SysBench Memory (Two threads)"), "memory.png", callback_benchmark_memory_dual, scan_benchmark_memory_dual, MODULE_FLAG_HIDE},
+    {N_("SysBench Memory (Two threads)"), "memory.png", callback_benchmark_memory_dual, scan_benchmark_memory_dual, MODULE_FLAG_HIDE},
     [BENCHMARK_MEMORY_QUAD] =
     {N_("SysBench Memory"), "memory.png", callback_benchmark_memory_quad, scan_benchmark_memory_quad, MODULE_FLAG_NONE},
 #if !GTK_CHECK_VERSION(3,0,0)

--- a/test/just_bench.sh
+++ b/test/just_bench.sh
@@ -27,7 +27,7 @@ if [ ! -z `which sysbench` ]; then
     do_hi_bench "SysBench CPU (Single-thread)"
     do_hi_bench "SysBench CPU (Multi-thread)"
     #do_hi_bench "SysBench CPU (Four threads)"
-    #do_hi_bench "SysBench Memory (Single-thread)"
+    do_hi_bench "SysBench Memory (Single-thread)"
     #do_hi_bench "SysBench Memory (Two threads)"
     do_hi_bench "SysBench Memory"
 fi


### PR DESCRIPTION
* Use a larger sample size for sysbench 1.0+ and 64-bit
* Store pointer size with bench results
* Re-enable single thread memory benchmark

Use a larger sample size where available. The small size was
chosen because the 32-bit ARM sysbench 0.4x in raspbian
can't do more than about ~4G, but the problem is that much more
powerful machines burn through that very quickly. The result is
in MiB/s so it should still be comparable, but the results should
be more stable.

Noticed with Ryzen that multi-thread varies significantly based on
what threads are used, but benchmark doesn't really have control
over that.
