### PR TITLE
Fix FR build problems

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-06-09 14:09-0500\n"
+"POT-Creation-Date: 2019-10-24 15:16-0500\n"
 "PO-Revision-Date: 2016-06-10 12:11+0200\n"
 "Last-Translator: Alexander Münch <git@thehacker.biz>\n"
 "Language-Team: German\n"
@@ -28,19 +28,20 @@ msgstr ""
 msgid "Big Endian"
 msgstr ""
 
-#: hardinfo/cpu_util.c:184 hardinfo/cpu_util.c:195
+#: hardinfo/cpu_util.c:184 hardinfo/cpu_util.c:195 modules/devices/gpu.c:200
 msgid "Frequency Scaling"
 msgstr ""
 
-#: hardinfo/cpu_util.c:185
+#: hardinfo/cpu_util.c:185 modules/devices/gpu.c:201
 msgid "Minimum"
 msgstr ""
 
 #: hardinfo/cpu_util.c:185 hardinfo/cpu_util.c:186 hardinfo/cpu_util.c:187
+#: hardinfo/dt_util.c:589 modules/devices/gpu.c:201 modules/devices/gpu.c:202
 msgid "kHz"
 msgstr ""
 
-#: hardinfo/cpu_util.c:186
+#: hardinfo/cpu_util.c:186 modules/devices/gpu.c:202
 msgid "Maximum"
 msgstr ""
 
@@ -48,11 +49,11 @@ msgstr ""
 msgid "Current"
 msgstr ""
 
-#: hardinfo/cpu_util.c:188
+#: hardinfo/cpu_util.c:188 modules/devices/gpu.c:203
 msgid "Transition Latency"
 msgstr ""
 
-#: hardinfo/cpu_util.c:188
+#: hardinfo/cpu_util.c:188 modules/devices/gpu.c:203
 msgid "ns"
 msgstr ""
 
@@ -60,13 +61,13 @@ msgstr ""
 msgid "Governor"
 msgstr ""
 
-#: hardinfo/cpu_util.c:190 hardinfo/cpu_util.c:196 modules/devices/gpu.c:149
-#: modules/devices/pci.c:116
+#: hardinfo/cpu_util.c:190 hardinfo/cpu_util.c:196 modules/devices/gpu.c:153
+#: modules/devices/pci.c:134 modules/devices/usb.c:136
 msgid "Driver"
 msgstr "Treiber"
 
-#: hardinfo/cpu_util.c:202 modules/computer.c:596
-#: modules/devices/arm/processor.c:242 modules/devices/x86/processor.c:284
+#: hardinfo/cpu_util.c:202 modules/computer.c:737
+#: modules/devices/arm/processor.c:256 modules/devices/x86/processor.c:284
 #: modules/devices/x86/processor.c:388 modules/devices/x86/processor.c:524
 msgid "(Not Available)"
 msgstr ""
@@ -75,7 +76,8 @@ msgstr ""
 msgid "Socket"
 msgstr ""
 
-#: hardinfo/cpu_util.c:215 hardinfo/cpu_util.c:217
+#: hardinfo/cpu_util.c:215 hardinfo/cpu_util.c:217 modules/devices/gpu.c:149
+#: modules/devices/gpu.c:227
 msgid "Core"
 msgstr ""
 
@@ -87,8 +89,8 @@ msgstr ""
 msgid "Drawer"
 msgstr ""
 
-#: hardinfo/cpu_util.c:228 modules/devices/arm/processor.c:449
-#: modules/devices/x86/processor.c:697
+#: hardinfo/cpu_util.c:228 modules/devices/arm/processor.c:471
+#: modules/devices/x86/processor.c:750
 msgid "Topology"
 msgstr ""
 
@@ -96,112 +98,336 @@ msgstr ""
 msgid "ID"
 msgstr ""
 
-#: hardinfo/dmi_util.c:130
+#: hardinfo/dmi_util.c:25
+msgid "BIOS Information"
+msgstr ""
+
+#: hardinfo/dmi_util.c:26 modules/devices/parisc/processor.c:157
+msgid "System"
+msgstr ""
+
+#: hardinfo/dmi_util.c:27
+msgid "Base Board"
+msgstr ""
+
+#: hardinfo/dmi_util.c:28 modules/devices/dmi.c:53
+msgid "Chassis"
+msgstr ""
+
+#: hardinfo/dmi_util.c:29 modules/computer.c:529 modules/computer.c:1000
+#: modules/devices/alpha/processor.c:87 modules/devices/arm/processor.c:341
+#: modules/devices.c:99 modules/devices/ia64/processor.c:159
+#: modules/devices/m68k/processor.c:83 modules/devices/mips/processor.c:74
+#: modules/devices/parisc/processor.c:154 modules/devices/ppc/processor.c:157
+#: modules/devices/riscv/processor.c:181 modules/devices/s390/processor.c:131
+#: modules/devices/sh/processor.c:83 modules/devices/sparc/processor.c:74
+#: modules/devices/x86/processor.c:646
+msgid "Processor"
+msgstr "Prozessor"
+
+#: hardinfo/dmi_util.c:30
+msgid "Memory Controller"
+msgstr ""
+
+#: hardinfo/dmi_util.c:31
+msgid "Memory Module"
+msgstr ""
+
+#: hardinfo/dmi_util.c:32 modules/devices/parisc/processor.c:163
+#: modules/devices/x86/processor.c:662
+msgid "Cache"
+msgstr ""
+
+#: hardinfo/dmi_util.c:33
+msgid "Port Connector"
+msgstr ""
+
+#: hardinfo/dmi_util.c:34
+msgid "System Slots"
+msgstr ""
+
+#: hardinfo/dmi_util.c:35
+msgid "On Board Devices"
+msgstr ""
+
+#: hardinfo/dmi_util.c:36
+msgid "OEM Strings"
+msgstr ""
+
+#: hardinfo/dmi_util.c:37
+msgid "System Configuration Options"
+msgstr ""
+
+#: hardinfo/dmi_util.c:38
+msgid "BIOS Language"
+msgstr ""
+
+#: hardinfo/dmi_util.c:39
+msgid "Group Associations"
+msgstr ""
+
+#: hardinfo/dmi_util.c:40
+msgid "System Event Log"
+msgstr ""
+
+#: hardinfo/dmi_util.c:41
+msgid "Physical Memory Array"
+msgstr ""
+
+#: hardinfo/dmi_util.c:42
+msgid "Memory Device"
+msgstr ""
+
+#: hardinfo/dmi_util.c:43
+msgid "32-bit Memory Error"
+msgstr ""
+
+#: hardinfo/dmi_util.c:44
+msgid "Memory Array Mapped Address"
+msgstr ""
+
+#: hardinfo/dmi_util.c:45
+msgid "Memory Device Mapped Address"
+msgstr ""
+
+#: hardinfo/dmi_util.c:46
+msgid "Built-in Pointing Device"
+msgstr ""
+
+#: hardinfo/dmi_util.c:47
+msgid "Portable Battery"
+msgstr ""
+
+#: hardinfo/dmi_util.c:48
+msgid "System Reset"
+msgstr ""
+
+#: hardinfo/dmi_util.c:49
+msgid "Hardware Security"
+msgstr ""
+
+#: hardinfo/dmi_util.c:50
+msgid "System Power Controls"
+msgstr ""
+
+#: hardinfo/dmi_util.c:51
+msgid "Voltage Probe"
+msgstr ""
+
+#: hardinfo/dmi_util.c:52
+msgid "Cooling Device"
+msgstr ""
+
+#: hardinfo/dmi_util.c:53
+msgid "Temperature Probe"
+msgstr ""
+
+#: hardinfo/dmi_util.c:54
+msgid "Electrical Current Probe"
+msgstr ""
+
+#: hardinfo/dmi_util.c:55
+msgid "Out-of-band Remote Access"
+msgstr ""
+
+#: hardinfo/dmi_util.c:56
+msgid "Boot Integrity Services"
+msgstr ""
+
+#: hardinfo/dmi_util.c:57
+msgid "System Boot"
+msgstr ""
+
+#: hardinfo/dmi_util.c:58
+msgid "64-bit Memory Error"
+msgstr ""
+
+#: hardinfo/dmi_util.c:59
+msgid "Management Device"
+msgstr ""
+
+#: hardinfo/dmi_util.c:60
+msgid "Management Device Component"
+msgstr ""
+
+#: hardinfo/dmi_util.c:61
+msgid "Management Device Threshold Data"
+msgstr ""
+
+#: hardinfo/dmi_util.c:62
+msgid "Memory Channel"
+msgstr ""
+
+#: hardinfo/dmi_util.c:63
+msgid "IPMI Device"
+msgstr ""
+
+#: hardinfo/dmi_util.c:64
+msgid "Power Supply"
+msgstr ""
+
+#: hardinfo/dmi_util.c:65
+msgid "Additional Information"
+msgstr ""
+
+#: hardinfo/dmi_util.c:66
+msgid "Onboard Device"
+msgstr ""
+
+#: hardinfo/dmi_util.c:226
 msgid "Invalid chassis type (0)"
 msgstr ""
 
-#: hardinfo/dmi_util.c:131 hardinfo/dmi_util.c:132
+#: hardinfo/dmi_util.c:227 hardinfo/dmi_util.c:228
 msgid "Unknown chassis type"
 msgstr ""
 
-#: hardinfo/dmi_util.c:133
+#: hardinfo/dmi_util.c:229
 msgid "Desktop"
 msgstr ""
 
-#: hardinfo/dmi_util.c:134
+#: hardinfo/dmi_util.c:230
 msgid "Low-profile Desktop"
 msgstr ""
 
-#: hardinfo/dmi_util.c:135
+#: hardinfo/dmi_util.c:231
 msgid "Pizza Box"
 msgstr ""
 
-#: hardinfo/dmi_util.c:136
+#: hardinfo/dmi_util.c:232
 msgid "Mini Tower"
 msgstr ""
 
-#: hardinfo/dmi_util.c:137
+#: hardinfo/dmi_util.c:233
 msgid "Tower"
 msgstr ""
 
-#: hardinfo/dmi_util.c:138
+#: hardinfo/dmi_util.c:234
 msgid "Portable"
 msgstr ""
 
-#: hardinfo/dmi_util.c:139 modules/computer.c:330 modules/computer.c:339
-#: modules/computer.c:361
+#: hardinfo/dmi_util.c:235 modules/computer.c:391 modules/computer.c:400
+#: modules/computer.c:422
 msgid "Laptop"
 msgstr ""
 
-#: hardinfo/dmi_util.c:140
+#: hardinfo/dmi_util.c:236
 msgid "Notebook"
 msgstr ""
 
-#: hardinfo/dmi_util.c:141
+#: hardinfo/dmi_util.c:237
 msgid "Handheld"
 msgstr ""
 
-#: hardinfo/dmi_util.c:142
+#: hardinfo/dmi_util.c:238
 msgid "Docking Station"
 msgstr ""
 
-#: hardinfo/dmi_util.c:143
+#: hardinfo/dmi_util.c:239
 msgid "All-in-one"
 msgstr ""
 
-#: hardinfo/dmi_util.c:144
+#: hardinfo/dmi_util.c:240
 msgid "Subnotebook"
 msgstr ""
 
-#: hardinfo/dmi_util.c:145
+#: hardinfo/dmi_util.c:241
 msgid "Space-saving"
 msgstr ""
 
-#: hardinfo/dmi_util.c:146
+#: hardinfo/dmi_util.c:242
 msgid "Lunch Box"
 msgstr ""
 
-#: hardinfo/dmi_util.c:147
+#: hardinfo/dmi_util.c:243
 msgid "Main Server Chassis"
 msgstr ""
 
-#: hardinfo/dmi_util.c:148
+#: hardinfo/dmi_util.c:244
 msgid "Expansion Chassis"
 msgstr ""
 
-#: hardinfo/dmi_util.c:149
+#: hardinfo/dmi_util.c:245
 msgid "Sub Chassis"
 msgstr ""
 
-#: hardinfo/dmi_util.c:150
+#: hardinfo/dmi_util.c:246
 msgid "Bus Expansion Chassis"
 msgstr ""
 
-#: hardinfo/dmi_util.c:151
+#: hardinfo/dmi_util.c:247
 msgid "Peripheral Chassis"
 msgstr ""
 
-#: hardinfo/dmi_util.c:152
+#: hardinfo/dmi_util.c:248
 msgid "RAID Chassis"
 msgstr ""
 
-#: hardinfo/dmi_util.c:153
+#: hardinfo/dmi_util.c:249
 msgid "Rack Mount Chassis"
 msgstr ""
 
-#: hardinfo/dmi_util.c:154
+#: hardinfo/dmi_util.c:250
 msgid "Sealed-case PC"
 msgstr ""
 
-#: hardinfo/dt_util.c:1011
+#: hardinfo/dmi_util.c:251
+msgid "Multi-system"
+msgstr ""
+
+#: hardinfo/dmi_util.c:252
+msgid "CompactPCI"
+msgstr ""
+
+#: hardinfo/dmi_util.c:253
+msgid "AdvancedTCA"
+msgstr ""
+
+#: hardinfo/dmi_util.c:254
+msgid "Blade"
+msgstr ""
+
+#: hardinfo/dmi_util.c:255
+msgid "Blade Enclosing"
+msgstr ""
+
+#: hardinfo/dmi_util.c:256
+msgid "Tablet"
+msgstr ""
+
+#: hardinfo/dmi_util.c:257
+msgid "Convertible"
+msgstr ""
+
+#: hardinfo/dmi_util.c:258
+msgid "Detachable"
+msgstr ""
+
+#: hardinfo/dmi_util.c:259
+msgid "IoT Gateway"
+msgstr ""
+
+#: hardinfo/dmi_util.c:260
+msgid "Embedded PC"
+msgstr ""
+
+#: hardinfo/dmi_util.c:261
+msgid "Mini PC"
+msgstr ""
+
+#: hardinfo/dmi_util.c:262
+msgid "Stick PC"
+msgstr ""
+
+#: hardinfo/dt_util.c:1179
 msgid "phandle Map"
 msgstr ""
 
-#: hardinfo/dt_util.c:1012
+#: hardinfo/dt_util.c:1180
 msgid "Alias Map"
 msgstr ""
 
-#: hardinfo/dt_util.c:1013
+#: hardinfo/dt_util.c:1181
 msgid "Symbol Map"
 msgstr ""
 
@@ -224,12 +450,16 @@ msgid ""
 "  Compiled for:      %s\n"
 msgstr ""
 
-#: hardinfo/hardinfo.c:58 hardinfo/hardinfo.c:59 modules/computer.c:644
-#: modules/devices/inputdevices.c:128 modules/devices/printers.c:138
+#: hardinfo/hardinfo.c:58 hardinfo/hardinfo.c:59 modules/computer.c:785
+#: modules/computer/modules.c:131 modules/computer/modules.c:132
+#: modules/devices/inputdevices.c:123 modules/devices/printers.c:138
+#: modules/devices/spd-decode.c:903
 msgid "Yes"
 msgstr "Ja"
 
-#: hardinfo/hardinfo.c:59 modules/computer.c:644 modules/devices/printers.c:138
+#: hardinfo/hardinfo.c:59 modules/computer.c:785 modules/computer/modules.c:131
+#: modules/computer/modules.c:132 modules/devices/printers.c:138
+#: modules/devices/spd-decode.c:900
 msgid "No"
 msgstr "Nein"
 
@@ -253,30 +483,38 @@ msgstr ""
 msgid "File Name"
 msgstr ""
 
-#: hardinfo/hardinfo.c:78 modules/computer.c:528 modules/computer.c:556
-#: modules/computer.c:674 modules/computer/languages.c:104
-#: modules/computer/modules.c:146 modules/devices/arm/processor.c:447
-#: modules/devices/dmi.c:37 modules/devices/dmi.c:46
-#: modules/devices/ia64/processor.c:160 modules/devices/inputdevices.c:116
-#: modules/devices/sh/processor.c:84 modules/devices/x86/processor.c:696
-#: modules/network.c:326
+#: hardinfo/hardinfo.c:78 modules/computer.c:666 modules/computer.c:694
+#: modules/computer.c:815 modules/computer/languages.c:95
+#: modules/computer/modules.c:149 modules/devices/arm/processor.c:469
+#: modules/devices/dmi.c:37 modules/devices/dmi.c:48 modules/devices/gpu.c:233
+#: modules/devices/ia64/processor.c:160 modules/devices/inputdevices.c:111
+#: modules/devices/monitors.c:399 modules/devices/monitors.c:502
+#: modules/devices/sh/processor.c:84 modules/devices/x86/processor.c:749
+#: modules/network.c:332
 msgid "Name"
 msgstr "Name"
 
-#: hardinfo/hardinfo.c:78 modules/computer.c:304 modules/computer.c:499
-#: modules/computer.c:501 modules/computer.c:602 modules/devices/dmi.c:40
-#: modules/devices/dmi.c:44 modules/devices/dmi.c:48 modules/devices/dmi.c:54
-#: modules/devices/inputdevices.c:121
+#: hardinfo/hardinfo.c:78 modules/computer.c:347 modules/computer.c:572
+#: modules/computer.c:574 modules/computer.c:743 modules/computer/modules.c:151
+#: modules/devices/dmi.c:40 modules/devices/dmi.c:46 modules/devices/dmi.c:50
+#: modules/devices/dmi.c:56 modules/devices/firmware.c:105
+#: modules/devices/inputdevices.c:116 modules/devices/monitors.c:405
 msgid "Version"
 msgstr ""
 
-#: hardinfo/hardinfo.c:125
+#: hardinfo/hardinfo.c:129
 #, c-format
 msgid "Unknown benchmark ``%s'' or benchmark.so not loaded"
 msgstr ""
 
-#: hardinfo/hardinfo.c:155
+#: hardinfo/hardinfo.c:159
 msgid "Don't know what to do. Exiting."
+msgstr ""
+
+#: hardinfo/usb_util.c:290 modules/devices/devicetree.c:91
+#: modules/devices/devicetree.c:92 modules/devices/monitors.c:407
+#: modules/devices/storage.c:246
+msgid "(None)"
 msgstr ""
 
 #: hardinfo/util.c:104 modules/computer/uptime.c:54
@@ -349,92 +587,112 @@ msgstr "Warnung"
 msgid "Fatal Error"
 msgstr "Kritischer Fehler"
 
-#: hardinfo/util.c:403
+#: hardinfo/util.c:406
 msgid "creates a report and prints to standard output"
 msgstr ""
 
-#: hardinfo/util.c:409
-msgid "chooses a report format (text, html)"
+#: hardinfo/util.c:412
+msgid "chooses a report format ([text], html)"
 msgstr ""
 
-#: hardinfo/util.c:415
+#: hardinfo/util.c:418
 msgid "run benchmark; requires benchmark.so to be loaded"
 msgstr ""
 
-#: hardinfo/util.c:421
+#: hardinfo/util.c:424
+msgid "note attached to benchmark results"
+msgstr ""
+
+#: hardinfo/util.c:430
 msgid "benchmark result format ([short], conf, shell)"
 msgstr ""
 
-#: hardinfo/util.c:427
+#: hardinfo/util.c:436
+msgid ""
+"maximum number of benchmark results to include (-1 for no limit, default is "
+"10)"
+msgstr ""
+
+#: hardinfo/util.c:442
 msgid "lists modules"
 msgstr ""
 
-#: hardinfo/util.c:433
+#: hardinfo/util.c:448
 msgid "specify module to load"
 msgstr ""
 
-#: hardinfo/util.c:439
+#: hardinfo/util.c:454
 msgid "automatically load module dependencies"
 msgstr ""
 
-#: hardinfo/util.c:446
+#: hardinfo/util.c:461
 msgid "run in XML-RPC server mode"
 msgstr ""
 
-#: hardinfo/util.c:453
+#: hardinfo/util.c:468
 msgid "shows program version and quit"
 msgstr ""
 
-#: hardinfo/util.c:459
+#: hardinfo/util.c:474
 msgid "do not run benchmarks"
 msgstr ""
 
-#: hardinfo/util.c:464
+#: hardinfo/util.c:480
+msgid "show all details"
+msgstr ""
+
+#: hardinfo/util.c:485
 msgid "- System Profiler and Benchmark tool"
 msgstr "- System-Profiler und Benchmark-Werkzeug"
 
-#: hardinfo/util.c:474
+#: hardinfo/util.c:495
 #, c-format
 msgid ""
 "Unrecognized arguments.\n"
 "Try ``%s --help'' for more information.\n"
 msgstr ""
 
-#: hardinfo/util.c:542
-#, c-format
-msgid "Couldn't find a Web browser to open URL %s."
-msgstr "Konnte keinen Web-Browser finden, um die URL %s zu öffnen."
-
-#: hardinfo/util.c:891
+#: hardinfo/util.c:903
 #, c-format
 msgid "Module \"%s\" depends on module \"%s\", load it?"
 msgstr ""
 
-#: hardinfo/util.c:914
+#: hardinfo/util.c:926
 #, c-format
 msgid "Module \"%s\" depends on module \"%s\"."
 msgstr ""
 
-#: hardinfo/util.c:959
+#: hardinfo/util.c:971
 #, c-format
 msgid "No module could be loaded. Check permissions on \"%s\" and try again."
 msgstr ""
 
-#: hardinfo/util.c:963
+#: hardinfo/util.c:975
 msgid ""
 "No module could be loaded. Please use hardinfo -l to list all available "
 "modules and try again with a valid module list."
 msgstr ""
 
-#: hardinfo/util.c:1040
+#: hardinfo/util.c:1030
 #, c-format
 msgid "Scanning: %s..."
 msgstr ""
 
-#: hardinfo/util.c:1050 shell/shell.c:301 shell/shell.c:772 shell/shell.c:1850
-#: modules/benchmark.c:549 modules/benchmark.c:557
+#: hardinfo/util.c:1040 shell/shell.c:310 shell/shell.c:795 shell/shell.c:1962
+#: modules/benchmark.c:583 modules/benchmark.c:591
 msgid "Done."
 msgstr "Fertig."
+
+#: hardinfo/vendor.c:440 modules/computer.c:573 modules/computer.c:765
+#: modules/computer/os.c:79 modules/computer/os.c:263 modules/computer/os.c:300
+#: modules/computer/os.c:499 modules/computer/os.c:569 modules/devices.c:359
+#: modules/devices.c:505 modules/devices/printers.c:99
+#: modules/devices/printers.c:106 modules/devices/printers.c:116
+#: modules/devices/printers.c:131 modules/devices/printers.c:140
+#: modules/devices/printers.c:243 modules/devices/spd-decode.c:312
+#: modules/devices/usb.c:146
+msgid "Unknown"
+msgstr ""
 
 #: shell/callbacks.c:128
 #, c-format
@@ -458,63 +716,63 @@ msgstr ""
 msgid "Contributors:"
 msgstr "Mitwirkende:"
 
-#: shell/callbacks.c:166
+#: shell/callbacks.c:167
 msgid "Based on work by:"
 msgstr ""
 
-#: shell/callbacks.c:167
+#: shell/callbacks.c:168
 msgid "MD5 implementation by Colin Plumb (see md5.c for details)"
 msgstr ""
 
-#: shell/callbacks.c:168
+#: shell/callbacks.c:169
 msgid "SHA1 implementation by Steve Reid (see sha1.c for details)"
 msgstr ""
 
-#: shell/callbacks.c:169
+#: shell/callbacks.c:170
 msgid "Blowfish implementation by Paul Kocher (see blowfich.c for details)"
 msgstr ""
 
-#: shell/callbacks.c:170
+#: shell/callbacks.c:171
 msgid "Raytracing benchmark by John Walker (see fbench.c for details)"
 msgstr ""
 
-#: shell/callbacks.c:171
+#: shell/callbacks.c:172
 msgid "FFT benchmark by Scott Robert Ladd (see fftbench.c for details)"
 msgstr ""
 
-#: shell/callbacks.c:172
+#: shell/callbacks.c:173
 msgid "Some code partly based on x86cpucaps by Osamu Kayasono"
 msgstr ""
 
-#: shell/callbacks.c:173
+#: shell/callbacks.c:174
 msgid "Vendor list based on GtkSysInfo by Pissens Sebastien"
 msgstr ""
 
-#: shell/callbacks.c:174
+#: shell/callbacks.c:175
 msgid "DMI support based on code by Stewart Adam"
 msgstr ""
 
-#: shell/callbacks.c:175
+#: shell/callbacks.c:176
 msgid "SCSI support based on code by Pascal F. Martin"
 msgstr ""
 
-#: shell/callbacks.c:180
+#: shell/callbacks.c:181
 msgid "Tango Project"
 msgstr ""
 
-#: shell/callbacks.c:181
+#: shell/callbacks.c:182
 msgid "The GNOME Project"
 msgstr ""
 
-#: shell/callbacks.c:182
+#: shell/callbacks.c:183
 msgid "VMWare, Inc. (USB icon from VMWare Workstation 6)"
 msgstr ""
 
-#: shell/callbacks.c:200
+#: shell/callbacks.c:201
 msgid "System information and benchmark tool"
 msgstr "System-Informationen und Benchmark-Werkzeug"
 
-#: shell/callbacks.c:205
+#: shell/callbacks.c:206
 msgid ""
 "HardInfo is free software; you can redistribute it and/or modify it under "
 "the terms of the GNU General Public License as published by the Free "
@@ -530,131 +788,131 @@ msgid ""
 "Franklin St, Fifth Floor, Boston, MA  02110-1301 USA"
 msgstr ""
 
-#: shell/callbacks.c:220
+#: shell/callbacks.c:221
 msgid "translator-credits"
 msgstr ""
 
-#: shell/menu.c:35
+#: shell/menu.c:43
 msgid "_Information"
 msgstr "_Informationen"
 
-#: shell/menu.c:36
+#: shell/menu.c:44
 msgid "_Remote"
 msgstr ""
 
-#: shell/menu.c:37
+#: shell/menu.c:45
 msgid "_View"
 msgstr "_Ansicht"
 
-#: shell/menu.c:38
+#: shell/menu.c:46
 msgid "_Help"
 msgstr "_Hilfe"
 
-#: shell/menu.c:39
+#: shell/menu.c:47
 msgid "About _Modules"
 msgstr "Über _Module"
 
-#: shell/menu.c:43
+#: shell/menu.c:51
 msgid "Generate _Report"
 msgstr "_Bericht generieren"
 
-#: shell/menu.c:48
+#: shell/menu.c:56
 msgid "_Network Updater..."
 msgstr "_Netzwerk-Updater…"
 
-#: shell/menu.c:53
+#: shell/menu.c:61
 msgid "_Open..."
 msgstr ""
 
-#: shell/menu.c:58
+#: shell/menu.c:66
 msgid "_Copy to Clipboard"
 msgstr "In die Zwischenablage _kopieren"
 
-#: shell/menu.c:59
+#: shell/menu.c:67
 msgid "Copy to clipboard"
 msgstr "In die Zwischenablage kopieren"
 
-#: shell/menu.c:63
+#: shell/menu.c:71
 msgid "_Refresh"
 msgstr "_Aktualisieren"
 
-#: shell/menu.c:68
+#: shell/menu.c:76
 msgid "_Open HardInfo Web Site"
 msgstr "HardInfo-_Webseite öffnen"
 
-#: shell/menu.c:73
+#: shell/menu.c:81
 msgid "_Report bug"
 msgstr "Fehler _melden"
 
-#: shell/menu.c:78
+#: shell/menu.c:86
 msgid "_About HardInfo"
 msgstr "_Über HardInfo"
 
-#: shell/menu.c:79
+#: shell/menu.c:87
 msgid "Displays program version information"
 msgstr ""
 
-#: shell/menu.c:83
+#: shell/menu.c:91
 msgid "_Quit"
 msgstr "_Beenden"
 
-#: shell/menu.c:90
+#: shell/menu.c:98
 msgid "_Side Pane"
 msgstr "_Seitenleiste"
 
-#: shell/menu.c:91
+#: shell/menu.c:99
 msgid "Toggles side pane visibility"
 msgstr ""
 
-#: shell/menu.c:94
+#: shell/menu.c:102
 msgid "_Toolbar"
 msgstr "_Symbolleiste"
 
-#: shell/report.c:500 shell/report.c:508
+#: shell/report.c:769 shell/report.c:777
 msgid "Save File"
 msgstr "Datei speichern"
 
-#: shell/report.c:503 shell/report.c:935 shell/syncmanager.c:748
+#: shell/report.c:772 shell/report.c:1243 shell/syncmanager.c:748
 msgid "_Cancel"
 msgstr ""
 
-#: shell/report.c:505
+#: shell/report.c:774
 msgid "_Save"
 msgstr ""
 
-#: shell/report.c:635
+#: shell/report.c:943
 msgid "Cannot create ReportContext. Programming bug?"
 msgstr ""
 
-#: shell/report.c:654
+#: shell/report.c:962
 msgid "Open the report with your web browser?"
 msgstr "Den Bericht in deinem Webbrowser öffnen?"
 
-#: shell/report.c:657
+#: shell/report.c:965
 msgid "_No"
 msgstr ""
 
-#: shell/report.c:658
+#: shell/report.c:966
 msgid "_Open"
 msgstr ""
 
-#: shell/report.c:688
+#: shell/report.c:996
 msgid "Generating report..."
 msgstr "Generiere Bericht…"
 
-#: shell/report.c:698
+#: shell/report.c:1006
 msgid "Report saved."
 msgstr "Bericht gespeichert."
 
-#: shell/report.c:700
+#: shell/report.c:1008
 msgid "Error while creating the report."
 msgstr "Fehler beim Erzeugen des Berichts."
 
-#: shell/report.c:802
+#: shell/report.c:1110
 msgid "Generate Report"
 msgstr "Bericht generieren"
 
-#: shell/report.c:827
+#: shell/report.c:1135
 msgid ""
 "<big><b>Generate Report</b></big>\n"
 "Please choose the information that you wish to view in your report:"
@@ -662,37 +920,37 @@ msgstr ""
 "<big><b>Bericht generieren</b></big>\n"
 "Bitte wähle die Informationen, die du in deinen Bereich einbeziehen möchtest:"
 
-#: shell/report.c:899
+#: shell/report.c:1207
 msgid "Select _None"
 msgstr "_Nichts auswählen"
 
-#: shell/report.c:910
+#: shell/report.c:1218
 msgid "Select _All"
 msgstr "_Alles auswählen"
 
-#: shell/report.c:945
+#: shell/report.c:1253
 msgid "_Generate"
 msgstr "_Generieren"
 
-#: shell/shell.c:402
+#: shell/shell.c:407
 #, c-format
 msgid "%s - System Information"
 msgstr "%s - System-Informationen"
 
-#: shell/shell.c:407
+#: shell/shell.c:412
 msgid "System Information"
 msgstr "System-Informationen"
 
-#: shell/shell.c:759
+#: shell/shell.c:782
 msgid "Loading modules..."
 msgstr ""
 
-#: shell/shell.c:1715
+#: shell/shell.c:1828
 #, c-format
 msgid "<b>%s → Summary</b>"
 msgstr "<b>%s → Zusammenfassung</b>"
 
-#: shell/shell.c:1824
+#: shell/shell.c:1936
 msgid "Updating..."
 msgstr "Aktualisiere…"
 
@@ -775,47 +1033,91 @@ msgstr "Netzwerk-Updater"
 msgid "_Synchronize"
 msgstr "_Synchronisieren"
 
-#: modules/benchmark/benches.c:74
-msgid "CPU Blowfish"
-msgstr "CPU Blowfish"
+#: modules/benchmark/benches.c:82
+msgid "CPU Blowfish (Single-thread)"
+msgstr ""
 
-#: modules/benchmark/benches.c:75
-msgid "CPU CryptoHash"
-msgstr "CPU Crypto-Hash"
+#: modules/benchmark/benches.c:84
+msgid "CPU Blowfish (Multi-thread)"
+msgstr ""
 
-#: modules/benchmark/benches.c:76
-msgid "CPU Fibonacci"
-msgstr "CPU Fibonacci"
+#: modules/benchmark/benches.c:86
+msgid "CPU Blowfish (Multi-core)"
+msgstr ""
 
-#: modules/benchmark/benches.c:77
-msgid "CPU N-Queens"
-msgstr "CPU Damenproblem"
-
-#: modules/benchmark/benches.c:78
+#: modules/benchmark/benches.c:88
 msgid "CPU Zlib"
 msgstr ""
 
-#: modules/benchmark/benches.c:79
+#: modules/benchmark/benches.c:90
+msgid "CPU CryptoHash"
+msgstr "CPU Crypto-Hash"
+
+#: modules/benchmark/benches.c:92
+msgid "CPU Fibonacci"
+msgstr "CPU Fibonacci"
+
+#: modules/benchmark/benches.c:94
+msgid "CPU N-Queens"
+msgstr "CPU Damenproblem"
+
+#: modules/benchmark/benches.c:96
 msgid "FPU FFT"
 msgstr "FPU FFT"
 
-#: modules/benchmark/benches.c:80
+#: modules/benchmark/benches.c:98
 msgid "FPU Raytracing"
 msgstr "FPU Raytracing"
 
-#: modules/benchmark/benches.c:82
+#: modules/benchmark/benches.c:100
+msgid "SysBench CPU (Single-thread)"
+msgstr ""
+
+#: modules/benchmark/benches.c:102
+msgid "SysBench CPU (Multi-thread)"
+msgstr ""
+
+#: modules/benchmark/benches.c:104
+msgid "SysBench CPU (Four threads)"
+msgstr ""
+
+#: modules/benchmark/benches.c:106
+msgid "SysBench Memory (Single-thread)"
+msgstr ""
+
+#: modules/benchmark/benches.c:108
+msgid "SysBench Memory (Two threads)"
+msgstr ""
+
+#: modules/benchmark/benches.c:110
+msgid "SysBench Memory"
+msgstr ""
+
+#: modules/benchmark/benches.c:113
 msgid "GPU Drawing"
 msgstr "GPU Zeichnen"
 
-#: modules/benchmark/benches.c:91
+#: modules/benchmark/benches.c:126
+msgid ""
+"Alexey Kopytov's <i><b>sysbench</b></i> is required.\n"
+"Results in events/second. Higher is better."
+msgstr ""
+
+#: modules/benchmark/benches.c:132
+msgid ""
+"Alexey Kopytov's <i><b>sysbench</b></i> is required.\n"
+"Results in MiB/second. Higher is better."
+msgstr ""
+
+#: modules/benchmark/benches.c:136
 msgid "Results in MiB/second. Higher is better."
 msgstr "Ergebnisse in MiB/Sekunde. Höhere Werte sind besser."
 
-#: modules/benchmark/benches.c:95
+#: modules/benchmark/benches.c:143
 msgid "Results in HIMarks. Higher is better."
 msgstr "Ergebnisse in HIMarks. Höhere Werte sind besser."
 
-#: modules/benchmark/benches.c:102
+#: modules/benchmark/benches.c:149
 msgid "Results in seconds. Lower is better."
 msgstr "Ergebnisse in Sekunden. Niedrigere Werte sind besser."
 
@@ -834,158 +1136,201 @@ msgstr "Ergebnisse in Sekunden. Niedrigere Werte sind besser."
 #.
 #. / Used for an unknown value. Having it in only one place cleans up the .po line references
 #: modules/benchmark/bench_results.c:22 modules/computer.c:41
-#: modules/computer/display.c:41 modules/computer/os.c:279
-#: modules/devices.c:383 modules/devices/gpu.c:42 modules/devices/gpu.c:58
-#: modules/devices/gpu.c:150 modules/devices/gpu.c:151 modules/devices/pci.c:25
-#: modules/devices/pci.c:117 modules/devices/pci.c:118 modules/devices/usb.c:27
-#: modules/network/net.c:437 includes/cpu_util.h:11
+#: modules/computer/display.c:41 modules/computer/display.c:58
+#: modules/computer/os.c:286 modules/computer/os.c:346 modules/devices.c:488
+#: modules/devices/dmi_memory.c:52 modules/devices/dmi_memory.c:53
+#: modules/devices/dmi_memory.c:579 modules/devices/dmi_memory.c:719
+#: modules/devices/dmi_memory.c:855 modules/devices/gpu.c:42
+#: modules/devices/gpu.c:58 modules/devices/gpu.c:112 modules/devices/gpu.c:120
+#: modules/devices/gpu.c:154 modules/devices/gpu.c:155
+#: modules/devices/gpu.c:176 modules/devices/monitors.c:27
+#: modules/devices/monitors.c:28 modules/devices/monitors.c:153
+#: modules/devices/monitors.c:162 modules/devices/pci.c:25
+#: modules/devices/pci.c:135 modules/devices/pci.c:136
+#: modules/devices/spd-decode.c:306 modules/devices/spd-decode.c:307
+#: modules/devices/spd-decode.c:310 modules/devices/spd-decode.c:311
+#: modules/devices/spd-decode.c:914 modules/devices/spd-decode.c:915
+#: modules/devices/storage.c:247 modules/devices/storage.c:309
+#: modules/devices/usb.c:28 modules/network/net.c:437 includes/cpu_util.h:11
 msgid "(Unknown)"
 msgstr ""
 
-#: modules/benchmark/bench_results.c:47 modules/benchmark/bench_results.c:322
-#: modules/devices/alpha/processor.c:90 modules/devices/arm/processor.c:276
-#: modules/devices/arm/processor.c:289 modules/devices/arm/processor.c:331
-#: modules/devices/arm/processor.c:478 modules/devices.c:310
-#: modules/devices.c:318 modules/devices.c:346
-#: modules/devices/ia64/processor.c:167 modules/devices/ia64/processor.c:196
-#: modules/devices/m68k/processor.c:87 modules/devices/mips/processor.c:77
-#: modules/devices/parisc/processor.c:158
+#: modules/benchmark/bench_results.c:49 modules/benchmark/bench_results.c:330
+#: modules/devices/alpha/processor.c:90 modules/devices/arm/processor.c:290
+#: modules/devices/arm/processor.c:303 modules/devices/arm/processor.c:345
+#: modules/devices/arm/processor.c:500 modules/devices.c:325
+#: modules/devices.c:333 modules/devices.c:361 modules/devices/gpu.c:115
+#: modules/devices/gpu.c:117 modules/devices/gpu.c:123
+#: modules/devices/gpu.c:125 modules/devices/gpu.c:179
+#: modules/devices/gpu.c:181 modules/devices/ia64/processor.c:167
+#: modules/devices/ia64/processor.c:196 modules/devices/m68k/processor.c:87
+#: modules/devices/mips/processor.c:77 modules/devices/parisc/processor.c:158
 #: modules/devices/parisc/processor.c:191 modules/devices/ppc/processor.c:160
 #: modules/devices/ppc/processor.c:187 modules/devices/riscv/processor.c:186
 #: modules/devices/riscv/processor.c:214 modules/devices/s390/processor.c:160
 #: modules/devices/sh/processor.c:87 modules/devices/sh/processor.c:88
 #: modules/devices/sh/processor.c:89 modules/devices/x86/processor.c:318
-#: modules/devices/x86/processor.c:331 modules/devices/x86/processor.c:655
-#: modules/devices/x86/processor.c:726
+#: modules/devices/x86/processor.c:331 modules/devices/x86/processor.c:657
+#: modules/devices/x86/processor.c:780
 msgid "MHz"
 msgstr ""
 
-#: modules/benchmark/bench_results.c:374 modules/benchmark/bench_results.c:441
+#: modules/benchmark/bench_results.c:396 modules/benchmark/bench_results.c:495
 msgid "kiB"
 msgstr ""
 
-#: modules/benchmark/bench_results.c:389 modules/benchmark/bench_results.c:426
+#: modules/benchmark/bench_results.c:403 modules/benchmark/bench_results.c:453
+#, c-format
+msgid "%d-bit"
+msgstr ""
+
+#: modules/benchmark/bench_results.c:422 modules/benchmark/bench_results.c:477
 msgid "Benchmark Result"
 msgstr ""
 
-#: modules/benchmark/bench_results.c:390 modules/benchmark/bench_results.c:428
+#: modules/benchmark/bench_results.c:423 modules/benchmark/bench_results.c:479
 msgid "Threads"
 msgstr ""
 
-#: modules/benchmark/bench_results.c:391 modules/benchmark/bench_results.c:431
+#: modules/benchmark/bench_results.c:424 modules/benchmark/bench_results.c:481
+msgid "Elapsed Time"
+msgstr ""
+
+#: modules/benchmark/bench_results.c:424 modules/benchmark/bench_results.c:481
+msgid "seconds"
+msgstr ""
+
+#: modules/benchmark/bench_results.c:425 modules/computer/languages.c:101
+#: modules/devices/arm/processor.c:355 modules/devices/gpu.c:147
+#: modules/devices/ia64/processor.c:166 modules/devices/pci.c:132
+#: modules/devices/ppc/processor.c:159
+msgid "Revision"
+msgstr ""
+
+#: modules/benchmark/bench_results.c:426 modules/benchmark/bench_results.c:482
+msgid "Extra Information"
+msgstr ""
+
+#: modules/benchmark/bench_results.c:427 modules/benchmark/bench_results.c:483
+msgid "User Note"
+msgstr ""
+
+#: modules/benchmark/bench_results.c:429 modules/benchmark/bench_results.c:485
 msgid "Note"
 msgstr ""
 
-#: modules/benchmark/bench_results.c:392 modules/benchmark/bench_results.c:432
+#: modules/benchmark/bench_results.c:430 modules/benchmark/bench_results.c:486
 msgid ""
 "This result is from an old version of HardInfo. Results might not be "
 "comparable to current version. Some details are missing."
 msgstr ""
 
-#: modules/benchmark/bench_results.c:393 modules/benchmark/bench_results.c:433
+#: modules/benchmark/bench_results.c:431 modules/benchmark/bench_results.c:487
 #: modules/devices/devicetree/pmac_data.c:81 modules/devices/sh/processor.c:85
 msgid "Machine"
 msgstr ""
 
-#: modules/benchmark/bench_results.c:394 modules/benchmark/bench_results.c:434
-#: modules/devices/devicetree.c:206 modules/devices/dmi.c:45
+#: modules/benchmark/bench_results.c:432 modules/benchmark/bench_results.c:488
+#: modules/devices/devicetree.c:208 modules/devices/dmi.c:47
 msgid "Board"
 msgstr ""
 
-#: modules/benchmark/bench_results.c:395 modules/benchmark/bench_results.c:435
+#: modules/benchmark/bench_results.c:433 modules/benchmark/bench_results.c:489
 msgid "CPU Name"
 msgstr ""
 
-#: modules/benchmark/bench_results.c:396 modules/benchmark/bench_results.c:436
+#: modules/benchmark/bench_results.c:434 modules/benchmark/bench_results.c:490
 msgid "CPU Description"
 msgstr ""
 
-#: modules/benchmark/bench_results.c:397 modules/benchmark/bench_results.c:437
-#: modules/benchmark.c:390
+#: modules/benchmark/bench_results.c:435 modules/benchmark/bench_results.c:491
+#: modules/benchmark.c:442
 msgid "CPU Config"
 msgstr ""
 
-#: modules/benchmark/bench_results.c:398 modules/benchmark/bench_results.c:438
+#: modules/benchmark/bench_results.c:436 modules/benchmark/bench_results.c:492
 msgid "Threads Available"
 msgstr ""
 
-#: modules/benchmark/bench_results.c:399 modules/benchmark/bench_results.c:439
+#: modules/benchmark/bench_results.c:437 modules/benchmark/bench_results.c:493
 msgid "GPU"
 msgstr ""
 
-#: modules/benchmark/bench_results.c:400 modules/benchmark/bench_results.c:440
-#: modules/computer.c:479
+#: modules/benchmark/bench_results.c:438 modules/benchmark/bench_results.c:494
+#: modules/computer.c:542
 msgid "OpenGL Renderer"
 msgstr "OpenGL-Renderer"
 
-#: modules/benchmark/bench_results.c:401 modules/benchmark/bench_results.c:441
-#: modules/computer.c:110 modules/computer.c:468 modules/devices.c:99
+#: modules/benchmark/bench_results.c:439 modules/benchmark/bench_results.c:495
+#: modules/computer.c:123 modules/computer.c:531 modules/computer.c:1000
+#: modules/devices/gpu.c:150
 msgid "Memory"
 msgstr "Hauptspeicher"
 
-#: modules/benchmark/bench_results.c:427
+#: modules/benchmark/bench_results.c:440 modules/benchmark/bench_results.c:496
+msgid "Pointer Size"
+msgstr ""
+
+#: modules/benchmark/bench_results.c:478
 msgid "Benchmark"
 msgstr ""
 
-#: modules/benchmark/bench_results.c:429
+#: modules/benchmark/bench_results.c:480 modules/devices/dmi_memory.c:879
+#: modules/devices/firmware.c:246 modules/devices/monitors.c:492
+#: modules/devices/x86/processor.c:691
 msgid "Result"
 msgstr ""
 
-#: modules/benchmark/bench_results.c:430
-msgid "Elapsed Time"
-msgstr ""
-
-#: modules/benchmark/bench_results.c:442
+#: modules/benchmark/bench_results.c:498
 msgid "Handles"
 msgstr ""
 
-#: modules/benchmark/bench_results.c:443
+#: modules/benchmark/bench_results.c:499
 msgid "mid"
 msgstr ""
 
-#: modules/benchmark/bench_results.c:444
+#: modules/benchmark/bench_results.c:500
 msgid "cfg_val"
 msgstr ""
 
-#: modules/benchmark.c:390
+#: modules/benchmark.c:442
 msgid "Results"
 msgstr "Ergebnisse"
 
-#: modules/benchmark.c:390 modules/computer.c:811
-#: modules/devices/sparc/processor.c:75
+#: modules/benchmark.c:442 modules/devices/sparc/processor.c:75
 msgid "CPU"
 msgstr ""
 
-#: modules/benchmark.c:460
+#: modules/benchmark.c:513
 #, c-format
 msgid "Benchmarking: <b>%s</b>."
 msgstr "Benchmarke: <b>%s</b>."
 
-#: modules/benchmark.c:479 modules/benchmark.c:498
-msgid "Cancel"
-msgstr "Abbrechen"
-
-#: modules/benchmark.c:483 modules/benchmark.c:495
+#: modules/benchmark.c:527
 msgid "Benchmarking. Please do not move your mouse or press any keys."
 msgstr "Benchmarke. Bitte bewege den Mauszeiger nicht und drücke keine Tasten."
 
-#: modules/benchmark.c:567
+#: modules/benchmark.c:530
+msgid "Cancel"
+msgstr "Abbrechen"
+
+#: modules/benchmark.c:601
 msgid "Benchmarks"
 msgstr "Benchmarks"
 
-#: modules/benchmark.c:585
+#: modules/benchmark.c:619
 msgid "Perform tasks and compare with other systems"
 msgstr "Erledigt Aufgaben und vergleicht die Ergebnisse mit anderen Systemen"
 
-#: modules/benchmark.c:692
+#: modules/benchmark.c:730
 msgid "Send benchmark results"
 msgstr "Übermittle Benchmark-Ergebnisse"
 
-#: modules/benchmark.c:697
+#: modules/benchmark.c:735
 msgid "Receive benchmark results"
 msgstr "Lade Benchmark-Ergebnisse"
 
-#: modules/computer/alsa.c:26 modules/computer.c:483
+#: modules/computer/alsa.c:26 modules/computer.c:546
 msgid "Audio Devices"
 msgstr "Audio-Geräte"
 
@@ -993,499 +1338,606 @@ msgstr "Audio-Geräte"
 msgid "Audio Adapter"
 msgstr ""
 
-#: modules/computer.c:76
+#: modules/computer.c:80 modules/devices/firmware.c:104
 msgid "Summary"
 msgstr "Zusammenfassung"
 
-#: modules/computer.c:77 modules/computer.c:471 modules/computer.c:810
+#: modules/computer.c:81 modules/computer.c:534 modules/computer.c:999
 msgid "Operating System"
 msgstr "Betriebssystem"
 
-#: modules/computer.c:78 modules/devices/gpu.c:151 modules/devices/pci.c:118
+#: modules/computer.c:82
+msgid "Security"
+msgstr ""
+
+#: modules/computer.c:83 modules/devices/gpu.c:155 modules/devices/pci.c:136
 msgid "Kernel Modules"
 msgstr "Kernel-Module"
 
-#: modules/computer.c:79 modules/computer.c:540
+#: modules/computer.c:84 modules/computer.c:678
 msgid "Boots"
 msgstr "Systemstarts"
 
-#: modules/computer.c:80
+#: modules/computer.c:85
 msgid "Languages"
 msgstr "Sprachen"
 
-#: modules/computer.c:81
+#: modules/computer.c:86
+msgid "Memory Usage"
+msgstr ""
+
+#: modules/computer.c:87
 msgid "Filesystems"
 msgstr "Dateisysteme"
 
-#: modules/computer.c:82 modules/computer.c:476
+#: modules/computer.c:88 modules/computer.c:539
 msgid "Display"
 msgstr "Anzeige"
 
-#: modules/computer.c:83 modules/computer/environment.c:32
+#: modules/computer.c:89 modules/computer/environment.c:32
 msgid "Environment Variables"
 msgstr "Umgebungsvariablen"
 
-#: modules/computer.c:85
+#: modules/computer.c:91
 msgid "Development"
 msgstr "Entwicklung"
 
-#: modules/computer.c:87 modules/computer.c:661
+#: modules/computer.c:93 modules/computer.c:802
 msgid "Users"
 msgstr "Benutzer"
 
-#: modules/computer.c:88
+#: modules/computer.c:94
 msgid "Groups"
 msgstr "Gruppen"
 
-#: modules/computer.c:112
+#: modules/computer.c:125
 #, c-format
 msgid "%dMB (%dMB used)"
 msgstr ""
 
-#: modules/computer.c:114 modules/computer.c:514
+#: modules/computer.c:127 modules/computer.c:594
 msgid "Uptime"
 msgstr ""
 
-#: modules/computer.c:116 modules/computer.c:473
+#: modules/computer.c:129 modules/computer.c:536
 msgid "Date/Time"
 msgstr ""
 
-#: modules/computer.c:121 modules/computer.c:515
+#: modules/computer.c:134 modules/computer.c:595
 msgid "Load Average"
 msgstr ""
 
-#: modules/computer.c:123 modules/computer.c:516
-msgid "Available entropy in /dev/random"
-msgstr ""
-
-#: modules/computer.c:211
+#: modules/computer.c:247
 msgid "Scripting Languages"
 msgstr "Script-Sprachen"
 
-#: modules/computer.c:212
+#: modules/computer.c:248
 msgid "Gambas3 (gbr3)"
 msgstr ""
 
-#: modules/computer.c:213
-msgid "Python"
+#: modules/computer.c:249
+msgid "Python (default)"
 msgstr ""
 
-#: modules/computer.c:214
+#: modules/computer.c:250
 msgid "Python2"
 msgstr ""
 
-#: modules/computer.c:215
+#: modules/computer.c:251
 msgid "Python3"
 msgstr ""
 
-#: modules/computer.c:216
+#: modules/computer.c:252
 msgid "Perl"
 msgstr "Perl"
 
-#: modules/computer.c:217
+#: modules/computer.c:253
 msgid "Perl6 (VM)"
 msgstr ""
 
-#: modules/computer.c:218
+#: modules/computer.c:254
 msgid "Perl6"
 msgstr ""
 
-#: modules/computer.c:219
+#: modules/computer.c:255
 msgid "PHP"
 msgstr "PHP"
 
-#: modules/computer.c:220
+#: modules/computer.c:256
 msgid "Ruby"
 msgstr "Ruby"
 
-#: modules/computer.c:221
+#: modules/computer.c:257
 msgid "Bash"
 msgstr "Bash"
 
-#: modules/computer.c:222
+#: modules/computer.c:258
+msgid "JavaScript (Node.js)"
+msgstr ""
+
+#: modules/computer.c:259
+msgid "awk"
+msgstr ""
+
+#: modules/computer.c:260
 msgid "Compilers"
 msgstr "Compiler"
 
-#: modules/computer.c:223
+#: modules/computer.c:261
 msgid "C (GCC)"
 msgstr "C (GCC)"
 
-#: modules/computer.c:224
+#: modules/computer.c:262
 msgid "C (Clang)"
 msgstr "C (Clang)"
 
-#: modules/computer.c:225
+#: modules/computer.c:263
 msgid "D (dmd)"
 msgstr "D (dmd)"
 
-#: modules/computer.c:226
+#: modules/computer.c:264
 msgid "Gambas3 (gbc3)"
 msgstr ""
 
-#: modules/computer.c:227
+#: modules/computer.c:265
 msgid "Java"
 msgstr "Java"
 
-#: modules/computer.c:228
-msgid "CSharp (Mono, old)"
-msgstr "CSharp (Mono, old)"
+#: modules/computer.c:266
+msgid "C♯ (mcs)"
+msgstr ""
 
-#: modules/computer.c:229
-msgid "CSharp (Mono)"
-msgstr "CSharp (Mono)"
-
-#: modules/computer.c:230
+#: modules/computer.c:267
 msgid "Vala"
 msgstr "Vala"
 
-#: modules/computer.c:231
+#: modules/computer.c:268
 msgid "Haskell (GHC)"
 msgstr "Haskell (GHC)"
 
-#: modules/computer.c:232
+#: modules/computer.c:269
 msgid "FreePascal"
 msgstr "FreePascal"
 
-#: modules/computer.c:233
+#: modules/computer.c:270
 msgid "Go"
 msgstr ""
 
-#: modules/computer.c:234
+#: modules/computer.c:271
+msgid "Rust"
+msgstr ""
+
+#: modules/computer.c:272
 msgid "Tools"
 msgstr "Werkzeug-Programme"
 
-#: modules/computer.c:235
+#: modules/computer.c:273
 msgid "make"
 msgstr "make"
 
-#: modules/computer.c:236
+#: modules/computer.c:274
+msgid "ninja"
+msgstr ""
+
+#: modules/computer.c:275
 msgid "GDB"
 msgstr "GDB"
 
-#: modules/computer.c:237
+#: modules/computer.c:276
+msgid "LLDB"
+msgstr ""
+
+#: modules/computer.c:277
 msgid "strace"
 msgstr "strace"
 
-#: modules/computer.c:238
+#: modules/computer.c:278
 msgid "valgrind"
 msgstr "valgrind"
 
-#: modules/computer.c:239
+#: modules/computer.c:279
 msgid "QMake"
 msgstr "QMake"
 
-#: modules/computer.c:240
+#: modules/computer.c:280
 msgid "CMake"
 msgstr ""
 
-#: modules/computer.c:241
+#: modules/computer.c:281
 msgid "Gambas3 IDE"
 msgstr ""
 
 #: modules/computer.c:282
+msgid "Radare2"
+msgstr ""
+
+#: modules/computer.c:283
+msgid "ltrace"
+msgstr ""
+
+#: modules/computer.c:324
 msgid "Not found"
 msgstr "Nicht gefunden"
 
-#: modules/computer.c:287
+#: modules/computer.c:329
 #, c-format
 msgid "Detecting version: %s"
 msgstr ""
 
-#: modules/computer.c:304
+#: modules/computer.c:347
 msgid "Program"
 msgstr "Programm"
 
-#: modules/computer.c:324
+#: modules/computer.c:365
+msgid "Field"
+msgstr ""
+
+#: modules/computer.c:365 modules/computer.c:667 modules/computer/modules.c:149
+#: modules/computer/modules.c:150 modules/devices/arm/processor.c:470
+msgid "Description"
+msgstr "Beschreibung"
+
+#: modules/computer.c:365 modules/devices.c:726
+msgid "Value"
+msgstr ""
+
+#: modules/computer.c:385
 msgid "Single-board computer"
 msgstr ""
 
 #. /proc/apm
-#: modules/computer.c:373
+#: modules/computer.c:434
 msgid "Unknown physical machine type"
 msgstr ""
 
-#: modules/computer.c:393 modules/computer.c:394
+#: modules/computer.c:454 modules/computer.c:455
 msgid "Virtual (VMware)"
 msgstr ""
 
-#: modules/computer.c:396 modules/computer.c:397 modules/computer.c:398
-#: modules/computer.c:399
+#: modules/computer.c:457 modules/computer.c:458 modules/computer.c:459
+#: modules/computer.c:460
 msgid "Virtual (QEMU)"
 msgstr ""
 
-#: modules/computer.c:401 modules/computer.c:402
+#: modules/computer.c:462 modules/computer.c:463
 msgid "Virtual (Unknown)"
 msgstr ""
 
-#: modules/computer.c:404 modules/computer.c:405 modules/computer.c:406
-#: modules/computer.c:427
+#: modules/computer.c:465 modules/computer.c:466 modules/computer.c:467
+#: modules/computer.c:488
 msgid "Virtual (VirtualBox)"
 msgstr ""
 
-#: modules/computer.c:408 modules/computer.c:409 modules/computer.c:410
-#: modules/computer.c:421
+#: modules/computer.c:469 modules/computer.c:470 modules/computer.c:471
+#: modules/computer.c:482
 msgid "Virtual (Xen)"
 msgstr ""
 
-#: modules/computer.c:412
+#: modules/computer.c:473
 msgid "Virtual (hypervisor present)"
 msgstr ""
 
-#: modules/computer.c:465 modules/computer.c:769
+#: modules/computer.c:528 modules/computer.c:953
 msgid "Computer"
 msgstr "Computer"
 
-#: modules/computer.c:466 modules/devices/alpha/processor.c:87
-#: modules/devices/arm/processor.c:327 modules/devices.c:98
-#: modules/devices/ia64/processor.c:159 modules/devices/m68k/processor.c:83
-#: modules/devices/mips/processor.c:74 modules/devices/parisc/processor.c:154
-#: modules/devices/ppc/processor.c:157 modules/devices/riscv/processor.c:181
-#: modules/devices/s390/processor.c:131 modules/devices/sh/processor.c:83
-#: modules/devices/sparc/processor.c:74 modules/devices/x86/processor.c:644
-msgid "Processor"
-msgstr "Prozessor"
-
-#: modules/computer.c:469
+#: modules/computer.c:532
 msgid "Machine Type"
 msgstr "Maschinen-Typ"
 
-#: modules/computer.c:472 modules/computer.c:508
+#: modules/computer.c:535 modules/computer.c:588
 msgid "User Name"
 msgstr "Benutzername"
 
-#: modules/computer.c:477
+#: modules/computer.c:540
 msgid "Resolution"
 msgstr "Auflösung"
 
-#: modules/computer.c:477 modules/computer.c:607
+#: modules/computer.c:540 modules/computer.c:748
 #, c-format
 msgid "%dx%d pixels"
 msgstr ""
 
-#: modules/computer.c:480
+#: modules/computer.c:543
 msgid "Session Display Server"
 msgstr ""
 
-#: modules/computer.c:485 modules/devices.c:106
+#: modules/computer.c:548 modules/devices.c:108
 msgid "Input Devices"
 msgstr "Eingabegeräte"
 
-#: modules/computer.c:500
+#: modules/computer.c:572
 msgid "Kernel"
 msgstr ""
 
-#: modules/computer.c:502
+#: modules/computer.c:573
+msgid "Command Line"
+msgstr ""
+
+#: modules/computer.c:575
 msgid "C Library"
 msgstr "C-Library"
 
-#: modules/computer.c:503
+#: modules/computer.c:576
 msgid "Distribution"
 msgstr ""
 
-#: modules/computer.c:506
+#: modules/computer.c:582
+msgid "Spin/Flavor"
+msgstr ""
+
+#: modules/computer.c:586
 msgid "Current Session"
 msgstr "Aktuelle Sitzung"
 
-#: modules/computer.c:507
+#: modules/computer.c:587
 msgid "Computer Name"
 msgstr "Computername"
 
-#: modules/computer.c:509 modules/computer/languages.c:108
+#: modules/computer.c:589 modules/computer/languages.c:99
 msgid "Language"
 msgstr "Sprache"
 
-#: modules/computer.c:510 modules/computer/users.c:50
+#: modules/computer.c:590 modules/computer/users.c:50
 msgid "Home Directory"
 msgstr "Stammverzeichnis"
 
-#: modules/computer.c:513
+#: modules/computer.c:591
+msgid "Desktop Environment"
+msgstr "Desktop-Umgebung"
+
+#: modules/computer.c:594
 msgid "Misc"
 msgstr "Verschiedenes"
 
-#: modules/computer.c:526
-msgid "Loaded Modules"
-msgstr "Geladene Module"
-
-#: modules/computer.c:529 modules/computer/modules.c:145
-#: modules/computer/modules.c:147 modules/devices/arm/processor.c:448
-#: modules/devices.c:575
-msgid "Description"
-msgstr "Beschreibung"
-
-#: modules/computer.c:542
-msgid "Date & Time"
-msgstr "Datum & Uhrzeit"
-
-#: modules/computer.c:543
-msgid "Kernel Version"
-msgstr "Kernel-Version"
-
-#: modules/computer.c:553
-msgid "Available Languages"
+#: modules/computer.c:607
+msgid "HardInfo"
 msgstr ""
 
-#: modules/computer.c:555
-msgid "Language Code"
-msgstr "Sprach-Code"
-
-#: modules/computer.c:567
-msgid "Mounted File Systems"
+#: modules/computer.c:608
+msgid "HardInfo running as"
 msgstr ""
 
-#: modules/computer.c:569 modules/computer/filesystem.c:85
-msgid "Mount Point"
-msgstr "Mount-Punkt"
-
-#: modules/computer.c:570
-msgid "Usage"
-msgstr "Verwendung"
-
-#: modules/computer.c:571 modules/devices/gpu.c:93 modules/devices/gpu.c:101
-#: modules/devices/gpu.c:187 modules/devices/pci.c:70 modules/devices/pci.c:78
-#: modules/devices/pci.c:122 modules/devices/usb.c:72
-msgid "Device"
-msgstr "Gerät"
-
-#: modules/computer.c:590
-msgid "Session"
+#: modules/computer.c:609
+msgid "Superuser"
 msgstr ""
 
-#: modules/computer.c:591 modules/devices.c:614 modules/devices/dmi.c:53
-#: modules/devices/inputdevices.c:117
-msgid "Type"
+#: modules/computer.c:609
+msgid "User"
 msgstr ""
 
-#: modules/computer.c:594
-msgid "Wayland"
+#: modules/computer.c:613
+msgid "Health"
 msgstr ""
 
-#: modules/computer.c:595 modules/computer.c:600
-msgid "Current Display Name"
+#: modules/computer.c:614
+msgid "Available entropy in /dev/random"
 msgstr ""
 
-#: modules/computer.c:599
-msgid "X Server"
+#: modules/computer.c:618
+msgid "Hardening Features"
 msgstr ""
 
-#: modules/computer.c:601 modules/computer.c:641 modules/devices/dmi.c:39
-#: modules/devices/dmi.c:43 modules/devices/dmi.c:47 modules/devices/dmi.c:52
-#: modules/devices/gpu.c:92 modules/devices/gpu.c:100 modules/devices/gpu.c:186
-#: modules/devices/ia64/processor.c:161 modules/devices/inputdevices.c:119
-#: modules/devices/pci.c:69 modules/devices/pci.c:77 modules/devices/usb.c:64
-#: modules/devices/x86/processor.c:651
-msgid "Vendor"
-msgstr "Hersteller"
-
-#: modules/computer.c:603
-msgid "Release Number"
-msgstr ""
-
-#: modules/computer.c:611
-msgid "Screens"
-msgstr ""
-
-#: modules/computer.c:617
-msgid "Disconnected"
+#: modules/computer.c:619
+msgid "ASLR"
 msgstr ""
 
 #: modules/computer.c:620
+msgid "dmesg"
+msgstr ""
+
+#: modules/computer.c:624
+msgid "Linux Security Modules"
+msgstr ""
+
+#: modules/computer.c:625
+msgid "Modules available"
+msgstr ""
+
+#: modules/computer.c:626
+msgid "SELinux status"
+msgstr ""
+
+#: modules/computer.c:632
+msgid "CPU Vulnerabilities"
+msgstr ""
+
+#: modules/computer.c:664
+msgid "Loaded Modules"
+msgstr "Geladene Module"
+
+#: modules/computer.c:680
+msgid "Date & Time"
+msgstr "Datum & Uhrzeit"
+
+#: modules/computer.c:681
+msgid "Kernel Version"
+msgstr "Kernel-Version"
+
+#: modules/computer.c:691
+msgid "Available Languages"
+msgstr ""
+
+#: modules/computer.c:693
+msgid "Language Code"
+msgstr "Sprach-Code"
+
+#: modules/computer.c:705
+msgid "Mounted File Systems"
+msgstr ""
+
+#: modules/computer.c:707 modules/computer/filesystem.c:85
+msgid "Mount Point"
+msgstr "Mount-Punkt"
+
+#: modules/computer.c:708
+msgid "Usage"
+msgstr "Verwendung"
+
+#: modules/computer.c:709 modules/devices/gpu.c:75 modules/devices/gpu.c:83
+#: modules/devices/gpu.c:225 modules/devices/pci.c:88 modules/devices/pci.c:96
+#: modules/devices/pci.c:140 modules/devices/usb.c:169
+#: modules/devices/usb.c:181
+msgid "Device"
+msgstr "Gerät"
+
+#: modules/computer.c:731
+msgid "Session"
+msgstr ""
+
+#: modules/computer.c:732 modules/devices.c:726 modules/devices/dmi.c:55
+#: modules/devices/dmi_memory.c:603 modules/devices/dmi_memory.c:749
+#: modules/devices/inputdevices.c:112 modules/devices/x86/processor.c:714
+msgid "Type"
+msgstr ""
+
+#: modules/computer.c:735
+msgid "Wayland"
+msgstr ""
+
+#: modules/computer.c:736 modules/computer.c:741
+msgid "Current Display Name"
+msgstr ""
+
+#: modules/computer.c:740
+msgid "X Server"
+msgstr ""
+
+#: modules/computer.c:742 modules/computer.c:782 modules/devices/dmi.c:39
+#: modules/devices/dmi.c:45 modules/devices/dmi.c:49 modules/devices/dmi.c:54
+#: modules/devices/dmi_memory.c:750 modules/devices/dmi_memory.c:895
+#: modules/devices/firmware.c:105 modules/devices/firmware.c:168
+#: modules/devices/firmware.c:190 modules/devices/firmware.c:228
+#: modules/devices/gpu.c:74 modules/devices/gpu.c:82 modules/devices/gpu.c:224
+#: modules/devices/ia64/processor.c:161 modules/devices/inputdevices.c:114
+#: modules/devices/monitors.c:398 modules/devices/pci.c:87
+#: modules/devices/pci.c:95 modules/devices/usb.c:168
+#: modules/devices/x86/processor.c:653
+msgid "Vendor"
+msgstr "Hersteller"
+
+#: modules/computer.c:744
+msgid "Release Number"
+msgstr ""
+
+#: modules/computer.c:752
+msgid "Screens"
+msgstr ""
+
+#: modules/computer.c:758
+msgid "Disconnected"
+msgstr ""
+
+#: modules/computer.c:761
 msgid "Connected"
 msgstr ""
 
-#: modules/computer.c:624 modules/computer/os.c:78 modules/computer/os.c:234
-#: modules/computer/os.c:392 modules/devices.c:344 modules/devices.c:396
-#: modules/devices/printers.c:99 modules/devices/printers.c:106
-#: modules/devices/printers.c:116 modules/devices/printers.c:131
-#: modules/devices/printers.c:140 modules/devices/printers.c:243
-msgid "Unknown"
-msgstr ""
-
-#: modules/computer.c:628
+#: modules/computer.c:769
 msgid "Unused"
 msgstr ""
 
-#: modules/computer.c:629
+#: modules/computer.c:770
 #, c-format
 msgid "%dx%d pixels, offset (%d, %d)"
 msgstr ""
 
-#: modules/computer.c:638
+#: modules/computer.c:779
 msgid "Outputs (XRandR)"
 msgstr ""
 
-#: modules/computer.c:640
+#: modules/computer.c:781
 msgid "OpenGL (GLX)"
 msgstr ""
 
-#: modules/computer.c:642
+#: modules/computer.c:783
 msgid "Renderer"
 msgstr ""
 
-#: modules/computer.c:643
+#: modules/computer.c:784
 msgid "Direct Rendering"
 msgstr "Direct-Rendering"
 
-#: modules/computer.c:645
+#: modules/computer.c:786
 msgid "Version (Compatibility)"
 msgstr ""
 
-#: modules/computer.c:646
+#: modules/computer.c:787
 msgid "Shading Language Version (Compatibility)"
 msgstr ""
 
-#: modules/computer.c:647
+#: modules/computer.c:788
 msgid "Version (Core)"
 msgstr ""
 
-#: modules/computer.c:648
+#: modules/computer.c:789
 msgid "Shading Language Version (Core)"
 msgstr ""
 
-#: modules/computer.c:649
+#: modules/computer.c:790
 msgid "Version (ES)"
 msgstr ""
 
-#: modules/computer.c:650
+#: modules/computer.c:791
 msgid "Shading Language Version (ES)"
 msgstr ""
 
-#: modules/computer.c:651
+#: modules/computer.c:792
 msgid "GLX Version"
 msgstr ""
 
-#: modules/computer.c:672
+#: modules/computer.c:813
 msgid "Group"
 msgstr ""
 
-#: modules/computer.c:675 modules/computer/users.c:49
+#: modules/computer.c:816 modules/computer/users.c:49
 msgid "Group ID"
 msgstr "Gruppen-ID"
 
-#: modules/computer.c:811
-msgid "RAM"
+#. / <value> <unit> "usable memory"
+#: modules/computer.c:909
+#, c-format
+msgid "%0.1f %s available to Linux"
 msgstr ""
 
-#: modules/computer.c:811 modules/devices/devicetree/pmac_data.c:82
+#: modules/computer.c:911 modules/devices/dmi_memory.c:661
+#: modules/devices/dmi_memory.c:809 modules/devices/dmi_memory.c:936
+msgid "GiB"
+msgstr ""
+
+#: modules/computer.c:913 modules/devices/dmi_memory.c:581
+#: modules/devices/dmi_memory.c:663 modules/devices/dmi_memory.c:723
+#: modules/devices/dmi_memory.c:811 modules/devices/dmi_memory.c:857
+#: modules/devices/dmi_memory.c:938 modules/network/net.c:395
+#: modules/network/net.c:417 modules/network/net.c:418
+msgid "MiB"
+msgstr ""
+
+#: modules/computer.c:915 modules/computer/memory_usage.c:77
+#: modules/computer/modules.c:149
+msgid "KiB"
+msgstr ""
+
+#: modules/computer.c:972 modules/devices/devicetree/pmac_data.c:82
 msgid "Motherboard"
 msgstr ""
 
-#: modules/computer.c:811
+#: modules/computer.c:1000
 msgid "Graphics"
 msgstr ""
 
-#: modules/computer.c:812 modules/devices.c:107
+#: modules/computer.c:1001 modules/devices.c:109
 msgid "Storage"
 msgstr "Speicher"
 
-#: modules/computer.c:812 modules/devices.c:103
+#: modules/computer.c:1001 modules/devices.c:105
 msgid "Printers"
 msgstr "Drucker"
 
-#: modules/computer.c:812
+#: modules/computer.c:1001
 msgid "Audio"
 msgstr ""
 
-#: modules/computer.c:857
+#: modules/computer.c:1050
 msgid "Gathers high-level computer information"
 msgstr "Sammelt high-level Computer-Informationen"
 
@@ -1505,7 +1957,9 @@ msgstr ""
 msgid "Read-Only"
 msgstr ""
 
-#: modules/computer/filesystem.c:86 modules/devices/spd-decode.c:1510
+#: modules/computer/filesystem.c:86 modules/devices/dmi_memory.c:609
+#: modules/devices/dmi_memory.c:754 modules/devices/dmi_memory.c:786
+#: modules/devices/dmi_memory.c:825 modules/devices/dmi_memory.c:894
 msgid "Size"
 msgstr ""
 
@@ -1517,37 +1971,32 @@ msgstr ""
 msgid "Available"
 msgstr ""
 
-#: modules/computer/languages.c:103
+#: modules/computer/languages.c:94
 msgid "Locale Information"
 msgstr ""
 
-#: modules/computer/languages.c:105
+#: modules/computer/languages.c:96 modules/devices/dmi_memory.c:599
+#: modules/devices/gpu.c:204
 msgid "Source"
 msgstr ""
 
-#: modules/computer/languages.c:106
+#: modules/computer/languages.c:97
 msgid "Address"
 msgstr ""
 
-#: modules/computer/languages.c:107
+#: modules/computer/languages.c:98
 msgid "E-mail"
 msgstr ""
 
-#: modules/computer/languages.c:109
+#: modules/computer/languages.c:100
 msgid "Territory"
 msgstr ""
 
-#: modules/computer/languages.c:110 modules/devices/arm/processor.c:341
-#: modules/devices/gpu.c:146 modules/devices/ia64/processor.c:166
-#: modules/devices/pci.c:114 modules/devices/ppc/processor.c:159
-msgid "Revision"
-msgstr ""
-
-#: modules/computer/languages.c:111 modules/devices/dmi.c:42
+#: modules/computer/languages.c:102 modules/devices/dmi.c:44
 msgid "Date"
 msgstr ""
 
-#: modules/computer/languages.c:112
+#: modules/computer/languages.c:103
 msgid "Codeset"
 msgstr ""
 
@@ -1555,105 +2004,187 @@ msgstr ""
 msgid "Couldn't obtain load average"
 msgstr ""
 
-#: modules/computer/modules.c:125 modules/computer/modules.c:126
-#: modules/computer/modules.c:127 modules/computer/modules.c:128
-#: modules/computer/modules.c:129 modules/devices/dmi.c:115
+#: modules/computer/memory_usage.c:106
+msgid "Total Memory"
+msgstr ""
+
+#: modules/computer/memory_usage.c:107
+msgid "Free Memory"
+msgstr ""
+
+#: modules/computer/memory_usage.c:108
+msgid "Cached Swap"
+msgstr ""
+
+#: modules/computer/memory_usage.c:109
+msgid "High Memory"
+msgstr ""
+
+#: modules/computer/memory_usage.c:110
+msgid "Free High Memory"
+msgstr ""
+
+#: modules/computer/memory_usage.c:111
+msgid "Low Memory"
+msgstr ""
+
+#: modules/computer/memory_usage.c:112
+msgid "Free Low Memory"
+msgstr ""
+
+#: modules/computer/memory_usage.c:113
+msgid "Virtual Memory"
+msgstr ""
+
+#: modules/computer/memory_usage.c:114
+msgid "Free Virtual Memory"
+msgstr ""
+
+#: modules/computer/modules.c:117 modules/computer/modules.c:118
+#: modules/computer/modules.c:119 modules/computer/modules.c:120
+#: modules/computer/modules.c:121 modules/computer/modules.c:122
+#: modules/devices/dmi.c:111 modules/devices/dmi_memory.c:881
+#: modules/devices/firmware.c:246 modules/devices/x86/processor.c:693
 msgid "(Not available)"
 msgstr ""
 
-#: modules/computer/modules.c:142
+#: modules/computer/modules.c:148
 msgid "Module Information"
 msgstr ""
 
-#: modules/computer/modules.c:143
+#: modules/computer/modules.c:148 modules/devices/gpu.c:230
 msgid "Path"
 msgstr ""
 
-#: modules/computer/modules.c:144
+#: modules/computer/modules.c:148
 msgid "Used Memory"
 msgstr ""
 
-#: modules/computer/modules.c:144 modules/devices/devmemory.c:72
-msgid "KiB"
-msgstr ""
-
-#: modules/computer/modules.c:148
+#: modules/computer/modules.c:150
 msgid "Version Magic"
 msgstr ""
 
-#: modules/computer/modules.c:149
+#: modules/computer/modules.c:151
+msgid "In Linus' Tree"
+msgstr ""
+
+#: modules/computer/modules.c:152
+msgid "Retpoline Enabled"
+msgstr ""
+
+#: modules/computer/modules.c:152
 msgid "Copyright"
 msgstr ""
 
-#: modules/computer/modules.c:150
+#: modules/computer/modules.c:152
 msgid "Author"
 msgstr ""
 
-#: modules/computer/modules.c:151
+#: modules/computer/modules.c:153
 msgid "License"
 msgstr ""
 
-#: modules/computer/modules.c:158
+#: modules/computer/modules.c:159
 msgid "Dependencies"
 msgstr ""
 
-#: modules/computer/os.c:35 modules/computer/os.c:36 modules/computer/os.c:37
-#: modules/computer/os.c:38
+#: modules/computer/os.c:36 modules/computer/os.c:37 modules/computer/os.c:38
+#: modules/computer/os.c:39
 msgid "GNU C Library"
 msgstr ""
 
-#: modules/computer/os.c:39
+#: modules/computer/os.c:40
 msgid "uClibc or uClibc-ng"
 msgstr ""
 
-#: modules/computer/os.c:40
+#: modules/computer/os.c:41
 msgid "diet libc"
 msgstr ""
 
-#: modules/computer/os.c:112 modules/computer/os.c:115
+#: modules/computer/os.c:113 modules/computer/os.c:116
 msgid "GNOME Shell "
 msgstr ""
 
-#: modules/computer/os.c:123 modules/computer/os.c:126
+#: modules/computer/os.c:124 modules/computer/os.c:127
 msgid "Version: "
 msgstr ""
 
-#: modules/computer/os.c:157
+#: modules/computer/os.c:146 modules/computer/os.c:149
+msgid "MATE Desktop Environment "
+msgstr ""
+
+#: modules/computer/os.c:180
 #, c-format
 msgid "Unknown (Window Manager: %s)"
 msgstr ""
 
 #. /{desktop environment} on {session type}
-#: modules/computer/os.c:168
+#: modules/computer/os.c:191
 #, c-format
 msgid "%s on %s"
 msgstr ""
 
-#: modules/computer/os.c:232
+#: modules/computer/os.c:261
 msgid "Terminal"
 msgstr ""
 
+#: modules/computer/os.c:278
+msgid "User access allowed"
+msgstr ""
+
+#: modules/computer/os.c:280
+msgid "User access forbidden"
+msgstr ""
+
+#: modules/computer/os.c:282
+msgid "Access allowed (running as superuser)"
+msgstr ""
+
+#: modules/computer/os.c:284
+msgid "Access forbidden? (running as superuser)"
+msgstr ""
+
+#: modules/computer/os.c:294 modules/computer/os.c:560
+msgid "Disabled"
+msgstr ""
+
+#: modules/computer/os.c:296
+msgid "Partially enabled (mmap base+stack+VDSO base)"
+msgstr ""
+
+#: modules/computer/os.c:298
+msgid "Fully enabled (mmap base+stack+VDSO base+heap)"
+msgstr ""
+
 #. /bits of entropy for rng (0)
-#: modules/computer/os.c:241
+#: modules/computer/os.c:308
 msgid "(None or not available)"
 msgstr ""
 
 #. /bits of entropy for rng (low/poor value)
-#: modules/computer/os.c:242
+#: modules/computer/os.c:309
 #, c-format
 msgid "%d bits (low)"
 msgstr ""
 
 #. /bits of entropy for rng (medium value)
-#: modules/computer/os.c:243
+#: modules/computer/os.c:310
 #, c-format
 msgid "%d bits (medium)"
 msgstr ""
 
 #. /bits of entropy for rng (high/good value)
-#: modules/computer/os.c:244
+#: modules/computer/os.c:311
 #, c-format
 msgid "%d bits (healthy)"
+msgstr ""
+
+#: modules/computer/os.c:555
+msgid "Not installed"
+msgstr ""
+
+#: modules/computer/os.c:558
+msgid "Enabled"
 msgstr ""
 
 #: modules/computer/users.c:47
@@ -1668,13 +2199,13 @@ msgstr ""
 msgid "Default Shell"
 msgstr ""
 
-#: modules/devices/alpha/processor.c:88 modules/devices/devicetree.c:161
-#: modules/devices/devicetree.c:207 modules/devices/devicetree/pmac_data.c:80
-#: modules/devices/gpu.c:124 modules/devices/ia64/processor.c:165
+#: modules/devices/alpha/processor.c:88 modules/devices/devicetree.c:163
+#: modules/devices/devicetree.c:209 modules/devices/devicetree/pmac_data.c:80
+#: modules/devices/gpu.c:106 modules/devices/ia64/processor.c:165
 #: modules/devices/m68k/processor.c:84 modules/devices/mips/processor.c:75
-#: modules/devices/parisc/processor.c:155 modules/devices/ppc/processor.c:158
-#: modules/devices/riscv/processor.c:182 modules/devices/s390/processor.c:132
-#: modules/devices/spd-decode.c:1510
+#: modules/devices/monitors.c:400 modules/devices/parisc/processor.c:155
+#: modules/devices/ppc/processor.c:158 modules/devices/riscv/processor.c:182
+#: modules/devices/s390/processor.c:132
 msgid "Model"
 msgstr ""
 
@@ -1682,28 +2213,28 @@ msgstr ""
 msgid "Platform String"
 msgstr ""
 
-#: modules/devices/alpha/processor.c:90 modules/devices/arm/processor.c:331
+#: modules/devices/alpha/processor.c:90 modules/devices/arm/processor.c:345
 #: modules/devices/ia64/processor.c:167 modules/devices/m68k/processor.c:87
 #: modules/devices/mips/processor.c:77 modules/devices/parisc/processor.c:158
 #: modules/devices/ppc/processor.c:160 modules/devices/riscv/processor.c:186
-#: modules/devices/sh/processor.c:87 modules/devices/x86/processor.c:655
+#: modules/devices/sh/processor.c:87 modules/devices/x86/processor.c:657
 msgid "Frequency"
 msgstr "Taktfrequenz"
 
-#: modules/devices/alpha/processor.c:91 modules/devices/arm/processor.c:332
+#: modules/devices/alpha/processor.c:91 modules/devices/arm/processor.c:346
 #: modules/devices/ia64/processor.c:168 modules/devices/m68k/processor.c:88
 #: modules/devices/mips/processor.c:78 modules/devices/parisc/processor.c:159
 #: modules/devices/ppc/processor.c:161 modules/devices/s390/processor.c:134
-#: modules/devices/sh/processor.c:90 modules/devices/x86/processor.c:656
+#: modules/devices/sh/processor.c:90 modules/devices/x86/processor.c:658
 msgid "BogoMips"
 msgstr ""
 
-#: modules/devices/alpha/processor.c:92 modules/devices/arm/processor.c:333
+#: modules/devices/alpha/processor.c:92 modules/devices/arm/processor.c:347
 #: modules/devices/ia64/processor.c:169 modules/devices/m68k/processor.c:89
 #: modules/devices/mips/processor.c:79 modules/devices/parisc/processor.c:160
 #: modules/devices/ppc/processor.c:162 modules/devices/riscv/processor.c:187
 #: modules/devices/s390/processor.c:135 modules/devices/sh/processor.c:91
-#: modules/devices/sparc/processor.c:77 modules/devices/x86/processor.c:657
+#: modules/devices/sparc/processor.c:77 modules/devices/x86/processor.c:659
 msgid "Byte Order"
 msgstr "Byte-Reihenfolge"
 
@@ -1877,76 +2408,77 @@ msgctxt "arm-flag"
 msgid "Advanced SIMD/NEON on AArch64 (arch>8)"
 msgstr ""
 
-#: modules/devices/arm/processor.c:142
+#: modules/devices/arm/processor.c:143
 msgid "ARM Processor"
 msgstr "ARM Prozessor"
 
-#: modules/devices/arm/processor.c:200 modules/devices/riscv/processor.c:147
-#: modules/devices/x86/processor.c:606
+#: modules/devices/arm/processor.c:214 modules/devices/riscv/processor.c:147
+#: modules/devices/x86/processor.c:608
 msgid "Empty List"
 msgstr ""
 
-#: modules/devices/arm/processor.c:226 modules/devices/x86/processor.c:268
+#: modules/devices/arm/processor.c:240 modules/devices/gpu.c:148
+#: modules/devices/gpu.c:226 modules/devices/x86/processor.c:268
 msgid "Clocks"
 msgstr ""
 
-#: modules/devices/arm/processor.c:272 modules/devices/arm/processor.c:285
+#: modules/devices/arm/processor.c:286 modules/devices/arm/processor.c:299
 #: modules/devices/x86/processor.c:314 modules/devices/x86/processor.c:327
 #, c-format
 msgid "%.2f-%.2f %s=%dx\n"
 msgstr ""
 
-#: modules/devices/arm/processor.c:328
+#: modules/devices/arm/processor.c:342
 msgid "Linux Name"
 msgstr ""
 
-#: modules/devices/arm/processor.c:329
+#: modules/devices/arm/processor.c:343
 msgid "Decoded Name"
 msgstr ""
 
-#: modules/devices/arm/processor.c:330 modules/network/net.c:453
+#: modules/devices/arm/processor.c:344 modules/network/net.c:453
 msgid "Mode"
 msgstr ""
 
-#: modules/devices/arm/processor.c:336
+#: modules/devices/arm/processor.c:350
 msgid "ARM"
 msgstr ""
 
-#: modules/devices/arm/processor.c:337
+#: modules/devices/arm/processor.c:351
 msgid "Implementer"
 msgstr ""
 
-#: modules/devices/arm/processor.c:338
+#: modules/devices/arm/processor.c:352 modules/devices/dmi_memory.c:896
 msgid "Part"
 msgstr ""
 
-#: modules/devices/arm/processor.c:339 modules/devices/ia64/processor.c:162
+#: modules/devices/arm/processor.c:353 modules/devices/ia64/processor.c:162
 #: modules/devices/parisc/processor.c:156 modules/devices/riscv/processor.c:183
 msgid "Architecture"
 msgstr ""
 
-#: modules/devices/arm/processor.c:340
+#: modules/devices/arm/processor.c:354
 msgid "Variant"
 msgstr ""
 
-#: modules/devices/arm/processor.c:342 modules/devices/riscv/processor.c:190
-#: modules/devices/sparc/processor.c:78 modules/devices/x86/processor.c:663
+#: modules/devices/arm/processor.c:356 modules/devices/riscv/processor.c:190
+#: modules/devices/sparc/processor.c:78 modules/devices/x86/processor.c:665
 msgid "Capabilities"
 msgstr "Fähigkeiten"
 
-#: modules/devices/arm/processor.c:446
+#: modules/devices/arm/processor.c:468
 msgid "SOC/Package"
 msgstr ""
 
-#: modules/devices/arm/processor.c:450 modules/devices/x86/processor.c:698
+#: modules/devices/arm/processor.c:472 modules/devices/x86/processor.c:751
 msgid "Logical CPU Config"
 msgstr ""
 
-#: modules/devices/arm/processor.c:467
+#: modules/devices/arm/processor.c:489
 msgid "SOC/Package Information"
 msgstr ""
 
-#: modules/devices/battery.c:181
+#: modules/devices/battery.c:178
 #, c-format
 msgid ""
 "\n"
@@ -1967,7 +2499,7 @@ msgstr ""
 "Modellnummer=%s\n"
 "Seriennummer=%s\n"
 
-#: modules/devices/battery.c:258
+#: modules/devices/battery.c:255
 #, c-format
 msgid ""
 "\n"
@@ -1988,7 +2520,7 @@ msgstr ""
 "Modellnummer=%s\n"
 "Seriennummer=%s\n"
 
-#: modules/devices/battery.c:346
+#: modules/devices/battery.c:343
 #, fuzzy, c-format
 msgid ""
 "\n"
@@ -2007,7 +2539,7 @@ msgstr ""
 "APM Driver-Version=%s\n"
 "APM BIOS-Version=%s\n"
 
-#: modules/devices/battery.c:358
+#: modules/devices/battery.c:355
 #, fuzzy, c-format
 msgid ""
 "\n"
@@ -2024,7 +2556,7 @@ msgstr ""
 "APM Driver-Version=%s\n"
 "APM BIOS-Version=%s\n"
 
-#: modules/devices/battery.c:385
+#: modules/devices/battery.c:382
 msgid ""
 "[No batteries]\n"
 "No batteries found on this system=\n"
@@ -2036,31 +2568,40 @@ msgstr ""
 msgid "Graphics Processors"
 msgstr ""
 
-#: modules/devices.c:101 modules/devices/pci.c:143
+#: modules/devices.c:101 modules/devices/monitors.c:445
+#: modules/devices/monitors.c:492
+msgid "Monitors"
+msgstr "Bildschirme"
+
+#: modules/devices.c:102 modules/devices/pci.c:163
 msgid "PCI Devices"
 msgstr "PCI-Geräte"
 
-#: modules/devices.c:102 modules/devices/usb.c:92
+#: modules/devices.c:103 modules/devices/usb.c:210
 msgid "USB Devices"
 msgstr "USB-Geräte"
 
 #: modules/devices.c:104
+msgid "Firmware"
+msgstr ""
+
+#: modules/devices.c:106
 msgid "Battery"
 msgstr "Akku"
 
-#: modules/devices.c:105
+#: modules/devices.c:107
 msgid "Sensors"
 msgstr "Sensoren"
 
-#: modules/devices.c:109
-msgid "DMI"
-msgstr "DMI"
-
 #: modules/devices.c:110
-msgid "Memory SPD"
-msgstr "Hauptspeicher (SPD)"
+msgid "System DMI"
+msgstr ""
 
-#: modules/devices.c:115
+#: modules/devices.c:111
+msgid "Memory Devices"
+msgstr ""
+
+#: modules/devices.c:113 modules/devices.c:115
 msgid "Device Tree"
 msgstr ""
 
@@ -2068,21 +2609,21 @@ msgstr ""
 msgid "Resources"
 msgstr "Ressourcen"
 
-#: modules/devices.c:162
+#: modules/devices.c:177
 #, c-format
 msgid "%d physical processor"
 msgid_plural "%d physical processors"
 msgstr[0] ""
 msgstr[1] ""
 
-#: modules/devices.c:163
+#: modules/devices.c:178
 #, c-format
 msgid "%d core"
 msgid_plural "%d cores"
 msgstr[0] ""
 msgstr[1] ""
 
-#: modules/devices.c:164
+#: modules/devices.c:179
 #, c-format
 msgid "%d thread"
 msgid_plural "%d threads"
@@ -2090,106 +2631,102 @@ msgstr[0] ""
 msgstr[1] ""
 
 #. /NP procs; NC cores; NT threads
-#: modules/devices.c:165
+#: modules/devices.c:180
 #, c-format
 msgid "%s; %s; %s"
 msgstr ""
 
-#: modules/devices.c:575
-msgid "Field"
-msgstr ""
-
-#: modules/devices.c:575 modules/devices.c:614
-msgid "Value"
-msgstr ""
-
-#: modules/devices.c:614
+#: modules/devices.c:726
 msgid "Sensor"
 msgstr ""
 
-#: modules/devices.c:661
+#: modules/devices.c:773 modules/devices/dmi_memory.c:826
 msgid "Devices"
 msgstr "Geräte"
 
-#: modules/devices.c:673
+#: modules/devices.c:785
 msgid "Update PCI ID listing"
 msgstr ""
 
-#: modules/devices.c:685
+#: modules/devices.c:797
 msgid "Update CPU feature database"
 msgstr ""
 
-#: modules/devices.c:713
+#: modules/devices.c:825
 msgid "Gathers information about hardware devices"
 msgstr "Sammelt Informationen über die Hardware-Geräte"
 
-#: modules/devices.c:732
+#: modules/devices.c:844
 msgid "Resource information requires superuser privileges"
 msgstr ""
 
-#: modules/devices/devicetree.c:50
+#: modules/devices.c:850
+msgid ""
+"Any NVMe storage devices present are not listed.\n"
+"<b><i>udisksd</i></b> is required for NVMe devices."
+msgstr ""
+
+#: modules/devices/devicetree.c:52
 msgid "Properties"
 msgstr ""
 
-#: modules/devices/devicetree.c:51
+#: modules/devices/devicetree.c:53
 msgid "Children"
 msgstr ""
 
-#: modules/devices/devicetree.c:87
+#: modules/devices/devicetree.c:89
 msgid "Node"
 msgstr ""
 
-#: modules/devices/devicetree.c:88
+#: modules/devices/devicetree.c:90
 msgid "Node Path"
 msgstr ""
 
-#: modules/devices/devicetree.c:89
+#: modules/devices/devicetree.c:91
 msgid "Alias"
 msgstr ""
 
-#: modules/devices/devicetree.c:89 modules/devices/devicetree.c:90
-msgid "(None)"
-msgstr ""
-
-#: modules/devices/devicetree.c:90
+#: modules/devices/devicetree.c:92
 msgid "Symbol"
 msgstr ""
 
-#: modules/devices/devicetree.c:143 modules/devices/devicetree/pmac_data.c:79
+#: modules/devices/devicetree.c:145 modules/devices/devicetree/pmac_data.c:79
 msgid "Platform"
 msgstr ""
 
-#: modules/devices/devicetree.c:144 modules/devices/devicetree.c:209
+#: modules/devices/devicetree.c:146 modules/devices/devicetree.c:211
+#: modules/devices/gpu.c:231
 msgid "Compatible"
 msgstr ""
 
-#: modules/devices/devicetree.c:145
+#: modules/devices/devicetree.c:147
 msgid "GPU-compatible"
 msgstr ""
 
-#: modules/devices/devicetree.c:160
+#: modules/devices/devicetree.c:162
 msgid "Raspberry Pi or Compatible"
 msgstr ""
 
-#: modules/devices/devicetree.c:162 modules/devices/devicetree.c:189
-#: modules/devices/devicetree.c:208 modules/devices/devicetree/rpi_data.c:161
-#: modules/devices/dmi.c:49 modules/devices/dmi.c:55
+#: modules/devices/devicetree.c:164 modules/devices/devicetree.c:191
+#: modules/devices/devicetree.c:210 modules/devices/devicetree/rpi_data.c:168
+#: modules/devices/dmi.c:41 modules/devices/dmi.c:51 modules/devices/dmi.c:57
+#: modules/devices/usb.c:178
 msgid "Serial Number"
 msgstr ""
 
-#: modules/devices/devicetree.c:163 modules/devices/devicetree/rpi_data.c:158
+#: modules/devices/devicetree.c:165 modules/devices/devicetree/rpi_data.c:165
 msgid "RCode"
 msgstr ""
 
-#: modules/devices/devicetree.c:163
+#: modules/devices/devicetree.c:165
 msgid "No revision code available; unable to lookup model details."
 msgstr ""
 
-#: modules/devices/devicetree.c:188
+#: modules/devices/devicetree.c:190
 msgid "More"
 msgstr ""
 
-#: modules/devices/devicetree.c:268
+#: modules/devices/devicetree.c:271
 msgid "Messages"
 msgstr ""
 
@@ -2213,87 +2750,51 @@ msgstr ""
 msgid "PMAC Generation"
 msgstr ""
 
-#: modules/devices/devicetree/rpi_data.c:153
-#: modules/devices/devicetree/rpi_data.c:154
+#: modules/devices/devicetree/rpi_data.c:160
+#: modules/devices/devicetree/rpi_data.c:161
 msgid "Raspberry Pi"
 msgstr ""
 
-#: modules/devices/devicetree/rpi_data.c:154
+#: modules/devices/devicetree/rpi_data.c:161
 msgid "Board Name"
 msgstr ""
 
-#: modules/devices/devicetree/rpi_data.c:155
+#: modules/devices/devicetree/rpi_data.c:162
 msgid "PCB Revision"
 msgstr ""
 
-#: modules/devices/devicetree/rpi_data.c:156
+#: modules/devices/devicetree/rpi_data.c:163
 msgid "Introduction"
 msgstr ""
 
-#: modules/devices/devicetree/rpi_data.c:157 modules/devices/spd-decode.c:1510
+#: modules/devices/devicetree/rpi_data.c:164 modules/devices/usb.c:170
 msgid "Manufacturer"
 msgstr ""
 
-#: modules/devices/devicetree/rpi_data.c:159
+#: modules/devices/devicetree/rpi_data.c:166
 msgid "SOC (spec)"
 msgstr ""
 
-#: modules/devices/devicetree/rpi_data.c:160
+#: modules/devices/devicetree/rpi_data.c:167
 msgid "Memory (spec)"
 msgstr ""
 
-#: modules/devices/devicetree/rpi_data.c:162
+#: modules/devices/devicetree/rpi_data.c:169
 msgid "Permanent overvolt bit"
 msgstr ""
 
-#: modules/devices/devicetree/rpi_data.c:162
+#: modules/devices/devicetree/rpi_data.c:169
 msgctxt "rpi-ov-bit"
 msgid "Set"
 msgstr ""
 
-#: modules/devices/devicetree/rpi_data.c:162
+#: modules/devices/devicetree/rpi_data.c:169
 msgctxt "rpi-ov-bit"
 msgid "Not set"
 msgstr ""
 
-#: modules/devices/devmemory.c:101
-msgid "Total Memory"
-msgstr ""
-
-#: modules/devices/devmemory.c:102
-msgid "Free Memory"
-msgstr ""
-
-#: modules/devices/devmemory.c:103
-msgid "Cached Swap"
-msgstr ""
-
-#: modules/devices/devmemory.c:104
-msgid "High Memory"
-msgstr ""
-
-#: modules/devices/devmemory.c:105
-msgid "Free High Memory"
-msgstr ""
-
-#: modules/devices/devmemory.c:106
-msgid "Low Memory"
-msgstr ""
-
-#: modules/devices/devmemory.c:107
-msgid "Free Low Memory"
-msgstr ""
-
-#: modules/devices/devmemory.c:108
-msgid "Virtual Memory"
-msgstr ""
-
-#: modules/devices/devmemory.c:109
-msgid "Free Virtual Memory"
-msgstr ""
-
-#: modules/devices/dmi.c:36 modules/devices/inputdevices.c:120
-#: modules/devices/usb.c:63
+#: modules/devices/dmi.c:36 modules/devices/inputdevices.c:115
+#: modules/devices/usb.c:167
 msgid "Product"
 msgstr ""
 
@@ -2302,90 +2803,402 @@ msgstr ""
 msgid "Family"
 msgstr ""
 
-#: modules/devices/dmi.c:41
+#: modules/devices/dmi.c:42
+msgid "SKU"
+msgstr ""
+
+#: modules/devices/dmi.c:43
 msgid "BIOS"
 msgstr ""
 
-#: modules/devices/dmi.c:50 modules/devices/dmi.c:56
+#: modules/devices/dmi.c:52 modules/devices/dmi.c:58
 msgid "Asset Tag"
 msgstr ""
 
-#: modules/devices/dmi.c:51
-msgid "Chassis"
-msgstr ""
-
-#: modules/devices/dmi.c:116
+#: modules/devices/dmi.c:115 modules/devices/dmi_memory.c:882
+#: modules/devices/x86/processor.c:694
 msgid "(Not available; Perhaps try running HardInfo as root.)"
 msgstr ""
 
-#: modules/devices/gpu.c:102 modules/devices/pci.c:79
+#: modules/devices/dmi.c:156
+msgid "DMI Unavailable"
+msgstr ""
+
+#: modules/devices/dmi.c:158
+msgid "DMI is not avaliable. Perhaps this platform does not provide DMI."
+msgstr ""
+
+#: modules/devices/dmi.c:159
+msgid "DMI is not available; Perhaps try running HardInfo as root."
+msgstr ""
+
+#: modules/devices/dmi_memory.c:598
+msgid "Serial Presence Detect (SPD)"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:601
+msgid "SPD Revision"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:602 modules/devices/dmi_memory.c:748
+msgid "Form Factor"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:604
+msgid "Module Vendor"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:606
+msgid "DRAM Vendor"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:608 modules/devices/dmi_memory.c:753
+msgid "Part Number"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:610
+msgid "Manufacturing Date (Week / Year)"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:644 modules/devices/dmi_memory.c:879
+msgid "Memory Device List"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:686
+msgid "Memory Array"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:687 modules/devices/x86/processor.c:713
+msgid "DMI Handle"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:688 modules/devices/dmi_memory.c:746
+#: modules/devices/dmi_memory.c:784 modules/devices/dmi_memory.c:893
+msgid "Locator"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:689
+msgid "Use"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:690
+msgid "Error Correction Type"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:691
+msgid "Size (Present / Max)"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:692
+msgid "Devices (Populated / Sockets)"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:693 modules/devices/dmi_memory.c:827
+msgid "Types Present"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:744 modules/devices/dmi_memory.c:782
+msgid "Memory Socket"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:745 modules/devices/dmi_memory.c:783
+msgid "DMI Handles (Array, Socket)"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:747 modules/devices/dmi_memory.c:785
+msgid "Bank Locator"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:755
+msgid "Rated Speed"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:756
+msgid "Configured Speed"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:757
+msgid "Data Width/Total Width"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:758
+msgid "Rank"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:759
+msgid "Minimum Voltage"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:760
+msgid "Maximum Voltage"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:761
+msgid "Configured Voltage"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:786 modules/devices/dmi_memory.c:793
+#: modules/devices/monitors.c:492
+msgid "(Empty)"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:824
+msgid "Serial Presence Detect (SPD) Summary"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:947
+msgid " <b><i>dmidecode</i></b> utility available"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:948
+msgid " ... <i>and</i> HardInfo running with superuser privileges"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:949
+msgid " <b><i>eeprom</i></b> module loaded (for SDR, DDR, DDR2, DDR3)"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:950
+msgid ""
+" ... <i>or</i> <b><i>ee1004</i></b> module loaded <b>and configured!</b> "
+"(for DDR4)"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:961
+msgid "Memory information requires <b>one or both</b> of the following:"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:982
+msgid ""
+"\"More often than not, information contained in the DMI tables is "
+"inaccurate,\n"
+"incomplete or simply wrong.\" -<i><b>dmidecode</b></i> manual page"
+msgstr ""
+
+#: modules/devices/firmware.c:69
+msgid "Device cannot be removed easily"
+msgstr ""
+
+#: modules/devices/firmware.c:70
+msgid "Device is updatable in this or any other mode"
+msgstr ""
+
+#: modules/devices/firmware.c:71
+msgid "Update can only be done from offline mode"
+msgstr ""
+
+#: modules/devices/firmware.c:72
+msgid "Requires AC power"
+msgstr ""
+
+#: modules/devices/firmware.c:73
+msgid "Is locked and can be unlocked"
+msgstr ""
+
+#: modules/devices/firmware.c:74
+msgid "Is found in current metadata"
+msgstr ""
+
+#: modules/devices/firmware.c:75
+msgid "Requires a bootloader mode to be manually enabled by the user"
+msgstr ""
+
+#: modules/devices/firmware.c:76
+msgid "Has been registered with other plugins"
+msgstr ""
+
+#: modules/devices/firmware.c:77
+msgid "Requires a reboot to apply firmware or to reload hardware"
+msgstr ""
+
+#: modules/devices/firmware.c:78
+msgid "Requires system shutdown to apply firmware"
+msgstr ""
+
+#: modules/devices/firmware.c:79
+msgid "Has been reported to a metadata server"
+msgstr ""
+
+#: modules/devices/firmware.c:80
+msgid "User has been notified"
+msgstr ""
+
+#: modules/devices/firmware.c:81
+msgid "Always use the runtime version rather than the bootloader"
+msgstr ""
+
+#: modules/devices/firmware.c:82
+msgid "Install composite firmware on the parent before the child"
+msgstr ""
+
+#: modules/devices/firmware.c:83
+msgid "Is currently in bootloader mode"
+msgstr ""
+
+#: modules/devices/firmware.c:84
+msgid "The hardware is waiting to be replugged"
+msgstr ""
+
+#: modules/devices/firmware.c:85
+msgid "Ignore validation safety checks when flashing this device"
+msgstr ""
+
+#: modules/devices/firmware.c:86
+msgid "Requires the update to be retried with a new plugin"
+msgstr ""
+
+#: modules/devices/firmware.c:87
+msgid "Do not add instance IDs from the device baseclass"
+msgstr ""
+
+#: modules/devices/firmware.c:88
+msgid "Device update needs to be separately activated"
+msgstr ""
+
+#: modules/devices/firmware.c:89
+msgid ""
+"Ensure the version is a valid semantic version, e.g. numbers separated with "
+"dots"
+msgstr ""
+
+#: modules/devices/firmware.c:90
+msgid "Extra metadata can be exposed about this device"
+msgstr ""
+
+#: modules/devices/firmware.c:104
+msgid "DeviceId"
+msgstr ""
+
+#: modules/devices/firmware.c:104
+msgid "Guid"
+msgstr ""
+
+#: modules/devices/firmware.c:104
+msgid "Plugin"
+msgstr ""
+
+#: modules/devices/firmware.c:104 modules/network.c:380
+msgid "Flags"
+msgstr ""
+
+#: modules/devices/firmware.c:105
+msgid "VendorId"
+msgstr ""
+
+#: modules/devices/firmware.c:105
+msgid "VersionBootloader"
+msgstr ""
+
+#: modules/devices/firmware.c:106
+msgid "Icon"
+msgstr ""
+
+#: modules/devices/firmware.c:106
+msgid "InstallDuration"
+msgstr ""
+
+#: modules/devices/firmware.c:106
+msgid "Created"
+msgstr ""
+
+#: modules/devices/firmware.c:245
+msgid "Firmware List"
+msgstr ""
+
+#: modules/devices/firmware.c:258
+msgid "Requires the <i><b>fwupdmgr</b></i> utility."
+msgstr ""
+
+#: modules/devices/gpu.c:84 modules/devices/pci.c:97
 msgid "SVendor"
 msgstr ""
 
-#: modules/devices/gpu.c:103 modules/devices/pci.c:80
+#: modules/devices/gpu.c:85 modules/devices/pci.c:98
 msgid "SDevice"
 msgstr ""
 
-#: modules/devices/gpu.c:111 modules/devices/pci.c:90
+#: modules/devices/gpu.c:93 modules/devices/pci.c:108
 msgid "PCI Express"
 msgstr ""
 
-#: modules/devices/gpu.c:112 modules/devices/pci.c:92
+#: modules/devices/gpu.c:94 modules/devices/pci.c:110
 msgid "Maximum Link Width"
 msgstr ""
 
-#: modules/devices/gpu.c:113 modules/devices/pci.c:94
+#: modules/devices/gpu.c:95 modules/devices/pci.c:112
 msgid "Maximum Link Speed"
 msgstr ""
 
-#: modules/devices/gpu.c:113 modules/devices/pci.c:93 modules/devices/pci.c:94
+#: modules/devices/gpu.c:95 modules/devices/pci.c:111 modules/devices/pci.c:112
 msgid "GT/s"
 msgstr ""
 
-#: modules/devices/gpu.c:123
+#: modules/devices/gpu.c:105
 msgid "NVIDIA"
 msgstr ""
 
-#: modules/devices/gpu.c:125
+#: modules/devices/gpu.c:107
 msgid "BIOS Version"
 msgstr ""
 
-#: modules/devices/gpu.c:126
+#: modules/devices/gpu.c:108
 msgid "UUID"
 msgstr ""
 
-#: modules/devices/gpu.c:141 modules/devices/gpu.c:183
-#: modules/devices/inputdevices.c:115 modules/devices/pci.c:111
-#: modules/devices/usb.c:62
+#: modules/devices/gpu.c:142 modules/devices/gpu.c:222
+#: modules/devices/inputdevices.c:110 modules/devices/pci.c:129
+#: modules/devices/usb.c:166
 msgid "Device Information"
 msgstr ""
 
-#: modules/devices/gpu.c:142 modules/devices/gpu.c:184
+#: modules/devices/gpu.c:143 modules/devices/gpu.c:223
 msgid "Location"
 msgstr ""
 
-#: modules/devices/gpu.c:143
+#: modules/devices/gpu.c:144
 msgid "DRM Device"
 msgstr ""
 
-#: modules/devices/gpu.c:144 modules/devices/pci.c:112 modules/devices/usb.c:67
+#: modules/devices/gpu.c:145 modules/devices/pci.c:130
+#: modules/devices/usb.c:133 modules/devices/usb.c:174
 msgid "Class"
 msgstr ""
 
-#: modules/devices/gpu.c:150 modules/devices/pci.c:117
+#: modules/devices/gpu.c:154 modules/devices/pci.c:135
 msgid "In Use"
 msgstr ""
 
-#: modules/devices/gpu.c:174
+#: modules/devices/gpu.c:185
 msgid "Unknown integrated GPU"
 msgstr ""
 
-#: modules/devices/gpu.c:185
-msgid "DT Compatibility"
+#: modules/devices/gpu.c:191
+msgid "clock-frequency property"
 msgstr ""
 
-#: modules/devices/gpu.c:201
+#: modules/devices/gpu.c:192
+msgid "Operating Points (OPPv1)"
+msgstr ""
+
+#: modules/devices/gpu.c:193
+msgid "Operating Points (OPPv2)"
+msgstr ""
+
+#: modules/devices/gpu.c:229
+msgid "Device Tree Node"
+msgstr ""
+
+#: modules/devices/gpu.c:232 modules/devices/monitors.c:471
+#: modules/network/net.c:454
+msgid "Status"
+msgstr ""
+
+#: modules/devices/gpu.c:249
 msgid "GPUs"
+msgstr ""
+
+#: modules/devices/gpu.c:273
+msgid "No GPU devices found"
 msgstr ""
 
 #: modules/devices/ia64/processor.c:108
@@ -2404,16 +3217,16 @@ msgstr ""
 msgid "Features"
 msgstr "Funktionen"
 
-#: modules/devices/inputdevices.c:118 modules/devices/pci.c:121
-#: modules/devices/usb.c:71
+#: modules/devices/inputdevices.c:113 modules/devices/pci.c:139
+#: modules/devices/usb.c:180
 msgid "Bus"
 msgstr ""
 
-#: modules/devices/inputdevices.c:124
+#: modules/devices/inputdevices.c:119
 msgid "Connected to"
 msgstr ""
 
-#: modules/devices/inputdevices.c:128
+#: modules/devices/inputdevices.c:123
 msgid "InfraRed port"
 msgstr ""
 
@@ -2433,12 +3246,156 @@ msgstr ""
 msgid "System Type"
 msgstr ""
 
-#: modules/devices/parisc/processor.c:107
-msgid "PA-RISC Processor"
+#: modules/devices/monitors.c:29 modules/devices/monitors.c:253
+#: modules/devices/monitors.c:346 modules/devices/spd-decode.c:595
+msgid "(Unspecified)"
 msgstr ""
 
-#: modules/devices/parisc/processor.c:157
-msgid "System"
+#: modules/devices/monitors.c:228
+#, c-format
+msgid "Week %d of %d"
+msgstr ""
+
+#: modules/devices/monitors.c:238
+msgid "Ok"
+msgstr ""
+
+#: modules/devices/monitors.c:238
+msgid "Fail"
+msgstr ""
+
+#: modules/devices/monitors.c:266 modules/devices/monitors.c:274
+#: modules/devices/monitors.c:282 modules/devices/monitors.c:293
+#: modules/devices/monitors.c:301 modules/devices/monitors.c:308
+#: modules/devices/monitors.c:316 modules/devices/monitors.c:324
+#: modules/devices/monitors.c:332 modules/devices/monitors.c:338
+msgid "(Empty List)"
+msgstr ""
+
+#: modules/devices/monitors.c:390
+msgid "Signal Type"
+msgstr ""
+
+#: modules/devices/monitors.c:390
+msgid "Digital"
+msgstr ""
+
+#: modules/devices/monitors.c:390
+msgid "Analog"
+msgstr ""
+
+#: modules/devices/monitors.c:391 modules/devices/usb.c:132
+#: modules/network.c:310 modules/network.c:363 modules/network.c:380
+msgid "Interface"
+msgstr "Schnittstelle"
+
+#: modules/devices/monitors.c:392
+msgid "Bits per Color Channel"
+msgstr ""
+
+#: modules/devices/monitors.c:393
+msgid "Speaker Allocation"
+msgstr ""
+
+#: modules/devices/monitors.c:394
+msgid "Output (Max)"
+msgstr ""
+
+#: modules/devices/monitors.c:397
+msgid "EDID Device"
+msgstr ""
+
+#: modules/devices/monitors.c:401
+msgid "Serial"
+msgstr ""
+
+#: modules/devices/monitors.c:402
+msgid "Manufacture Date"
+msgstr ""
+
+#: modules/devices/monitors.c:403
+msgid "EDID Meta"
+msgstr ""
+
+#: modules/devices/monitors.c:404
+msgid "Data Size"
+msgstr ""
+
+#: modules/devices/monitors.c:404
+msgid "bytes"
+msgstr ""
+
+#: modules/devices/monitors.c:406
+msgid "Extension Blocks"
+msgstr ""
+
+#: modules/devices/monitors.c:407
+msgid "Extended to"
+msgstr ""
+
+#: modules/devices/monitors.c:408
+msgid "Checksum"
+msgstr ""
+
+#: modules/devices/monitors.c:409
+msgid "EDID Descriptors"
+msgstr ""
+
+#: modules/devices/monitors.c:410
+msgid "Detailed Timing Descriptors (DTD)"
+msgstr ""
+
+#: modules/devices/monitors.c:411
+msgid "Established Timings Bitmap (ETB)"
+msgstr ""
+
+#: modules/devices/monitors.c:412
+msgid "Standard Timings (STD)"
+msgstr ""
+
+#: modules/devices/monitors.c:413
+msgid "E-EDID Extension Blocks"
+msgstr ""
+
+#: modules/devices/monitors.c:414
+msgid "EIA/CEA-861 Data Blocks"
+msgstr ""
+
+#: modules/devices/monitors.c:415
+msgid "EIA/CEA-861 Short Audio Descriptors"
+msgstr ""
+
+#: modules/devices/monitors.c:416
+msgid "EIA/CEA-861 Short Video Descriptors"
+msgstr ""
+
+#: modules/devices/monitors.c:417
+msgid "DisplayID Timings"
+msgstr ""
+
+#: modules/devices/monitors.c:418
+msgid "DisplayID Strings"
+msgstr ""
+
+#: modules/devices/monitors.c:419
+msgid "Hex Dump"
+msgstr ""
+
+#: modules/devices/monitors.c:419
+msgid "Data"
+msgstr ""
+
+#: modules/devices/monitors.c:469 modules/devices/monitors.c:501
+#: modules/devices/pci.c:137 modules/devices/usb.c:179
+msgid "Connection"
+msgstr ""
+
+#: modules/devices/monitors.c:470
+msgid "DRM"
+msgstr ""
+
+#: modules/devices/parisc/processor.c:107
+msgid "PA-RISC Processor"
 msgstr ""
 
 #: modules/devices/parisc/processor.c:161
@@ -2449,31 +3406,23 @@ msgstr ""
 msgid "SVersion"
 msgstr ""
 
-#: modules/devices/parisc/processor.c:163 modules/devices/x86/processor.c:660
-msgid "Cache"
-msgstr ""
-
-#: modules/devices/pci.c:91
+#: modules/devices/pci.c:109
 msgid "Link Width"
 msgstr ""
 
-#: modules/devices/pci.c:93
+#: modules/devices/pci.c:111
 msgid "Link Speed"
 msgstr ""
 
-#: modules/devices/pci.c:119 modules/devices/usb.c:70
-msgid "Connection"
-msgstr ""
-
-#: modules/devices/pci.c:120
+#: modules/devices/pci.c:138
 msgid "Domain"
 msgstr ""
 
-#: modules/devices/pci.c:123
+#: modules/devices/pci.c:141
 msgid "Function"
 msgstr ""
 
-#: modules/devices/pci.c:161
+#: modules/devices/pci.c:185
 msgid "No PCI devices found"
 msgstr ""
 
@@ -2681,29 +3630,416 @@ msgstr ""
 msgid "Module Frequency"
 msgstr ""
 
-#: modules/devices/spd-decode.c:1475
+#: modules/devices/spd-decode.c:306
+msgid "Row address bits"
+msgstr ""
+
+#: modules/devices/spd-decode.c:307
+msgid "Column address bits"
+msgstr ""
+
+#: modules/devices/spd-decode.c:308
+msgid "Number of rows"
+msgstr ""
+
+#: modules/devices/spd-decode.c:309
+msgid "Data width"
+msgstr ""
+
+#: modules/devices/spd-decode.c:310
+msgid "Interface signal levels"
+msgstr ""
+
+#: modules/devices/spd-decode.c:311
+msgid "Configuration type"
+msgstr ""
+
+#: modules/devices/spd-decode.c:312
+msgid "Refresh"
+msgstr ""
+
+#: modules/devices/spd-decode.c:313 modules/devices/spd-decode.c:397
+#: modules/devices/spd-decode.c:492 modules/devices/spd-decode.c:617
+msgid "Timings"
+msgstr ""
+
+#: modules/devices/spd-decode.c:593
+msgid "Ranks"
+msgstr ""
+
+#: modules/devices/spd-decode.c:594
+msgid "IO Pins per Chip"
+msgstr ""
+
+#: modules/devices/spd-decode.c:595
+msgid "Die count"
+msgstr ""
+
+#: modules/devices/spd-decode.c:596
+msgid "Thermal Sensor"
+msgstr ""
+
+#: modules/devices/spd-decode.c:596
+msgid "Present"
+msgstr ""
+
+#: modules/devices/spd-decode.c:596
+msgid "Not present"
+msgstr ""
+
+#: modules/devices/spd-decode.c:597
+msgid "Supported Voltages"
+msgstr ""
+
+#: modules/devices/spd-decode.c:601
+msgid "Supported CAS Latencies"
+msgstr ""
+
+#: modules/devices/spd-decode.c:638
+msgid "Invalid"
+msgstr ""
+
+#: modules/devices/spd-decode.c:870
+msgid "XMP Profile"
+msgstr ""
+
+#: modules/devices/spd-decode.c:871 modules/devices/usb.c:173
+msgid "Speed"
+msgstr ""
+
+#: modules/devices/spd-decode.c:872 modules/devices/spd-decode.c:914
+#: modules/devices/x86/processor.c:715
+msgid "Voltage"
+msgstr ""
+
+#: modules/devices/spd-decode.c:873
+msgid "XMP Timings"
+msgstr ""
+
+#: modules/devices/spd-decode.c:915
+msgid "XMP"
+msgstr ""
+
+#: modules/devices/spd-decode.c:916
+msgid "JEDEC Timings"
+msgstr ""
+
+#: modules/devices/storage.c:84
+msgid "Read Error Rate"
+msgstr ""
+
+#: modules/devices/storage.c:85
+msgid "Throughput Performance"
+msgstr ""
+
+#: modules/devices/storage.c:86
+msgid "Spin-Up Time"
+msgstr ""
+
+#: modules/devices/storage.c:87
+msgid "Start/Stop Count"
+msgstr ""
+
+#: modules/devices/storage.c:88
+msgid "Reallocated Sector Count"
+msgstr ""
+
+#: modules/devices/storage.c:89
+msgid "Read Channel Margin"
+msgstr ""
+
+#: modules/devices/storage.c:90
+msgid "Seek Error Rate"
+msgstr ""
+
+#: modules/devices/storage.c:91
+msgid "Seek Timer Performance"
+msgstr ""
+
+#: modules/devices/storage.c:92 modules/devices/storage.c:131
+msgid "Power-On Hours"
+msgstr ""
+
+#: modules/devices/storage.c:93
+msgid "Spin Retry Count"
+msgstr ""
+
+#: modules/devices/storage.c:94
+msgid "Calibration Retry Count"
+msgstr ""
+
+#: modules/devices/storage.c:95
+msgid "Power Cycle Count"
+msgstr ""
+
+#: modules/devices/storage.c:96 modules/devices/storage.c:113
+msgid "Soft Read Error Rate"
+msgstr ""
+
+#: modules/devices/storage.c:97
+msgid "Runtime Bad Block"
+msgstr ""
+
+#: modules/devices/storage.c:98
+msgid "End-to-End error"
+msgstr ""
+
+#: modules/devices/storage.c:99
+msgid "Reported Uncorrectable Errors"
+msgstr ""
+
+#: modules/devices/storage.c:100
+msgid "Command Timeout"
+msgstr ""
+
+#: modules/devices/storage.c:101
+msgid "High Fly Writes"
+msgstr ""
+
+#: modules/devices/storage.c:102
+msgid "Airflow Temperature"
+msgstr ""
+
+#: modules/devices/storage.c:103
+msgid "G-sense Error Rate"
+msgstr ""
+
+#: modules/devices/storage.c:104
+msgid "Power-off Retract Count"
+msgstr ""
+
+#: modules/devices/storage.c:105
+msgid "Load Cycle Count"
+msgstr ""
+
+#: modules/devices/storage.c:106 modules/devices/storage.c:129
+msgid "Temperature"
+msgstr ""
+
+#: modules/devices/storage.c:107
+msgid "Hardware ECC Recovered"
+msgstr ""
+
+#: modules/devices/storage.c:108
+msgid "Reallocation Event Count"
+msgstr ""
+
+#: modules/devices/storage.c:109
+msgid "Current Pending Sector Count"
+msgstr ""
+
+#: modules/devices/storage.c:110
+msgid "Uncorrectable Sector Count"
+msgstr ""
+
+#: modules/devices/storage.c:111
+msgid "UltraDMA CRC Error Count"
+msgstr ""
+
+#: modules/devices/storage.c:112
+msgid "Multi-Zone Error Rate"
+msgstr ""
+
+#: modules/devices/storage.c:114
+msgid "Run Out Cancel"
+msgstr ""
+
+#: modules/devices/storage.c:115
+msgid "Flying Height"
+msgstr ""
+
+#: modules/devices/storage.c:116
+msgid "Spin High Current"
+msgstr ""
+
+#: modules/devices/storage.c:117
+msgid "Spin Buzz"
+msgstr ""
+
+#: modules/devices/storage.c:118
+msgid "Offline Seek Performance"
+msgstr ""
+
+#: modules/devices/storage.c:119
+msgid "Disk Shift"
+msgstr ""
+
+#: modules/devices/storage.c:120
+msgid "G-Sense Error Rate"
+msgstr ""
+
+#: modules/devices/storage.c:121
+msgid "Loaded Hours"
+msgstr ""
+
+#: modules/devices/storage.c:122
+msgid "Load/Unload Retry Count"
+msgstr ""
+
+#: modules/devices/storage.c:123
+msgid "Load Friction"
+msgstr ""
+
+#: modules/devices/storage.c:124
+msgid "Load/Unload Cycle Count"
+msgstr ""
+
+#: modules/devices/storage.c:125
+msgid "Load-in time"
+msgstr ""
+
+#: modules/devices/storage.c:126
+msgid "Torque Amplification Count"
+msgstr ""
+
+#: modules/devices/storage.c:127
+msgid "Power-Off Retract Count"
+msgstr ""
+
+#: modules/devices/storage.c:128
+msgid "GMR Head Amplitude"
+msgstr ""
+
+#: modules/devices/storage.c:130
+msgid "Endurance Remaining"
+msgstr ""
+
+#: modules/devices/storage.c:132
+msgid "Good Block Rate"
+msgstr ""
+
+#: modules/devices/storage.c:133
+msgid "Head Flying Hours"
+msgstr ""
+
+#: modules/devices/storage.c:134
+msgid "Read Error Retry Rate"
+msgstr ""
+
+#: modules/devices/storage.c:135
+msgid "Total LBAs Written"
+msgstr ""
+
+#: modules/devices/storage.c:136
+msgid "Total LBAs Read"
+msgstr ""
+
+#: modules/devices/storage.c:141
 msgid ""
-"[SPD]\n"
-"Please load the eeprom module to obtain information about memory SPD=\n"
-"[$ShellParam$]\n"
-"ReloadInterval=500\n"
+"\n"
+"[UDisks2]\n"
 msgstr ""
 
-#: modules/devices/spd-decode.c:1480
+#: modules/devices/storage.c:199
+msgid "Removable"
+msgstr ""
+
+#: modules/devices/storage.c:199
+msgid "Fixed"
+msgstr ""
+
+#: modules/devices/storage.c:202
+msgid "Ejectable"
+msgstr ""
+
+#: modules/devices/storage.c:205
+msgid "Self-monitoring (S.M.A.R.T.)"
+msgstr ""
+
+#: modules/devices/storage.c:208 modules/devices/x86/processor.c:663
+msgid "Power Management"
+msgstr ""
+
+#: modules/devices/storage.c:211
+msgid "Advanced Power Management"
+msgstr ""
+
+#: modules/devices/storage.c:214
+msgid "Automatic Acoustic Management"
+msgstr ""
+
+#: modules/devices/storage.c:217
+#, c-format
 msgid ""
-"[SPD]\n"
-"Reading memory SPD not supported on this system=\n"
+"[Drive Information]\n"
+"Model=%s\n"
 msgstr ""
 
-#: modules/devices/spd-decode.c:1509
-msgid "SPD"
+#: modules/devices/storage.c:221 modules/devices/storage.c:449
+#: modules/devices/storage.c:648
+#, c-format
+msgid "Vendor=%s\n"
+msgstr "Hersteller=%s\n"
+
+#: modules/devices/storage.c:226
+#, c-format
+msgid ""
+"Revision=%s\n"
+"Block Device=%s\n"
+"Serial=%s\n"
+"Size=%s\n"
+"Features=%s\n"
 msgstr ""
 
-#: modules/devices/spd-decode.c:1510
-msgid "Bank"
+#: modules/devices/storage.c:240
+#, c-format
+msgid "Rotation Rate=%d RPM\n"
 msgstr ""
 
-#: modules/devices/storage.c:43
+#: modules/devices/storage.c:243
+#, c-format
+msgid ""
+"Media=%s\n"
+"Media compatibility=%s\n"
+msgstr ""
+
+#: modules/devices/storage.c:250
+#, c-format
+msgid "Connection bus=%s\n"
+msgstr ""
+
+#: modules/devices/storage.c:253
+#, c-format
+msgid ""
+"[Self-monitoring (S.M.A.R.T.)]\n"
+"Status=%s\n"
+"Bad Sectors=%ld\n"
+"Power on time=%d days %d hours\n"
+"Temperature=%d°C\n"
+msgstr ""
+
+#: modules/devices/storage.c:259
+msgid "Failing"
+msgstr ""
+
+#: modules/devices/storage.c:259
+msgid "OK"
+msgstr ""
+
+#: modules/devices/storage.c:265
+msgid ""
+"[S.M.A.R.T. Attributes]\n"
+"Attribute=Normalized Value / Worst / Threshold\n"
+msgstr ""
+
+#: modules/devices/storage.c:297
+#, c-format
+msgid "(%d) %s=%s\n"
+msgstr ""
+
+#: modules/devices/storage.c:306
+#, c-format
+msgid ""
+"[Partition table]\n"
+"Type=%s\n"
+msgstr ""
+
+#: modules/devices/storage.c:325
+#, c-format
+msgid "Partition %s=%s\n"
+msgstr ""
+
+#: modules/devices/storage.c:375
 msgid ""
 "\n"
 "[SCSI Disks]\n"
@@ -2711,7 +4047,7 @@ msgstr ""
 "\n"
 "[SCSI-Geräte]\n"
 
-#: modules/devices/storage.c:114 modules/devices/storage.c:320
+#: modules/devices/storage.c:446 modules/devices/storage.c:645
 #, c-format
 msgid ""
 "[Device Information]\n"
@@ -2720,17 +4056,7 @@ msgstr ""
 "[Geräte-Informationen]\n"
 "Modell=%s\n"
 
-#: modules/devices/storage.c:119 modules/devices/storage.c:326
-#, c-format
-msgid "Vendor=%s (%s)\n"
-msgstr "Hersteller=%s (%s)\n"
-
-#: modules/devices/storage.c:124 modules/devices/storage.c:328
-#, c-format
-msgid "Vendor=%s\n"
-msgstr "Hersteller=%s\n"
-
-#: modules/devices/storage.c:129
+#: modules/devices/storage.c:453
 #, c-format
 msgid ""
 "Type=%s\n"
@@ -2742,7 +4068,7 @@ msgid ""
 "LUN=%d\n"
 msgstr ""
 
-#: modules/devices/storage.c:174
+#: modules/devices/storage.c:499
 msgid ""
 "\n"
 "[IDE Disks]\n"
@@ -2750,12 +4076,12 @@ msgstr ""
 "\n"
 "[IDE-Geräte]\n"
 
-#: modules/devices/storage.c:257
+#: modules/devices/storage.c:582
 #, c-format
 msgid "Driver=%s\n"
 msgstr "Treiber=%s\n"
 
-#: modules/devices/storage.c:331
+#: modules/devices/storage.c:650
 #, c-format
 msgid ""
 "Device Name=hd%c\n"
@@ -2763,7 +4089,7 @@ msgid ""
 "Cache=%dkb\n"
 msgstr ""
 
-#: modules/devices/storage.c:341
+#: modules/devices/storage.c:660
 #, c-format
 msgid ""
 "[Geometry]\n"
@@ -2774,7 +4100,7 @@ msgstr ""
 "Physikalisch=%s\n"
 "Logisch=%s\n"
 
-#: modules/devices/storage.c:351
+#: modules/devices/storage.c:670
 #, c-format
 msgid ""
 "[Capabilities]\n"
@@ -2783,7 +4109,7 @@ msgstr ""
 "[Fähigkeiten]\n"
 "%s"
 
-#: modules/devices/storage.c:358
+#: modules/devices/storage.c:677
 #, c-format
 msgid ""
 "[Speeds]\n"
@@ -2792,27 +4118,35 @@ msgstr ""
 "[Geschwindigkeiten]\n"
 "%s"
 
-#: modules/devices/usb.c:65
-msgid "Max Current"
-msgstr ""
-
-#: modules/devices/usb.c:65
-msgid "mA"
-msgstr ""
-
-#: modules/devices/usb.c:66
-msgid "USB Version"
-msgstr ""
-
-#: modules/devices/usb.c:68
+#: modules/devices/usb.c:134 modules/devices/usb.c:175
 msgid "Sub-class"
 msgstr ""
 
-#: modules/devices/usb.c:69
+#: modules/devices/usb.c:135 modules/devices/usb.c:176 modules/network.c:347
+msgid "Protocol"
+msgstr "Protokoll"
+
+#: modules/devices/usb.c:143 modules/network/net.c:451
+msgid "Mb/s"
+msgstr ""
+
+#: modules/devices/usb.c:171
+msgid "Max Current"
+msgstr ""
+
+#: modules/devices/usb.c:171
+msgid "mA"
+msgstr ""
+
+#: modules/devices/usb.c:172
+msgid "USB Version"
+msgstr ""
+
+#: modules/devices/usb.c:177
 msgid "Device Version"
 msgstr ""
 
-#: modules/devices/usb.c:103
+#: modules/devices/usb.c:221
 msgid "No USB devices found."
 msgstr ""
 
@@ -2852,47 +4186,59 @@ msgstr ""
 msgid "Level %d (%s)#%d=%dx %dKB (%dKB), %d-way set-associative, %d sets\n"
 msgstr ""
 
-#: modules/devices/x86/processor.c:645
+#: modules/devices/x86/processor.c:647
 msgid "Model Name"
 msgstr ""
 
-#: modules/devices/x86/processor.c:646
+#: modules/devices/x86/processor.c:648
 msgid "Family, model, stepping"
 msgstr "Familie, Modell, Stufung"
 
-#: modules/devices/x86/processor.c:652
+#: modules/devices/x86/processor.c:654
 msgid "Microcode Version"
 msgstr ""
 
-#: modules/devices/x86/processor.c:653
+#: modules/devices/x86/processor.c:655
 msgid "Configuration"
 msgstr "Konfiguration"
 
-#: modules/devices/x86/processor.c:654
+#: modules/devices/x86/processor.c:656
 msgid "Cache Size"
 msgstr "Cache-Größe"
 
-#: modules/devices/x86/processor.c:654
+#: modules/devices/x86/processor.c:656
 msgid "kb"
 msgstr ""
 
-#: modules/devices/x86/processor.c:661
-msgid "Power Management"
-msgstr ""
-
-#: modules/devices/x86/processor.c:662
+#: modules/devices/x86/processor.c:664
 msgid "Bug Workarounds"
 msgstr ""
 
-#: modules/devices/x86/processor.c:695 modules/devices/x86/processor.c:715
+#: modules/devices/x86/processor.c:691
+msgid "Socket Information"
+msgstr ""
+
+#: modules/devices/x86/processor.c:712
+msgid "CPU Socket"
+msgstr ""
+
+#: modules/devices/x86/processor.c:716
+msgid "External Clock"
+msgstr ""
+
+#: modules/devices/x86/processor.c:717
+msgid "Max Frequency"
+msgstr ""
+
+#: modules/devices/x86/processor.c:748 modules/devices/x86/processor.c:769
 msgid "Package Information"
 msgstr ""
 
-#: modules/devices/x86/processor.c:742
+#: modules/devices/x86/processor.c:796
 msgid "Socket:Core"
 msgstr ""
 
-#: modules/devices/x86/processor.c:742
+#: modules/devices/x86/processor.c:796
 msgid "Thread"
 msgstr ""
 
@@ -4232,181 +5578,175 @@ msgctxt "x86-flag"
 msgid "CPU is affected by speculative store bypass attack"
 msgstr ""
 
+#. /bug:l1tf
+#: modules/devices/x86/x86_data.c:286
+msgctxt "x86-flag"
+msgid "CPU is affected by L1 Terminal Fault"
+msgstr ""
+
 #. /x86/kernel/cpu/powerflags.h
 #. /flag:pm:ts
-#: modules/devices/x86/x86_data.c:288
+#: modules/devices/x86/x86_data.c:289
 msgctxt "x86-flag"
 msgid "temperature sensor"
 msgstr ""
 
 #. /flag:pm:fid
-#: modules/devices/x86/x86_data.c:289
+#: modules/devices/x86/x86_data.c:290
 msgctxt "x86-flag"
 msgid "frequency id control"
 msgstr ""
 
 #. /flag:pm:vid
-#: modules/devices/x86/x86_data.c:290
+#: modules/devices/x86/x86_data.c:291
 msgctxt "x86-flag"
 msgid "voltage id control"
 msgstr ""
 
 #. /flag:pm:ttp
-#: modules/devices/x86/x86_data.c:291
+#: modules/devices/x86/x86_data.c:292
 msgctxt "x86-flag"
 msgid "thermal trip"
 msgstr ""
 
 #. /flag:pm:tm
-#: modules/devices/x86/x86_data.c:292
+#: modules/devices/x86/x86_data.c:293
 msgctxt "x86-flag"
 msgid "hardware thermal control"
 msgstr ""
 
 #. /flag:pm:stc
-#: modules/devices/x86/x86_data.c:293
+#: modules/devices/x86/x86_data.c:294
 msgctxt "x86-flag"
 msgid "software thermal control"
 msgstr ""
 
 #. /flag:pm:100mhzsteps
-#: modules/devices/x86/x86_data.c:294
+#: modules/devices/x86/x86_data.c:295
 msgctxt "x86-flag"
 msgid "100 MHz multiplier control"
 msgstr ""
 
 #. /flag:pm:hwpstate
-#: modules/devices/x86/x86_data.c:295
+#: modules/devices/x86/x86_data.c:296
 msgctxt "x86-flag"
 msgid "hardware P-state control"
 msgstr ""
 
 #. /flag:pm:cpb
-#: modules/devices/x86/x86_data.c:296
+#: modules/devices/x86/x86_data.c:297
 msgctxt "x86-flag"
 msgid "core performance boost"
 msgstr ""
 
 #. /flag:pm:eff_freq_ro
-#: modules/devices/x86/x86_data.c:297
+#: modules/devices/x86/x86_data.c:298
 msgctxt "x86-flag"
 msgid "Readonly aperf/mperf"
 msgstr ""
 
 #. /flag:pm:proc_feedback
-#: modules/devices/x86/x86_data.c:298
+#: modules/devices/x86/x86_data.c:299
 msgctxt "x86-flag"
 msgid "processor feedback interface"
 msgstr ""
 
 #. /flag:pm:acc_power
-#: modules/devices/x86/x86_data.c:299
+#: modules/devices/x86/x86_data.c:300
 msgctxt "x86-flag"
 msgid "accumulated power mechanism"
 msgstr ""
 
-#: modules/network.c:59
+#: modules/network.c:61
 msgid "Interfaces"
 msgstr "Schnittstellen"
 
-#: modules/network.c:60
+#: modules/network.c:62
 msgid "IP Connections"
 msgstr "IP-Verbindungen"
 
-#: modules/network.c:61
+#: modules/network.c:63
 msgid "Routing Table"
 msgstr "Routing-Tabelle"
 
-#: modules/network.c:62 modules/network.c:303
+#: modules/network.c:64 modules/network.c:309
 msgid "ARP Table"
 msgstr "ARP-Tabelle"
 
-#: modules/network.c:63
+#: modules/network.c:65
 msgid "DNS Servers"
 msgstr "DNS-Server"
 
-#: modules/network.c:64
+#: modules/network.c:66
 msgid "Statistics"
 msgstr "Statistiken"
 
-#: modules/network.c:65
+#: modules/network.c:67
 msgid "Shared Directories"
 msgstr "Freigegebene Verzeichnisse"
 
-#: modules/network.c:304 modules/network.c:326 modules/network.c:357
+#: modules/network.c:310 modules/network.c:332 modules/network.c:363
 #: modules/network/net.c:472
 msgid "IP Address"
 msgstr "IP-Adresse"
 
-#: modules/network.c:304 modules/network.c:357 modules/network.c:374
-msgid "Interface"
-msgstr "Schnittstelle"
-
-#: modules/network.c:304
+#: modules/network.c:310
 msgid "MAC Address"
 msgstr "MAC-Adresse"
 
-#: modules/network.c:313
+#: modules/network.c:319
 msgid "SAMBA"
 msgstr ""
 
-#: modules/network.c:314
+#: modules/network.c:320
 msgid "NFS"
 msgstr ""
 
-#: modules/network.c:325
+#: modules/network.c:331
 msgid "Name Servers"
 msgstr "DNS-Server"
 
-#: modules/network.c:340
+#: modules/network.c:346
 msgid "Connections"
 msgstr ""
 
-#: modules/network.c:341
+#: modules/network.c:347
 msgid "Local Address"
 msgstr "Lokale Adresse"
 
-#: modules/network.c:341
-msgid "Protocol"
-msgstr "Protokoll"
-
-#: modules/network.c:341
+#: modules/network.c:347
 msgid "Foreign Address"
 msgstr "Fremde Adresse"
 
-#: modules/network.c:341
+#: modules/network.c:347
 msgid "State"
 msgstr "Status"
 
-#: modules/network.c:357
+#: modules/network.c:363
 msgid "Sent"
 msgstr "Gesendet"
 
-#: modules/network.c:357
+#: modules/network.c:363
 msgid "Received"
 msgstr "Empfangen"
 
-#: modules/network.c:373
+#: modules/network.c:379
 msgid "IP routing table"
 msgstr ""
 
-#: modules/network.c:374
+#: modules/network.c:380
 msgid "Destination/Gateway"
 msgstr "Ziel/Vorgaberoute"
 
-#: modules/network.c:374
-msgid "Flags"
-msgstr ""
-
-#: modules/network.c:374 modules/network/net.c:473
+#: modules/network.c:380 modules/network/net.c:473
 msgid "Mask"
 msgstr "Netz-Maske"
 
-#: modules/network.c:402
+#: modules/network.c:408
 msgid "Network"
 msgstr "Netzwerk"
 
-#: modules/network.c:435
+#: modules/network.c:441
 msgid "Gathers information about this computer's network connection"
 msgstr "Sammelt Informationen über die Netzwerk-Verbindung dieses Computers"
 
@@ -4576,11 +5916,6 @@ msgstr ""
 msgid "None Found"
 msgstr ""
 
-#: modules/network/net.c:395 modules/network/net.c:417
-#: modules/network/net.c:418
-msgid "MiB"
-msgstr ""
-
 #: modules/network/net.c:409
 msgid "Network Adapter Properties"
 msgstr ""
@@ -4630,16 +5965,8 @@ msgstr ""
 msgid "Bit Rate"
 msgstr ""
 
-#: modules/network/net.c:451
-msgid "Mb/s"
-msgstr ""
-
 #: modules/network/net.c:452
 msgid "Transmission Power"
-msgstr ""
-
-#: modules/network/net.c:454
-msgid "Status"
 msgstr ""
 
 #: modules/network/net.c:455
@@ -4663,11 +5990,29 @@ msgstr ""
 msgid "Broadcast Address"
 msgstr ""
 
+#~ msgid "Couldn't find a Web browser to open URL %s."
+#~ msgstr "Konnte keinen Web-Browser finden, um die URL %s zu öffnen."
+
+#~ msgid "CPU Blowfish"
+#~ msgstr "CPU Blowfish"
+
+#~ msgid "CSharp (Mono, old)"
+#~ msgstr "CSharp (Mono, old)"
+
+#~ msgid "CSharp (Mono)"
+#~ msgstr "CSharp (Mono)"
+
+#~ msgid "DMI"
+#~ msgstr "DMI"
+
+#~ msgid "Memory SPD"
+#~ msgstr "Hauptspeicher (SPD)"
+
+#~ msgid "Vendor=%s (%s)\n"
+#~ msgstr "Hersteller=%s (%s)\n"
+
 #~ msgid "X11 Vendor"
 #~ msgstr "X11-Hersteller"
-
-#~ msgid "Monitors"
-#~ msgstr "Bildschirme"
 
 #~ msgid "Extensions"
 #~ msgstr "Erweiterungen"
@@ -4683,9 +6028,6 @@ msgstr ""
 
 #~ msgid "CPU Clock"
 #~ msgstr "CPU-Takt"
-
-#~ msgid "Desktop Environment"
-#~ msgstr "Desktop-Umgebung"
 
 #~ msgid "%s$CPU%d$%s=%.2fMHz\n"
 #~ msgstr "%s$CPU%d$%s=%.2fMHz\n"

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: hardinfo\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-06-09 14:09-0500\n"
+"POT-Creation-Date: 2019-10-24 15:16-0500\n"
 "PO-Revision-Date: 2017-08-04 00:00-0430\n"
 "Last-Translator: PICCORO Lenz McKAY <mckaygerhard@gmail.com>\n"
 "Language-Team: Fernando López <soportelihuen@linti.unlp.edu.ar>\n"
@@ -26,19 +26,20 @@ msgstr "Little Endian"
 msgid "Big Endian"
 msgstr "Big Endian"
 
-#: hardinfo/cpu_util.c:184 hardinfo/cpu_util.c:195
+#: hardinfo/cpu_util.c:184 hardinfo/cpu_util.c:195 modules/devices/gpu.c:200
 msgid "Frequency Scaling"
 msgstr "Escalador de frecuencia"
 
-#: hardinfo/cpu_util.c:185
+#: hardinfo/cpu_util.c:185 modules/devices/gpu.c:201
 msgid "Minimum"
 msgstr "Minimo"
 
 #: hardinfo/cpu_util.c:185 hardinfo/cpu_util.c:186 hardinfo/cpu_util.c:187
+#: hardinfo/dt_util.c:589 modules/devices/gpu.c:201 modules/devices/gpu.c:202
 msgid "kHz"
 msgstr "Khz"
 
-#: hardinfo/cpu_util.c:186
+#: hardinfo/cpu_util.c:186 modules/devices/gpu.c:202
 msgid "Maximum"
 msgstr "Maximo"
 
@@ -46,11 +47,11 @@ msgstr "Maximo"
 msgid "Current"
 msgstr "Actual"
 
-#: hardinfo/cpu_util.c:188
+#: hardinfo/cpu_util.c:188 modules/devices/gpu.c:203
 msgid "Transition Latency"
 msgstr "Latencia de transicion"
 
-#: hardinfo/cpu_util.c:188
+#: hardinfo/cpu_util.c:188 modules/devices/gpu.c:203
 msgid "ns"
 msgstr "ns"
 
@@ -58,13 +59,13 @@ msgstr "ns"
 msgid "Governor"
 msgstr "Gobernador"
 
-#: hardinfo/cpu_util.c:190 hardinfo/cpu_util.c:196 modules/devices/gpu.c:149
-#: modules/devices/pci.c:116
+#: hardinfo/cpu_util.c:190 hardinfo/cpu_util.c:196 modules/devices/gpu.c:153
+#: modules/devices/pci.c:134 modules/devices/usb.c:136
 msgid "Driver"
 msgstr "Manejador"
 
-#: hardinfo/cpu_util.c:202 modules/computer.c:596
-#: modules/devices/arm/processor.c:242 modules/devices/x86/processor.c:284
+#: hardinfo/cpu_util.c:202 modules/computer.c:737
+#: modules/devices/arm/processor.c:256 modules/devices/x86/processor.c:284
 #: modules/devices/x86/processor.c:388 modules/devices/x86/processor.c:524
 msgid "(Not Available)"
 msgstr "(no disponible)"
@@ -73,7 +74,8 @@ msgstr "(no disponible)"
 msgid "Socket"
 msgstr "Soket"
 
-#: hardinfo/cpu_util.c:215 hardinfo/cpu_util.c:217
+#: hardinfo/cpu_util.c:215 hardinfo/cpu_util.c:217 modules/devices/gpu.c:149
+#: modules/devices/gpu.c:227
 msgid "Core"
 msgstr "Core"
 
@@ -85,8 +87,8 @@ msgstr "Asentamientos"
 msgid "Drawer"
 msgstr "Dibujado"
 
-#: hardinfo/cpu_util.c:228 modules/devices/arm/processor.c:449
-#: modules/devices/x86/processor.c:697
+#: hardinfo/cpu_util.c:228 modules/devices/arm/processor.c:471
+#: modules/devices/x86/processor.c:750
 msgid "Topology"
 msgstr "Topologia"
 
@@ -94,112 +96,336 @@ msgstr "Topologia"
 msgid "ID"
 msgstr "ID"
 
-#: hardinfo/dmi_util.c:130
+#: hardinfo/dmi_util.c:25
+msgid "BIOS Information"
+msgstr ""
+
+#: hardinfo/dmi_util.c:26 modules/devices/parisc/processor.c:157
+msgid "System"
+msgstr "Sistema"
+
+#: hardinfo/dmi_util.c:27
+msgid "Base Board"
+msgstr ""
+
+#: hardinfo/dmi_util.c:28 modules/devices/dmi.c:53
+msgid "Chassis"
+msgstr ""
+
+#: hardinfo/dmi_util.c:29 modules/computer.c:529 modules/computer.c:1000
+#: modules/devices/alpha/processor.c:87 modules/devices/arm/processor.c:341
+#: modules/devices.c:99 modules/devices/ia64/processor.c:159
+#: modules/devices/m68k/processor.c:83 modules/devices/mips/processor.c:74
+#: modules/devices/parisc/processor.c:154 modules/devices/ppc/processor.c:157
+#: modules/devices/riscv/processor.c:181 modules/devices/s390/processor.c:131
+#: modules/devices/sh/processor.c:83 modules/devices/sparc/processor.c:74
+#: modules/devices/x86/processor.c:646
+msgid "Processor"
+msgstr "Procesador"
+
+#: hardinfo/dmi_util.c:30
+msgid "Memory Controller"
+msgstr ""
+
+#: hardinfo/dmi_util.c:31
+msgid "Memory Module"
+msgstr ""
+
+#: hardinfo/dmi_util.c:32 modules/devices/parisc/processor.c:163
+#: modules/devices/x86/processor.c:662
+msgid "Cache"
+msgstr "Cache"
+
+#: hardinfo/dmi_util.c:33
+msgid "Port Connector"
+msgstr ""
+
+#: hardinfo/dmi_util.c:34
+msgid "System Slots"
+msgstr ""
+
+#: hardinfo/dmi_util.c:35
+msgid "On Board Devices"
+msgstr ""
+
+#: hardinfo/dmi_util.c:36
+msgid "OEM Strings"
+msgstr ""
+
+#: hardinfo/dmi_util.c:37
+msgid "System Configuration Options"
+msgstr ""
+
+#: hardinfo/dmi_util.c:38
+msgid "BIOS Language"
+msgstr ""
+
+#: hardinfo/dmi_util.c:39
+msgid "Group Associations"
+msgstr ""
+
+#: hardinfo/dmi_util.c:40
+msgid "System Event Log"
+msgstr ""
+
+#: hardinfo/dmi_util.c:41
+msgid "Physical Memory Array"
+msgstr ""
+
+#: hardinfo/dmi_util.c:42
+msgid "Memory Device"
+msgstr ""
+
+#: hardinfo/dmi_util.c:43
+msgid "32-bit Memory Error"
+msgstr ""
+
+#: hardinfo/dmi_util.c:44
+msgid "Memory Array Mapped Address"
+msgstr ""
+
+#: hardinfo/dmi_util.c:45
+msgid "Memory Device Mapped Address"
+msgstr ""
+
+#: hardinfo/dmi_util.c:46
+msgid "Built-in Pointing Device"
+msgstr ""
+
+#: hardinfo/dmi_util.c:47
+msgid "Portable Battery"
+msgstr ""
+
+#: hardinfo/dmi_util.c:48
+msgid "System Reset"
+msgstr ""
+
+#: hardinfo/dmi_util.c:49
+msgid "Hardware Security"
+msgstr ""
+
+#: hardinfo/dmi_util.c:50
+msgid "System Power Controls"
+msgstr ""
+
+#: hardinfo/dmi_util.c:51
+msgid "Voltage Probe"
+msgstr ""
+
+#: hardinfo/dmi_util.c:52
+msgid "Cooling Device"
+msgstr ""
+
+#: hardinfo/dmi_util.c:53
+msgid "Temperature Probe"
+msgstr ""
+
+#: hardinfo/dmi_util.c:54
+msgid "Electrical Current Probe"
+msgstr ""
+
+#: hardinfo/dmi_util.c:55
+msgid "Out-of-band Remote Access"
+msgstr ""
+
+#: hardinfo/dmi_util.c:56
+msgid "Boot Integrity Services"
+msgstr ""
+
+#: hardinfo/dmi_util.c:57
+msgid "System Boot"
+msgstr ""
+
+#: hardinfo/dmi_util.c:58
+msgid "64-bit Memory Error"
+msgstr ""
+
+#: hardinfo/dmi_util.c:59
+msgid "Management Device"
+msgstr ""
+
+#: hardinfo/dmi_util.c:60
+msgid "Management Device Component"
+msgstr ""
+
+#: hardinfo/dmi_util.c:61
+msgid "Management Device Threshold Data"
+msgstr ""
+
+#: hardinfo/dmi_util.c:62
+msgid "Memory Channel"
+msgstr ""
+
+#: hardinfo/dmi_util.c:63
+msgid "IPMI Device"
+msgstr ""
+
+#: hardinfo/dmi_util.c:64
+msgid "Power Supply"
+msgstr ""
+
+#: hardinfo/dmi_util.c:65
+msgid "Additional Information"
+msgstr ""
+
+#: hardinfo/dmi_util.c:66
+msgid "Onboard Device"
+msgstr ""
+
+#: hardinfo/dmi_util.c:226
 msgid "Invalid chassis type (0)"
 msgstr "Clasificación maquina invalida (0)"
 
-#: hardinfo/dmi_util.c:131 hardinfo/dmi_util.c:132
+#: hardinfo/dmi_util.c:227 hardinfo/dmi_util.c:228
 msgid "Unknown chassis type"
 msgstr "Clasificación mauqina desconocida"
 
-#: hardinfo/dmi_util.c:133
+#: hardinfo/dmi_util.c:229
 msgid "Desktop"
 msgstr "PC Escritorio"
 
-#: hardinfo/dmi_util.c:134
+#: hardinfo/dmi_util.c:230
 msgid "Low-profile Desktop"
 msgstr "PC economico"
 
-#: hardinfo/dmi_util.c:135
+#: hardinfo/dmi_util.c:231
 msgid "Pizza Box"
 msgstr "PC caja pizza"
 
-#: hardinfo/dmi_util.c:136
+#: hardinfo/dmi_util.c:232
 msgid "Mini Tower"
 msgstr "Torre mediana"
 
-#: hardinfo/dmi_util.c:137
+#: hardinfo/dmi_util.c:233
 msgid "Tower"
 msgstr "Torreta"
 
-#: hardinfo/dmi_util.c:138
+#: hardinfo/dmi_util.c:234
 msgid "Portable"
 msgstr "Portable"
 
-#: hardinfo/dmi_util.c:139 modules/computer.c:330 modules/computer.c:339
-#: modules/computer.c:361
+#: hardinfo/dmi_util.c:235 modules/computer.c:391 modules/computer.c:400
+#: modules/computer.c:422
 msgid "Laptop"
 msgstr "Portatil"
 
-#: hardinfo/dmi_util.c:140
+#: hardinfo/dmi_util.c:236
 msgid "Notebook"
 msgstr "Mini portatil"
 
-#: hardinfo/dmi_util.c:141
+#: hardinfo/dmi_util.c:237
 msgid "Handheld"
 msgstr "Mini bolsillo"
 
-#: hardinfo/dmi_util.c:142
+#: hardinfo/dmi_util.c:238
 msgid "Docking Station"
 msgstr "Estacion fija"
 
-#: hardinfo/dmi_util.c:143
+#: hardinfo/dmi_util.c:239
 msgid "All-in-one"
 msgstr "All in one"
 
-#: hardinfo/dmi_util.c:144
+#: hardinfo/dmi_util.c:240
 msgid "Subnotebook"
 msgstr "Subportátil"
 
-#: hardinfo/dmi_util.c:145
+#: hardinfo/dmi_util.c:241
 msgid "Space-saving"
 msgstr "PC Espacio-pequeño"
 
-#: hardinfo/dmi_util.c:146
+#: hardinfo/dmi_util.c:242
 msgid "Lunch Box"
 msgstr "PC caja"
 
-#: hardinfo/dmi_util.c:147
+#: hardinfo/dmi_util.c:243
 msgid "Main Server Chassis"
 msgstr "Servidor principal"
 
-#: hardinfo/dmi_util.c:148
+#: hardinfo/dmi_util.c:244
 msgid "Expansion Chassis"
 msgstr "Servidor expansion"
 
-#: hardinfo/dmi_util.c:149
+#: hardinfo/dmi_util.c:245
 msgid "Sub Chassis"
 msgstr "Sub servidor"
 
-#: hardinfo/dmi_util.c:150
+#: hardinfo/dmi_util.c:246
 msgid "Bus Expansion Chassis"
 msgstr "Expansion de bus acoplable"
 
-#: hardinfo/dmi_util.c:151
+#: hardinfo/dmi_util.c:247
 msgid "Peripheral Chassis"
 msgstr "Periferico acoplable"
 
-#: hardinfo/dmi_util.c:152
+#: hardinfo/dmi_util.c:248
 msgid "RAID Chassis"
 msgstr "RAID acoplable"
 
-#: hardinfo/dmi_util.c:153
+#: hardinfo/dmi_util.c:249
 msgid "Rack Mount Chassis"
 msgstr "Rack de montaje acoplable"
 
-#: hardinfo/dmi_util.c:154
+#: hardinfo/dmi_util.c:250
 msgid "Sealed-case PC"
 msgstr "PC sellada"
 
-#: hardinfo/dt_util.c:1011
+#: hardinfo/dmi_util.c:251
+msgid "Multi-system"
+msgstr ""
+
+#: hardinfo/dmi_util.c:252
+msgid "CompactPCI"
+msgstr ""
+
+#: hardinfo/dmi_util.c:253
+msgid "AdvancedTCA"
+msgstr ""
+
+#: hardinfo/dmi_util.c:254
+msgid "Blade"
+msgstr ""
+
+#: hardinfo/dmi_util.c:255
+msgid "Blade Enclosing"
+msgstr ""
+
+#: hardinfo/dmi_util.c:256
+msgid "Tablet"
+msgstr ""
+
+#: hardinfo/dmi_util.c:257
+msgid "Convertible"
+msgstr ""
+
+#: hardinfo/dmi_util.c:258
+msgid "Detachable"
+msgstr ""
+
+#: hardinfo/dmi_util.c:259
+msgid "IoT Gateway"
+msgstr ""
+
+#: hardinfo/dmi_util.c:260
+msgid "Embedded PC"
+msgstr ""
+
+#: hardinfo/dmi_util.c:261
+msgid "Mini PC"
+msgstr ""
+
+#: hardinfo/dmi_util.c:262
+msgid "Stick PC"
+msgstr ""
+
+#: hardinfo/dt_util.c:1179
 msgid "phandle Map"
 msgstr "Mapa manejado"
 
-#: hardinfo/dt_util.c:1012
+#: hardinfo/dt_util.c:1180
 msgid "Alias Map"
 msgstr "Mapa alternativo"
 
-#: hardinfo/dt_util.c:1013
+#: hardinfo/dt_util.c:1181
 msgid "Symbol Map"
 msgstr "Mapa de simbolos"
 
@@ -230,12 +456,16 @@ msgstr ""
 "  Prefijo de bibliotecas: %s\n"
 "  Compilado en:           %s\n"
 
-#: hardinfo/hardinfo.c:58 hardinfo/hardinfo.c:59 modules/computer.c:644
-#: modules/devices/inputdevices.c:128 modules/devices/printers.c:138
+#: hardinfo/hardinfo.c:58 hardinfo/hardinfo.c:59 modules/computer.c:785
+#: modules/computer/modules.c:131 modules/computer/modules.c:132
+#: modules/devices/inputdevices.c:123 modules/devices/printers.c:138
+#: modules/devices/spd-decode.c:903
 msgid "Yes"
 msgstr "Sí"
 
-#: hardinfo/hardinfo.c:59 modules/computer.c:644 modules/devices/printers.c:138
+#: hardinfo/hardinfo.c:59 modules/computer.c:785 modules/computer/modules.c:131
+#: modules/computer/modules.c:132 modules/devices/printers.c:138
+#: modules/devices/spd-decode.c:900
 msgid "No"
 msgstr "_No"
 
@@ -265,31 +495,39 @@ msgstr ""
 msgid "File Name"
 msgstr "Nombre de archivo"
 
-#: hardinfo/hardinfo.c:78 modules/computer.c:528 modules/computer.c:556
-#: modules/computer.c:674 modules/computer/languages.c:104
-#: modules/computer/modules.c:146 modules/devices/arm/processor.c:447
-#: modules/devices/dmi.c:37 modules/devices/dmi.c:46
-#: modules/devices/ia64/processor.c:160 modules/devices/inputdevices.c:116
-#: modules/devices/sh/processor.c:84 modules/devices/x86/processor.c:696
-#: modules/network.c:326
+#: hardinfo/hardinfo.c:78 modules/computer.c:666 modules/computer.c:694
+#: modules/computer.c:815 modules/computer/languages.c:95
+#: modules/computer/modules.c:149 modules/devices/arm/processor.c:469
+#: modules/devices/dmi.c:37 modules/devices/dmi.c:48 modules/devices/gpu.c:233
+#: modules/devices/ia64/processor.c:160 modules/devices/inputdevices.c:111
+#: modules/devices/monitors.c:399 modules/devices/monitors.c:502
+#: modules/devices/sh/processor.c:84 modules/devices/x86/processor.c:749
+#: modules/network.c:332
 msgid "Name"
 msgstr "Nombre"
 
-#: hardinfo/hardinfo.c:78 modules/computer.c:304 modules/computer.c:499
-#: modules/computer.c:501 modules/computer.c:602 modules/devices/dmi.c:40
-#: modules/devices/dmi.c:44 modules/devices/dmi.c:48 modules/devices/dmi.c:54
-#: modules/devices/inputdevices.c:121
+#: hardinfo/hardinfo.c:78 modules/computer.c:347 modules/computer.c:572
+#: modules/computer.c:574 modules/computer.c:743 modules/computer/modules.c:151
+#: modules/devices/dmi.c:40 modules/devices/dmi.c:46 modules/devices/dmi.c:50
+#: modules/devices/dmi.c:56 modules/devices/firmware.c:105
+#: modules/devices/inputdevices.c:116 modules/devices/monitors.c:405
 msgid "Version"
 msgstr "Versión"
 
-#: hardinfo/hardinfo.c:125
+#: hardinfo/hardinfo.c:129
 #, c-format
 msgid "Unknown benchmark ``%s'' or benchmark.so not loaded"
 msgstr ""
 
-#: hardinfo/hardinfo.c:155
+#: hardinfo/hardinfo.c:159
 msgid "Don't know what to do. Exiting."
 msgstr "No se puede determinar que hacer. Saliendo."
+
+#: hardinfo/usb_util.c:290 modules/devices/devicetree.c:91
+#: modules/devices/devicetree.c:92 modules/devices/monitors.c:407
+#: modules/devices/storage.c:246
+msgid "(None)"
+msgstr "(ninguno)"
 
 #: hardinfo/util.c:104 modules/computer/uptime.c:54
 #, c-format
@@ -361,51 +599,65 @@ msgstr "Advertencia"
 msgid "Fatal Error"
 msgstr "Error fatal"
 
-#: hardinfo/util.c:403
+#: hardinfo/util.c:406
 msgid "creates a report and prints to standard output"
 msgstr "crea un reporte y lo imprime en la salida estándar"
 
-#: hardinfo/util.c:409
-msgid "chooses a report format (text, html)"
-msgstr "elige un formato para el reporte (texto, html)"
+#: hardinfo/util.c:412
+msgid "chooses a report format ([text], html)"
+msgstr ""
 
-#: hardinfo/util.c:415
+#: hardinfo/util.c:418
 msgid "run benchmark; requires benchmark.so to be loaded"
 msgstr "correr benchmark; requiere benchmark.so para ser cargado"
 
-#: hardinfo/util.c:421
+#: hardinfo/util.c:424
+msgid "note attached to benchmark results"
+msgstr ""
+
+#: hardinfo/util.c:430
 msgid "benchmark result format ([short], conf, shell)"
 msgstr ""
 
-#: hardinfo/util.c:427
+#: hardinfo/util.c:436
+msgid ""
+"maximum number of benchmark results to include (-1 for no limit, default is "
+"10)"
+msgstr ""
+
+#: hardinfo/util.c:442
 msgid "lists modules"
 msgstr "lista los módulos"
 
-#: hardinfo/util.c:433
+#: hardinfo/util.c:448
 msgid "specify module to load"
 msgstr "especificar módulo a cargar"
 
-#: hardinfo/util.c:439
+#: hardinfo/util.c:454
 msgid "automatically load module dependencies"
 msgstr "cargar automáticamente las dependencias de los módulos"
 
-#: hardinfo/util.c:446
+#: hardinfo/util.c:461
 msgid "run in XML-RPC server mode"
 msgstr "correr en modo servidor XML-RPC"
 
-#: hardinfo/util.c:453
+#: hardinfo/util.c:468
 msgid "shows program version and quit"
 msgstr "muestra la versión del programa y sale"
 
-#: hardinfo/util.c:459
+#: hardinfo/util.c:474
 msgid "do not run benchmarks"
 msgstr ""
 
-#: hardinfo/util.c:464
+#: hardinfo/util.c:480
+msgid "show all details"
+msgstr ""
+
+#: hardinfo/util.c:485
 msgid "- System Profiler and Benchmark tool"
 msgstr "- Analizador de sistema y herramienta de benchmark"
 
-#: hardinfo/util.c:474
+#: hardinfo/util.c:495
 #, c-format
 msgid ""
 "Unrecognized arguments.\n"
@@ -414,29 +666,24 @@ msgstr ""
 "Argumentos no reconocidos.\n"
 "Intente ``%s --help'' para más información.\n"
 
-#: hardinfo/util.c:542
-#, c-format
-msgid "Couldn't find a Web browser to open URL %s."
-msgstr "No se pudo encontrar un navegador Web para abrir la URL %s."
-
-#: hardinfo/util.c:891
+#: hardinfo/util.c:903
 #, c-format
 msgid "Module \"%s\" depends on module \"%s\", load it?"
 msgstr "El módulo \"%s\" depende del módulo \"%s\", ¿desea cargarlo?"
 
-#: hardinfo/util.c:914
+#: hardinfo/util.c:926
 #, c-format
 msgid "Module \"%s\" depends on module \"%s\"."
 msgstr "El módulo \"%s\" depende del módulo \"%s\"."
 
-#: hardinfo/util.c:959
+#: hardinfo/util.c:971
 #, c-format
 msgid "No module could be loaded. Check permissions on \"%s\" and try again."
 msgstr ""
 "No se puede cargar ningún módulo. Verifique los permisos en \"%s\" y pruebe "
 "de nuevo."
 
-#: hardinfo/util.c:963
+#: hardinfo/util.c:975
 msgid ""
 "No module could be loaded. Please use hardinfo -l to list all available "
 "modules and try again with a valid module list."
@@ -445,15 +692,26 @@ msgstr ""
 "todoslos módulos disponibles e intente de nuevo con una lista válida de "
 "módulos."
 
-#: hardinfo/util.c:1040
+#: hardinfo/util.c:1030
 #, c-format
 msgid "Scanning: %s..."
 msgstr "Escaneando: %s..."
 
-#: hardinfo/util.c:1050 shell/shell.c:301 shell/shell.c:772 shell/shell.c:1850
-#: modules/benchmark.c:549 modules/benchmark.c:557
+#: hardinfo/util.c:1040 shell/shell.c:310 shell/shell.c:795 shell/shell.c:1962
+#: modules/benchmark.c:583 modules/benchmark.c:591
 msgid "Done."
 msgstr "Hecho."
+
+#: hardinfo/vendor.c:440 modules/computer.c:573 modules/computer.c:765
+#: modules/computer/os.c:79 modules/computer/os.c:263 modules/computer/os.c:300
+#: modules/computer/os.c:499 modules/computer/os.c:569 modules/devices.c:359
+#: modules/devices.c:505 modules/devices/printers.c:99
+#: modules/devices/printers.c:106 modules/devices/printers.c:116
+#: modules/devices/printers.c:131 modules/devices/printers.c:140
+#: modules/devices/printers.c:243 modules/devices/spd-decode.c:312
+#: modules/devices/usb.c:146
+msgid "Unknown"
+msgstr "Desconocido"
 
 #: shell/callbacks.c:128
 #, c-format
@@ -477,65 +735,65 @@ msgstr "Autor:"
 msgid "Contributors:"
 msgstr "Contribuyentes:"
 
-#: shell/callbacks.c:166
+#: shell/callbacks.c:167
 msgid "Based on work by:"
 msgstr "Basado en el trabajo de:"
 
-#: shell/callbacks.c:167
+#: shell/callbacks.c:168
 msgid "MD5 implementation by Colin Plumb (see md5.c for details)"
 msgstr "Implementación de MD5 por Colin Plumb (ver md5.c para detalles)"
 
-#: shell/callbacks.c:168
+#: shell/callbacks.c:169
 msgid "SHA1 implementation by Steve Reid (see sha1.c for details)"
 msgstr "Implementación de SHA1 por Steve Reid (ver sha1.c para detalles)"
 
-#: shell/callbacks.c:169
+#: shell/callbacks.c:170
 msgid "Blowfish implementation by Paul Kocher (see blowfich.c for details)"
 msgstr ""
 "Implementación de Blowfish por Paul Kocher (ver blowfich.c para detalles)"
 
-#: shell/callbacks.c:170
+#: shell/callbacks.c:171
 msgid "Raytracing benchmark by John Walker (see fbench.c for details)"
 msgstr ""
 "Benchmark de trazado de rayos por John Walker (ver fbench.c para detalles)"
 
-#: shell/callbacks.c:171
+#: shell/callbacks.c:172
 msgid "FFT benchmark by Scott Robert Ladd (see fftbench.c for details)"
 msgstr "Benchmark  de FFT por Scott Robert Ladd (ver fftbench.c para detalles)"
 
-#: shell/callbacks.c:172
+#: shell/callbacks.c:173
 msgid "Some code partly based on x86cpucaps by Osamu Kayasono"
 msgstr "Parte del código parcialmente basado en x86cpucaps por Osamu Kayasono"
 
-#: shell/callbacks.c:173
+#: shell/callbacks.c:174
 msgid "Vendor list based on GtkSysInfo by Pissens Sebastien"
 msgstr "Lista de proveedores basada en GtkSysInfo por Pissens Sebastien"
 
-#: shell/callbacks.c:174
+#: shell/callbacks.c:175
 msgid "DMI support based on code by Stewart Adam"
 msgstr "Soporte DMI basado en código de Stewart Adam"
 
-#: shell/callbacks.c:175
+#: shell/callbacks.c:176
 msgid "SCSI support based on code by Pascal F. Martin"
 msgstr "Soporte SCSI basado en código de Pascal F. Martin"
 
-#: shell/callbacks.c:180
+#: shell/callbacks.c:181
 msgid "Tango Project"
 msgstr "Proyecto Tango"
 
-#: shell/callbacks.c:181
+#: shell/callbacks.c:182
 msgid "The GNOME Project"
 msgstr "El proyecto GNOME"
 
-#: shell/callbacks.c:182
+#: shell/callbacks.c:183
 msgid "VMWare, Inc. (USB icon from VMWare Workstation 6)"
 msgstr "VMWare, Inc. (icono USB de VMWare Workstation 6)"
 
-#: shell/callbacks.c:200
+#: shell/callbacks.c:201
 msgid "System information and benchmark tool"
 msgstr "Herramienta de Información y Pruebas del Sistema"
 
-#: shell/callbacks.c:205
+#: shell/callbacks.c:206
 msgid ""
 "HardInfo is free software; you can redistribute it and/or modify it under "
 "the terms of the GNU General Public License as published by the Free "
@@ -551,131 +809,131 @@ msgid ""
 "Franklin St, Fifth Floor, Boston, MA  02110-1301 USA"
 msgstr ""
 
-#: shell/callbacks.c:220
+#: shell/callbacks.c:221
 msgid "translator-credits"
 msgstr ""
 
-#: shell/menu.c:35
+#: shell/menu.c:43
 msgid "_Information"
 msgstr "_Información"
 
-#: shell/menu.c:36
+#: shell/menu.c:44
 msgid "_Remote"
 msgstr "_Remoto"
 
-#: shell/menu.c:37
+#: shell/menu.c:45
 msgid "_View"
 msgstr "_Ver"
 
-#: shell/menu.c:38
+#: shell/menu.c:46
 msgid "_Help"
 msgstr "_Ayuda"
 
-#: shell/menu.c:39
+#: shell/menu.c:47
 msgid "About _Modules"
 msgstr "Acerca de los _módulos"
 
-#: shell/menu.c:43
+#: shell/menu.c:51
 msgid "Generate _Report"
 msgstr "Generar _reporte"
 
-#: shell/menu.c:48
+#: shell/menu.c:56
 msgid "_Network Updater..."
 msgstr "_Actualizador por red..."
 
-#: shell/menu.c:53
+#: shell/menu.c:61
 msgid "_Open..."
 msgstr "_Abrir..."
 
-#: shell/menu.c:58
+#: shell/menu.c:66
 msgid "_Copy to Clipboard"
 msgstr "_Copiar al portapapeles"
 
-#: shell/menu.c:59
+#: shell/menu.c:67
 msgid "Copy to clipboard"
 msgstr "Copiar al portapapeles"
 
-#: shell/menu.c:63
+#: shell/menu.c:71
 msgid "_Refresh"
 msgstr "_Refrescar"
 
-#: shell/menu.c:68
+#: shell/menu.c:76
 msgid "_Open HardInfo Web Site"
 msgstr "_Abrir sitio web de Hardinfo"
 
-#: shell/menu.c:73
+#: shell/menu.c:81
 msgid "_Report bug"
 msgstr "_Reportar un error"
 
-#: shell/menu.c:78
+#: shell/menu.c:86
 msgid "_About HardInfo"
 msgstr "_Acerca de Hardinfo"
 
-#: shell/menu.c:79
+#: shell/menu.c:87
 msgid "Displays program version information"
 msgstr "Muestra la información de versión del programa"
 
-#: shell/menu.c:83
+#: shell/menu.c:91
 msgid "_Quit"
 msgstr "_Salir"
 
-#: shell/menu.c:90
+#: shell/menu.c:98
 msgid "_Side Pane"
 msgstr "_Panel lateral"
 
-#: shell/menu.c:91
+#: shell/menu.c:99
 msgid "Toggles side pane visibility"
 msgstr "Cambia la visibilidad del panel lateral"
 
-#: shell/menu.c:94
+#: shell/menu.c:102
 msgid "_Toolbar"
 msgstr "_Barra de herramientas"
 
-#: shell/report.c:500 shell/report.c:508
+#: shell/report.c:769 shell/report.c:777
 msgid "Save File"
 msgstr "Guardar archivo"
 
-#: shell/report.c:503 shell/report.c:935 shell/syncmanager.c:748
+#: shell/report.c:772 shell/report.c:1243 shell/syncmanager.c:748
 msgid "_Cancel"
 msgstr "_Cancelar"
 
-#: shell/report.c:505
+#: shell/report.c:774
 msgid "_Save"
 msgstr ""
 
-#: shell/report.c:635
+#: shell/report.c:943
 msgid "Cannot create ReportContext. Programming bug?"
 msgstr "No se puede crear ReportContext. ¿Error del programa?"
 
-#: shell/report.c:654
+#: shell/report.c:962
 msgid "Open the report with your web browser?"
 msgstr "¿Abrir el reporte en el navegador web?"
 
-#: shell/report.c:657
+#: shell/report.c:965
 msgid "_No"
 msgstr ""
 
-#: shell/report.c:658
+#: shell/report.c:966
 msgid "_Open"
 msgstr ""
 
-#: shell/report.c:688
+#: shell/report.c:996
 msgid "Generating report..."
 msgstr "Generando reporte..."
 
-#: shell/report.c:698
+#: shell/report.c:1006
 msgid "Report saved."
 msgstr "Reporte guardado."
 
-#: shell/report.c:700
+#: shell/report.c:1008
 msgid "Error while creating the report."
 msgstr "Error creando el reporte."
 
-#: shell/report.c:802
+#: shell/report.c:1110
 msgid "Generate Report"
 msgstr "Generar reporte"
 
-#: shell/report.c:827
+#: shell/report.c:1135
 msgid ""
 "<big><b>Generate Report</b></big>\n"
 "Please choose the information that you wish to view in your report:"
@@ -683,37 +941,37 @@ msgstr ""
 "<big><b>Generar reporte</b></big>\n"
 "Por favor elija la información que desea ver en el reporte:"
 
-#: shell/report.c:899
+#: shell/report.c:1207
 msgid "Select _None"
 msgstr "_Deseleccionar todo"
 
-#: shell/report.c:910
+#: shell/report.c:1218
 msgid "Select _All"
 msgstr "_Seleccionar todo"
 
-#: shell/report.c:945
+#: shell/report.c:1253
 msgid "_Generate"
 msgstr "_Generar"
 
-#: shell/shell.c:402
+#: shell/shell.c:407
 #, c-format
 msgid "%s - System Information"
 msgstr "%s - Información del sistema"
 
-#: shell/shell.c:407
+#: shell/shell.c:412
 msgid "System Information"
 msgstr "Información del sistema"
 
-#: shell/shell.c:759
+#: shell/shell.c:782
 msgid "Loading modules..."
 msgstr "Cargando módulos..."
 
-#: shell/shell.c:1715
+#: shell/shell.c:1828
 #, c-format
 msgid "<b>%s → Summary</b>"
 msgstr "<b>%s → Resumen</b>"
 
-#: shell/shell.c:1824
+#: shell/shell.c:1936
 msgid "Updating..."
 msgstr "Actualizando..."
 
@@ -806,47 +1064,91 @@ msgstr "Actualizador por red"
 msgid "_Synchronize"
 msgstr "_Sincronizar"
 
-#: modules/benchmark/benches.c:74
-msgid "CPU Blowfish"
+#: modules/benchmark/benches.c:82
+msgid "CPU Blowfish (Single-thread)"
 msgstr ""
 
-#: modules/benchmark/benches.c:75
-msgid "CPU CryptoHash"
+#: modules/benchmark/benches.c:84
+msgid "CPU Blowfish (Multi-thread)"
 msgstr ""
 
-#: modules/benchmark/benches.c:76
-msgid "CPU Fibonacci"
+#: modules/benchmark/benches.c:86
+msgid "CPU Blowfish (Multi-core)"
 msgstr ""
 
-#: modules/benchmark/benches.c:77
-msgid "CPU N-Queens"
-msgstr "CPU N-Reinas"
-
-#: modules/benchmark/benches.c:78
+#: modules/benchmark/benches.c:88
 msgid "CPU Zlib"
 msgstr "CPU Zlib"
 
-#: modules/benchmark/benches.c:79
+#: modules/benchmark/benches.c:90
+msgid "CPU CryptoHash"
+msgstr ""
+
+#: modules/benchmark/benches.c:92
+msgid "CPU Fibonacci"
+msgstr ""
+
+#: modules/benchmark/benches.c:94
+msgid "CPU N-Queens"
+msgstr "CPU N-Reinas"
+
+#: modules/benchmark/benches.c:96
 msgid "FPU FFT"
 msgstr "FPU FFT"
 
-#: modules/benchmark/benches.c:80
+#: modules/benchmark/benches.c:98
 msgid "FPU Raytracing"
 msgstr "FPU trazado de rayos"
 
-#: modules/benchmark/benches.c:82
+#: modules/benchmark/benches.c:100
+msgid "SysBench CPU (Single-thread)"
+msgstr ""
+
+#: modules/benchmark/benches.c:102
+msgid "SysBench CPU (Multi-thread)"
+msgstr ""
+
+#: modules/benchmark/benches.c:104
+msgid "SysBench CPU (Four threads)"
+msgstr ""
+
+#: modules/benchmark/benches.c:106
+msgid "SysBench Memory (Single-thread)"
+msgstr ""
+
+#: modules/benchmark/benches.c:108
+msgid "SysBench Memory (Two threads)"
+msgstr ""
+
+#: modules/benchmark/benches.c:110
+msgid "SysBench Memory"
+msgstr ""
+
+#: modules/benchmark/benches.c:113
 msgid "GPU Drawing"
 msgstr "GPU dibujado"
 
-#: modules/benchmark/benches.c:91
+#: modules/benchmark/benches.c:126
+msgid ""
+"Alexey Kopytov's <i><b>sysbench</b></i> is required.\n"
+"Results in events/second. Higher is better."
+msgstr ""
+
+#: modules/benchmark/benches.c:132
+msgid ""
+"Alexey Kopytov's <i><b>sysbench</b></i> is required.\n"
+"Results in MiB/second. Higher is better."
+msgstr ""
+
+#: modules/benchmark/benches.c:136
 msgid "Results in MiB/second. Higher is better."
 msgstr "Resultados en MiB/segundo. Más alto es mejor."
 
-#: modules/benchmark/benches.c:95
+#: modules/benchmark/benches.c:143
 msgid "Results in HIMarks. Higher is better."
 msgstr "Resultados en HIMarks. Más alto es mejor."
 
-#: modules/benchmark/benches.c:102
+#: modules/benchmark/benches.c:149
 msgid "Results in seconds. Lower is better."
 msgstr "Resultados en segundos. Más bajo es mejor."
 
@@ -865,158 +1167,201 @@ msgstr "Resultados en segundos. Más bajo es mejor."
 #.
 #. / Used for an unknown value. Having it in only one place cleans up the .po line references
 #: modules/benchmark/bench_results.c:22 modules/computer.c:41
-#: modules/computer/display.c:41 modules/computer/os.c:279
-#: modules/devices.c:383 modules/devices/gpu.c:42 modules/devices/gpu.c:58
-#: modules/devices/gpu.c:150 modules/devices/gpu.c:151 modules/devices/pci.c:25
-#: modules/devices/pci.c:117 modules/devices/pci.c:118 modules/devices/usb.c:27
-#: modules/network/net.c:437 includes/cpu_util.h:11
+#: modules/computer/display.c:41 modules/computer/display.c:58
+#: modules/computer/os.c:286 modules/computer/os.c:346 modules/devices.c:488
+#: modules/devices/dmi_memory.c:52 modules/devices/dmi_memory.c:53
+#: modules/devices/dmi_memory.c:579 modules/devices/dmi_memory.c:719
+#: modules/devices/dmi_memory.c:855 modules/devices/gpu.c:42
+#: modules/devices/gpu.c:58 modules/devices/gpu.c:112 modules/devices/gpu.c:120
+#: modules/devices/gpu.c:154 modules/devices/gpu.c:155
+#: modules/devices/gpu.c:176 modules/devices/monitors.c:27
+#: modules/devices/monitors.c:28 modules/devices/monitors.c:153
+#: modules/devices/monitors.c:162 modules/devices/pci.c:25
+#: modules/devices/pci.c:135 modules/devices/pci.c:136
+#: modules/devices/spd-decode.c:306 modules/devices/spd-decode.c:307
+#: modules/devices/spd-decode.c:310 modules/devices/spd-decode.c:311
+#: modules/devices/spd-decode.c:914 modules/devices/spd-decode.c:915
+#: modules/devices/storage.c:247 modules/devices/storage.c:309
+#: modules/devices/usb.c:28 modules/network/net.c:437 includes/cpu_util.h:11
 msgid "(Unknown)"
 msgstr "(desconocido)"
 
-#: modules/benchmark/bench_results.c:47 modules/benchmark/bench_results.c:322
-#: modules/devices/alpha/processor.c:90 modules/devices/arm/processor.c:276
-#: modules/devices/arm/processor.c:289 modules/devices/arm/processor.c:331
-#: modules/devices/arm/processor.c:478 modules/devices.c:310
-#: modules/devices.c:318 modules/devices.c:346
-#: modules/devices/ia64/processor.c:167 modules/devices/ia64/processor.c:196
-#: modules/devices/m68k/processor.c:87 modules/devices/mips/processor.c:77
-#: modules/devices/parisc/processor.c:158
+#: modules/benchmark/bench_results.c:49 modules/benchmark/bench_results.c:330
+#: modules/devices/alpha/processor.c:90 modules/devices/arm/processor.c:290
+#: modules/devices/arm/processor.c:303 modules/devices/arm/processor.c:345
+#: modules/devices/arm/processor.c:500 modules/devices.c:325
+#: modules/devices.c:333 modules/devices.c:361 modules/devices/gpu.c:115
+#: modules/devices/gpu.c:117 modules/devices/gpu.c:123
+#: modules/devices/gpu.c:125 modules/devices/gpu.c:179
+#: modules/devices/gpu.c:181 modules/devices/ia64/processor.c:167
+#: modules/devices/ia64/processor.c:196 modules/devices/m68k/processor.c:87
+#: modules/devices/mips/processor.c:77 modules/devices/parisc/processor.c:158
 #: modules/devices/parisc/processor.c:191 modules/devices/ppc/processor.c:160
 #: modules/devices/ppc/processor.c:187 modules/devices/riscv/processor.c:186
 #: modules/devices/riscv/processor.c:214 modules/devices/s390/processor.c:160
 #: modules/devices/sh/processor.c:87 modules/devices/sh/processor.c:88
 #: modules/devices/sh/processor.c:89 modules/devices/x86/processor.c:318
-#: modules/devices/x86/processor.c:331 modules/devices/x86/processor.c:655
-#: modules/devices/x86/processor.c:726
+#: modules/devices/x86/processor.c:331 modules/devices/x86/processor.c:657
+#: modules/devices/x86/processor.c:780
 msgid "MHz"
 msgstr "MHz"
 
-#: modules/benchmark/bench_results.c:374 modules/benchmark/bench_results.c:441
+#: modules/benchmark/bench_results.c:396 modules/benchmark/bench_results.c:495
 msgid "kiB"
 msgstr ""
 
-#: modules/benchmark/bench_results.c:389 modules/benchmark/bench_results.c:426
+#: modules/benchmark/bench_results.c:403 modules/benchmark/bench_results.c:453
+#, c-format
+msgid "%d-bit"
+msgstr ""
+
+#: modules/benchmark/bench_results.c:422 modules/benchmark/bench_results.c:477
 msgid "Benchmark Result"
 msgstr ""
 
-#: modules/benchmark/bench_results.c:390 modules/benchmark/bench_results.c:428
+#: modules/benchmark/bench_results.c:423 modules/benchmark/bench_results.c:479
 msgid "Threads"
 msgstr ""
 
-#: modules/benchmark/bench_results.c:391 modules/benchmark/bench_results.c:431
+#: modules/benchmark/bench_results.c:424 modules/benchmark/bench_results.c:481
+msgid "Elapsed Time"
+msgstr ""
+
+#: modules/benchmark/bench_results.c:424 modules/benchmark/bench_results.c:481
+msgid "seconds"
+msgstr ""
+
+#: modules/benchmark/bench_results.c:425 modules/computer/languages.c:101
+#: modules/devices/arm/processor.c:355 modules/devices/gpu.c:147
+#: modules/devices/ia64/processor.c:166 modules/devices/pci.c:132
+#: modules/devices/ppc/processor.c:159
+msgid "Revision"
+msgstr "Revision"
+
+#: modules/benchmark/bench_results.c:426 modules/benchmark/bench_results.c:482
+msgid "Extra Information"
+msgstr ""
+
+#: modules/benchmark/bench_results.c:427 modules/benchmark/bench_results.c:483
+msgid "User Note"
+msgstr ""
+
+#: modules/benchmark/bench_results.c:429 modules/benchmark/bench_results.c:485
 msgid "Note"
 msgstr ""
 
-#: modules/benchmark/bench_results.c:392 modules/benchmark/bench_results.c:432
+#: modules/benchmark/bench_results.c:430 modules/benchmark/bench_results.c:486
 msgid ""
 "This result is from an old version of HardInfo. Results might not be "
 "comparable to current version. Some details are missing."
 msgstr ""
 
-#: modules/benchmark/bench_results.c:393 modules/benchmark/bench_results.c:433
+#: modules/benchmark/bench_results.c:431 modules/benchmark/bench_results.c:487
 #: modules/devices/devicetree/pmac_data.c:81 modules/devices/sh/processor.c:85
 msgid "Machine"
 msgstr "Maquina"
 
-#: modules/benchmark/bench_results.c:394 modules/benchmark/bench_results.c:434
-#: modules/devices/devicetree.c:206 modules/devices/dmi.c:45
+#: modules/benchmark/bench_results.c:432 modules/benchmark/bench_results.c:488
+#: modules/devices/devicetree.c:208 modules/devices/dmi.c:47
 msgid "Board"
 msgstr "Tarjeta"
 
-#: modules/benchmark/bench_results.c:395 modules/benchmark/bench_results.c:435
+#: modules/benchmark/bench_results.c:433 modules/benchmark/bench_results.c:489
 msgid "CPU Name"
 msgstr ""
 
-#: modules/benchmark/bench_results.c:396 modules/benchmark/bench_results.c:436
+#: modules/benchmark/bench_results.c:434 modules/benchmark/bench_results.c:490
 msgid "CPU Description"
 msgstr ""
 
-#: modules/benchmark/bench_results.c:397 modules/benchmark/bench_results.c:437
-#: modules/benchmark.c:390
+#: modules/benchmark/bench_results.c:435 modules/benchmark/bench_results.c:491
+#: modules/benchmark.c:442
 msgid "CPU Config"
 msgstr "CPU Caracteristicas"
 
-#: modules/benchmark/bench_results.c:398 modules/benchmark/bench_results.c:438
+#: modules/benchmark/bench_results.c:436 modules/benchmark/bench_results.c:492
 msgid "Threads Available"
 msgstr ""
 
-#: modules/benchmark/bench_results.c:399 modules/benchmark/bench_results.c:439
+#: modules/benchmark/bench_results.c:437 modules/benchmark/bench_results.c:493
 msgid "GPU"
 msgstr ""
 
-#: modules/benchmark/bench_results.c:400 modules/benchmark/bench_results.c:440
-#: modules/computer.c:479
+#: modules/benchmark/bench_results.c:438 modules/benchmark/bench_results.c:494
+#: modules/computer.c:542
 msgid "OpenGL Renderer"
 msgstr "Renderizador OpenGL"
 
-#: modules/benchmark/bench_results.c:401 modules/benchmark/bench_results.c:441
-#: modules/computer.c:110 modules/computer.c:468 modules/devices.c:99
+#: modules/benchmark/bench_results.c:439 modules/benchmark/bench_results.c:495
+#: modules/computer.c:123 modules/computer.c:531 modules/computer.c:1000
+#: modules/devices/gpu.c:150
 msgid "Memory"
 msgstr "Memoria"
 
-#: modules/benchmark/bench_results.c:427
+#: modules/benchmark/bench_results.c:440 modules/benchmark/bench_results.c:496
+msgid "Pointer Size"
+msgstr ""
+
+#: modules/benchmark/bench_results.c:478
 msgid "Benchmark"
 msgstr ""
 
-#: modules/benchmark/bench_results.c:429
+#: modules/benchmark/bench_results.c:480 modules/devices/dmi_memory.c:879
+#: modules/devices/firmware.c:246 modules/devices/monitors.c:492
+#: modules/devices/x86/processor.c:691
 msgid "Result"
 msgstr ""
 
-#: modules/benchmark/bench_results.c:430
-msgid "Elapsed Time"
-msgstr ""
-
-#: modules/benchmark/bench_results.c:442
+#: modules/benchmark/bench_results.c:498
 msgid "Handles"
 msgstr ""
 
-#: modules/benchmark/bench_results.c:443
+#: modules/benchmark/bench_results.c:499
 msgid "mid"
 msgstr ""
 
-#: modules/benchmark/bench_results.c:444
+#: modules/benchmark/bench_results.c:500
 msgid "cfg_val"
 msgstr ""
 
-#: modules/benchmark.c:390
+#: modules/benchmark.c:442
 msgid "Results"
 msgstr "Resultados"
 
-#: modules/benchmark.c:390 modules/computer.c:811
-#: modules/devices/sparc/processor.c:75
+#: modules/benchmark.c:442 modules/devices/sparc/processor.c:75
 msgid "CPU"
 msgstr "CPU"
 
-#: modules/benchmark.c:460
+#: modules/benchmark.c:513
 #, c-format
 msgid "Benchmarking: <b>%s</b>."
 msgstr "Ejecutando benchmark: <b>%s</b>."
 
-#: modules/benchmark.c:479 modules/benchmark.c:498
-msgid "Cancel"
-msgstr "Cancelar"
-
-#: modules/benchmark.c:483 modules/benchmark.c:495
+#: modules/benchmark.c:527
 msgid "Benchmarking. Please do not move your mouse or press any keys."
 msgstr "Ejecutando benchmarks. Por favor no mueva el mouse ni use el teclado."
 
-#: modules/benchmark.c:567
+#: modules/benchmark.c:530
+msgid "Cancel"
+msgstr "Cancelar"
+
+#: modules/benchmark.c:601
 msgid "Benchmarks"
 msgstr "Benchmarks"
 
-#: modules/benchmark.c:585
+#: modules/benchmark.c:619
 msgid "Perform tasks and compare with other systems"
 msgstr "Realizar tareas y comparar con otros sistemas"
 
-#: modules/benchmark.c:692
+#: modules/benchmark.c:730
 msgid "Send benchmark results"
 msgstr "Enviar resultados de los benchmark"
 
-#: modules/benchmark.c:697
+#: modules/benchmark.c:735
 msgid "Receive benchmark results"
 msgstr "Recibir resultados de los benchmark"
 
-#: modules/computer/alsa.c:26 modules/computer.c:483
+#: modules/computer/alsa.c:26 modules/computer.c:546
 msgid "Audio Devices"
 msgstr "Dispositivos de audio"
 
@@ -1024,499 +1369,606 @@ msgstr "Dispositivos de audio"
 msgid "Audio Adapter"
 msgstr "Adaptador de audio"
 
-#: modules/computer.c:76
+#: modules/computer.c:80 modules/devices/firmware.c:104
 msgid "Summary"
 msgstr "Resumen"
 
-#: modules/computer.c:77 modules/computer.c:471 modules/computer.c:810
+#: modules/computer.c:81 modules/computer.c:534 modules/computer.c:999
 msgid "Operating System"
 msgstr "Sistema operativo"
 
-#: modules/computer.c:78 modules/devices/gpu.c:151 modules/devices/pci.c:118
+#: modules/computer.c:82
+msgid "Security"
+msgstr ""
+
+#: modules/computer.c:83 modules/devices/gpu.c:155 modules/devices/pci.c:136
 msgid "Kernel Modules"
 msgstr "Módulos del kernel"
 
-#: modules/computer.c:79 modules/computer.c:540
+#: modules/computer.c:84 modules/computer.c:678
 msgid "Boots"
 msgstr "Arranques"
 
-#: modules/computer.c:80
+#: modules/computer.c:85
 msgid "Languages"
 msgstr "Idiomas"
 
-#: modules/computer.c:81
+#: modules/computer.c:86
+msgid "Memory Usage"
+msgstr ""
+
+#: modules/computer.c:87
 msgid "Filesystems"
 msgstr "Sistemas de archivos"
 
-#: modules/computer.c:82 modules/computer.c:476
+#: modules/computer.c:88 modules/computer.c:539
 msgid "Display"
 msgstr "Pantalla"
 
-#: modules/computer.c:83 modules/computer/environment.c:32
+#: modules/computer.c:89 modules/computer/environment.c:32
 msgid "Environment Variables"
 msgstr "Variables de entorno"
 
-#: modules/computer.c:85
+#: modules/computer.c:91
 msgid "Development"
 msgstr "Desarrollo"
 
-#: modules/computer.c:87 modules/computer.c:661
+#: modules/computer.c:93 modules/computer.c:802
 msgid "Users"
 msgstr "Usuarios"
 
-#: modules/computer.c:88
+#: modules/computer.c:94
 msgid "Groups"
 msgstr "Grupos"
 
-#: modules/computer.c:112
+#: modules/computer.c:125
 #, c-format
 msgid "%dMB (%dMB used)"
 msgstr "%dMB (%dMB usados)"
 
-#: modules/computer.c:114 modules/computer.c:514
+#: modules/computer.c:127 modules/computer.c:594
 msgid "Uptime"
 msgstr "Activo"
 
-#: modules/computer.c:116 modules/computer.c:473
+#: modules/computer.c:129 modules/computer.c:536
 msgid "Date/Time"
 msgstr "Fecha/Hora"
 
-#: modules/computer.c:121 modules/computer.c:515
+#: modules/computer.c:134 modules/computer.c:595
 msgid "Load Average"
 msgstr "Promedio de carga"
 
-#: modules/computer.c:123 modules/computer.c:516
-msgid "Available entropy in /dev/random"
-msgstr "Entropía disponible en /dev/random"
-
-#: modules/computer.c:211
+#: modules/computer.c:247
 msgid "Scripting Languages"
 msgstr "Lenguajes de scripting"
 
-#: modules/computer.c:212
+#: modules/computer.c:248
 msgid "Gambas3 (gbr3)"
 msgstr ""
 
-#: modules/computer.c:213
-msgid "Python"
+#: modules/computer.c:249
+msgid "Python (default)"
 msgstr ""
 
-#: modules/computer.c:214
+#: modules/computer.c:250
 msgid "Python2"
 msgstr ""
 
-#: modules/computer.c:215
+#: modules/computer.c:251
 msgid "Python3"
 msgstr ""
 
-#: modules/computer.c:216
+#: modules/computer.c:252
 msgid "Perl"
 msgstr ""
 
-#: modules/computer.c:217
+#: modules/computer.c:253
 msgid "Perl6 (VM)"
 msgstr ""
 
-#: modules/computer.c:218
+#: modules/computer.c:254
 msgid "Perl6"
 msgstr ""
 
-#: modules/computer.c:219
+#: modules/computer.c:255
 msgid "PHP"
 msgstr ""
 
-#: modules/computer.c:220
+#: modules/computer.c:256
 msgid "Ruby"
 msgstr ""
 
-#: modules/computer.c:221
+#: modules/computer.c:257
 msgid "Bash"
 msgstr ""
 
-#: modules/computer.c:222
+#: modules/computer.c:258
+msgid "JavaScript (Node.js)"
+msgstr ""
+
+#: modules/computer.c:259
+msgid "awk"
+msgstr ""
+
+#: modules/computer.c:260
 msgid "Compilers"
 msgstr "Compiladores"
 
-#: modules/computer.c:223
+#: modules/computer.c:261
 msgid "C (GCC)"
 msgstr ""
 
-#: modules/computer.c:224
+#: modules/computer.c:262
 msgid "C (Clang)"
 msgstr ""
 
-#: modules/computer.c:225
+#: modules/computer.c:263
 msgid "D (dmd)"
 msgstr ""
 
-#: modules/computer.c:226
+#: modules/computer.c:264
 msgid "Gambas3 (gbc3)"
 msgstr ""
 
-#: modules/computer.c:227
+#: modules/computer.c:265
 msgid "Java"
 msgstr ""
 
-#: modules/computer.c:228
-msgid "CSharp (Mono, old)"
-msgstr "CSharp (Mono, antiguo)"
-
-#: modules/computer.c:229
-msgid "CSharp (Mono)"
+#: modules/computer.c:266
+msgid "C♯ (mcs)"
 msgstr ""
 
-#: modules/computer.c:230
+#: modules/computer.c:267
 msgid "Vala"
 msgstr ""
 
-#: modules/computer.c:231
+#: modules/computer.c:268
 msgid "Haskell (GHC)"
 msgstr ""
 
-#: modules/computer.c:232
+#: modules/computer.c:269
 msgid "FreePascal"
 msgstr ""
 
-#: modules/computer.c:233
+#: modules/computer.c:270
 msgid "Go"
 msgstr ""
 
-#: modules/computer.c:234
+#: modules/computer.c:271
+msgid "Rust"
+msgstr ""
+
+#: modules/computer.c:272
 msgid "Tools"
 msgstr "Herramientas"
 
-#: modules/computer.c:235
+#: modules/computer.c:273
 msgid "make"
 msgstr ""
 
-#: modules/computer.c:236
+#: modules/computer.c:274
+msgid "ninja"
+msgstr ""
+
+#: modules/computer.c:275
 msgid "GDB"
 msgstr ""
 
-#: modules/computer.c:237
+#: modules/computer.c:276
+msgid "LLDB"
+msgstr ""
+
+#: modules/computer.c:277
 msgid "strace"
 msgstr ""
 
-#: modules/computer.c:238
+#: modules/computer.c:278
 msgid "valgrind"
 msgstr ""
 
-#: modules/computer.c:239
+#: modules/computer.c:279
 msgid "QMake"
 msgstr ""
 
-#: modules/computer.c:240
+#: modules/computer.c:280
 msgid "CMake"
 msgstr ""
 
-#: modules/computer.c:241
+#: modules/computer.c:281
 msgid "Gambas3 IDE"
 msgstr ""
 
 #: modules/computer.c:282
+msgid "Radare2"
+msgstr ""
+
+#: modules/computer.c:283
+msgid "ltrace"
+msgstr ""
+
+#: modules/computer.c:324
 msgid "Not found"
 msgstr "No encontrado"
 
-#: modules/computer.c:287
+#: modules/computer.c:329
 #, c-format
 msgid "Detecting version: %s"
 msgstr "Detectando versión: %s"
 
-#: modules/computer.c:304
+#: modules/computer.c:347
 msgid "Program"
 msgstr "Programa"
 
-#: modules/computer.c:324
+#: modules/computer.c:365
+msgid "Field"
+msgstr "Campo"
+
+#: modules/computer.c:365 modules/computer.c:667 modules/computer/modules.c:149
+#: modules/computer/modules.c:150 modules/devices/arm/processor.c:470
+msgid "Description"
+msgstr "Descripción"
+
+#: modules/computer.c:365 modules/devices.c:726
+msgid "Value"
+msgstr "Valor"
+
+#: modules/computer.c:385
 msgid "Single-board computer"
 msgstr ""
 
 #. /proc/apm
-#: modules/computer.c:373
+#: modules/computer.c:434
 msgid "Unknown physical machine type"
 msgstr "Equipo fisico no catalogado"
 
-#: modules/computer.c:393 modules/computer.c:394
+#: modules/computer.c:454 modules/computer.c:455
 msgid "Virtual (VMware)"
 msgstr ""
 
-#: modules/computer.c:396 modules/computer.c:397 modules/computer.c:398
-#: modules/computer.c:399
+#: modules/computer.c:457 modules/computer.c:458 modules/computer.c:459
+#: modules/computer.c:460
 msgid "Virtual (QEMU)"
 msgstr ""
 
-#: modules/computer.c:401 modules/computer.c:402
+#: modules/computer.c:462 modules/computer.c:463
 msgid "Virtual (Unknown)"
 msgstr ""
 
-#: modules/computer.c:404 modules/computer.c:405 modules/computer.c:406
-#: modules/computer.c:427
+#: modules/computer.c:465 modules/computer.c:466 modules/computer.c:467
+#: modules/computer.c:488
 msgid "Virtual (VirtualBox)"
 msgstr ""
 
-#: modules/computer.c:408 modules/computer.c:409 modules/computer.c:410
-#: modules/computer.c:421
+#: modules/computer.c:469 modules/computer.c:470 modules/computer.c:471
+#: modules/computer.c:482
 msgid "Virtual (Xen)"
 msgstr ""
 
-#: modules/computer.c:412
+#: modules/computer.c:473
 msgid "Virtual (hypervisor present)"
 msgstr ""
 
-#: modules/computer.c:465 modules/computer.c:769
+#: modules/computer.c:528 modules/computer.c:953
 msgid "Computer"
 msgstr "Equipo"
 
-#: modules/computer.c:466 modules/devices/alpha/processor.c:87
-#: modules/devices/arm/processor.c:327 modules/devices.c:98
-#: modules/devices/ia64/processor.c:159 modules/devices/m68k/processor.c:83
-#: modules/devices/mips/processor.c:74 modules/devices/parisc/processor.c:154
-#: modules/devices/ppc/processor.c:157 modules/devices/riscv/processor.c:181
-#: modules/devices/s390/processor.c:131 modules/devices/sh/processor.c:83
-#: modules/devices/sparc/processor.c:74 modules/devices/x86/processor.c:644
-msgid "Processor"
-msgstr "Procesador"
-
-#: modules/computer.c:469
+#: modules/computer.c:532
 msgid "Machine Type"
 msgstr "Tipo de equipo"
 
-#: modules/computer.c:472 modules/computer.c:508
+#: modules/computer.c:535 modules/computer.c:588
 msgid "User Name"
 msgstr "Nombre de usuario"
 
-#: modules/computer.c:477
+#: modules/computer.c:540
 msgid "Resolution"
 msgstr "Resolución"
 
-#: modules/computer.c:477 modules/computer.c:607
+#: modules/computer.c:540 modules/computer.c:748
 #, c-format
 msgid "%dx%d pixels"
 msgstr "%dx%d pixeles"
 
-#: modules/computer.c:480
+#: modules/computer.c:543
 msgid "Session Display Server"
 msgstr ""
 
-#: modules/computer.c:485 modules/devices.c:106
+#: modules/computer.c:548 modules/devices.c:108
 msgid "Input Devices"
 msgstr "Dispositivos de entrada"
 
-#: modules/computer.c:500
+#: modules/computer.c:572
 msgid "Kernel"
 msgstr "Núcleo"
 
-#: modules/computer.c:502
+#: modules/computer.c:573
+msgid "Command Line"
+msgstr ""
+
+#: modules/computer.c:575
 msgid "C Library"
 msgstr "Biblioteca C"
 
-#: modules/computer.c:503
+#: modules/computer.c:576
 msgid "Distribution"
 msgstr "Distribución"
 
-#: modules/computer.c:506
+#: modules/computer.c:582
+msgid "Spin/Flavor"
+msgstr ""
+
+#: modules/computer.c:586
 msgid "Current Session"
 msgstr "Sesión actual"
 
-#: modules/computer.c:507
+#: modules/computer.c:587
 msgid "Computer Name"
 msgstr "Nombre del equipo"
 
-#: modules/computer.c:509 modules/computer/languages.c:108
+#: modules/computer.c:589 modules/computer/languages.c:99
 msgid "Language"
 msgstr "Idioma"
 
-#: modules/computer.c:510 modules/computer/users.c:50
+#: modules/computer.c:590 modules/computer/users.c:50
 msgid "Home Directory"
 msgstr "Directorio personal"
 
-#: modules/computer.c:513
+#: modules/computer.c:591
+msgid "Desktop Environment"
+msgstr "Entorno de escritorio"
+
+#: modules/computer.c:594
 msgid "Misc"
 msgstr "Otras"
 
-#: modules/computer.c:526
-msgid "Loaded Modules"
-msgstr "Módulos cargados"
-
-#: modules/computer.c:529 modules/computer/modules.c:145
-#: modules/computer/modules.c:147 modules/devices/arm/processor.c:448
-#: modules/devices.c:575
-msgid "Description"
-msgstr "Descripción"
-
-#: modules/computer.c:542
-msgid "Date & Time"
-msgstr "Fecha y hora"
-
-#: modules/computer.c:543
-msgid "Kernel Version"
-msgstr "Versión del núcleo"
-
-#: modules/computer.c:553
-msgid "Available Languages"
-msgstr "Idiomas disponibles"
-
-#: modules/computer.c:555
-msgid "Language Code"
-msgstr "Código del idioma"
-
-#: modules/computer.c:567
-msgid "Mounted File Systems"
-msgstr "Sistemas de archivos montados"
-
-#: modules/computer.c:569 modules/computer/filesystem.c:85
-msgid "Mount Point"
-msgstr "Punto de montaje"
-
-#: modules/computer.c:570
-msgid "Usage"
-msgstr "Uso"
-
-#: modules/computer.c:571 modules/devices/gpu.c:93 modules/devices/gpu.c:101
-#: modules/devices/gpu.c:187 modules/devices/pci.c:70 modules/devices/pci.c:78
-#: modules/devices/pci.c:122 modules/devices/usb.c:72
-msgid "Device"
-msgstr "Dispositivo"
-
-#: modules/computer.c:590
-msgid "Session"
+#: modules/computer.c:607
+msgid "HardInfo"
 msgstr ""
 
-#: modules/computer.c:591 modules/devices.c:614 modules/devices/dmi.c:53
-#: modules/devices/inputdevices.c:117
-msgid "Type"
-msgstr "Tipo"
-
-#: modules/computer.c:594
-msgid "Wayland"
+#: modules/computer.c:608
+msgid "HardInfo running as"
 msgstr ""
 
-#: modules/computer.c:595 modules/computer.c:600
-msgid "Current Display Name"
+#: modules/computer.c:609
+msgid "Superuser"
 msgstr ""
 
-#: modules/computer.c:599
-msgid "X Server"
+#: modules/computer.c:609
+msgid "User"
 msgstr ""
 
-#: modules/computer.c:601 modules/computer.c:641 modules/devices/dmi.c:39
-#: modules/devices/dmi.c:43 modules/devices/dmi.c:47 modules/devices/dmi.c:52
-#: modules/devices/gpu.c:92 modules/devices/gpu.c:100 modules/devices/gpu.c:186
-#: modules/devices/ia64/processor.c:161 modules/devices/inputdevices.c:119
-#: modules/devices/pci.c:69 modules/devices/pci.c:77 modules/devices/usb.c:64
-#: modules/devices/x86/processor.c:651
-msgid "Vendor"
-msgstr "Proveedor"
-
-#: modules/computer.c:603
-msgid "Release Number"
+#: modules/computer.c:613
+msgid "Health"
 msgstr ""
 
-#: modules/computer.c:611
-msgid "Screens"
+#: modules/computer.c:614
+msgid "Available entropy in /dev/random"
+msgstr "Entropía disponible en /dev/random"
+
+#: modules/computer.c:618
+msgid "Hardening Features"
 msgstr ""
 
-#: modules/computer.c:617
-msgid "Disconnected"
+#: modules/computer.c:619
+msgid "ASLR"
 msgstr ""
 
 #: modules/computer.c:620
+msgid "dmesg"
+msgstr ""
+
+#: modules/computer.c:624
+msgid "Linux Security Modules"
+msgstr ""
+
+#: modules/computer.c:625
+msgid "Modules available"
+msgstr ""
+
+#: modules/computer.c:626
+msgid "SELinux status"
+msgstr ""
+
+#: modules/computer.c:632
+msgid "CPU Vulnerabilities"
+msgstr ""
+
+#: modules/computer.c:664
+msgid "Loaded Modules"
+msgstr "Módulos cargados"
+
+#: modules/computer.c:680
+msgid "Date & Time"
+msgstr "Fecha y hora"
+
+#: modules/computer.c:681
+msgid "Kernel Version"
+msgstr "Versión del núcleo"
+
+#: modules/computer.c:691
+msgid "Available Languages"
+msgstr "Idiomas disponibles"
+
+#: modules/computer.c:693
+msgid "Language Code"
+msgstr "Código del idioma"
+
+#: modules/computer.c:705
+msgid "Mounted File Systems"
+msgstr "Sistemas de archivos montados"
+
+#: modules/computer.c:707 modules/computer/filesystem.c:85
+msgid "Mount Point"
+msgstr "Punto de montaje"
+
+#: modules/computer.c:708
+msgid "Usage"
+msgstr "Uso"
+
+#: modules/computer.c:709 modules/devices/gpu.c:75 modules/devices/gpu.c:83
+#: modules/devices/gpu.c:225 modules/devices/pci.c:88 modules/devices/pci.c:96
+#: modules/devices/pci.c:140 modules/devices/usb.c:169
+#: modules/devices/usb.c:181
+msgid "Device"
+msgstr "Dispositivo"
+
+#: modules/computer.c:731
+msgid "Session"
+msgstr ""
+
+#: modules/computer.c:732 modules/devices.c:726 modules/devices/dmi.c:55
+#: modules/devices/dmi_memory.c:603 modules/devices/dmi_memory.c:749
+#: modules/devices/inputdevices.c:112 modules/devices/x86/processor.c:714
+msgid "Type"
+msgstr "Tipo"
+
+#: modules/computer.c:735
+msgid "Wayland"
+msgstr ""
+
+#: modules/computer.c:736 modules/computer.c:741
+msgid "Current Display Name"
+msgstr ""
+
+#: modules/computer.c:740
+msgid "X Server"
+msgstr ""
+
+#: modules/computer.c:742 modules/computer.c:782 modules/devices/dmi.c:39
+#: modules/devices/dmi.c:45 modules/devices/dmi.c:49 modules/devices/dmi.c:54
+#: modules/devices/dmi_memory.c:750 modules/devices/dmi_memory.c:895
+#: modules/devices/firmware.c:105 modules/devices/firmware.c:168
+#: modules/devices/firmware.c:190 modules/devices/firmware.c:228
+#: modules/devices/gpu.c:74 modules/devices/gpu.c:82 modules/devices/gpu.c:224
+#: modules/devices/ia64/processor.c:161 modules/devices/inputdevices.c:114
+#: modules/devices/monitors.c:398 modules/devices/pci.c:87
+#: modules/devices/pci.c:95 modules/devices/usb.c:168
+#: modules/devices/x86/processor.c:653
+msgid "Vendor"
+msgstr "Proveedor"
+
+#: modules/computer.c:744
+msgid "Release Number"
+msgstr ""
+
+#: modules/computer.c:752
+msgid "Screens"
+msgstr ""
+
+#: modules/computer.c:758
+msgid "Disconnected"
+msgstr ""
+
+#: modules/computer.c:761
 msgid "Connected"
 msgstr ""
 
-#: modules/computer.c:624 modules/computer/os.c:78 modules/computer/os.c:234
-#: modules/computer/os.c:392 modules/devices.c:344 modules/devices.c:396
-#: modules/devices/printers.c:99 modules/devices/printers.c:106
-#: modules/devices/printers.c:116 modules/devices/printers.c:131
-#: modules/devices/printers.c:140 modules/devices/printers.c:243
-msgid "Unknown"
-msgstr "Desconocido"
-
-#: modules/computer.c:628
+#: modules/computer.c:769
 msgid "Unused"
 msgstr ""
 
-#: modules/computer.c:629
+#: modules/computer.c:770
 #, c-format
 msgid "%dx%d pixels, offset (%d, %d)"
 msgstr ""
 
-#: modules/computer.c:638
+#: modules/computer.c:779
 msgid "Outputs (XRandR)"
 msgstr ""
 
-#: modules/computer.c:640
+#: modules/computer.c:781
 msgid "OpenGL (GLX)"
 msgstr ""
 
-#: modules/computer.c:642
+#: modules/computer.c:783
 msgid "Renderer"
 msgstr "Renderizador"
 
-#: modules/computer.c:643
+#: modules/computer.c:784
 msgid "Direct Rendering"
 msgstr "Renderizado Directo"
 
-#: modules/computer.c:645
+#: modules/computer.c:786
 msgid "Version (Compatibility)"
 msgstr ""
 
-#: modules/computer.c:646
+#: modules/computer.c:787
 msgid "Shading Language Version (Compatibility)"
 msgstr ""
 
-#: modules/computer.c:647
+#: modules/computer.c:788
 msgid "Version (Core)"
 msgstr ""
 
-#: modules/computer.c:648
+#: modules/computer.c:789
 msgid "Shading Language Version (Core)"
 msgstr ""
 
-#: modules/computer.c:649
+#: modules/computer.c:790
 msgid "Version (ES)"
 msgstr ""
 
-#: modules/computer.c:650
+#: modules/computer.c:791
 msgid "Shading Language Version (ES)"
 msgstr ""
 
-#: modules/computer.c:651
+#: modules/computer.c:792
 msgid "GLX Version"
 msgstr ""
 
-#: modules/computer.c:672
+#: modules/computer.c:813
 msgid "Group"
 msgstr "Grupo"
 
-#: modules/computer.c:675 modules/computer/users.c:49
+#: modules/computer.c:816 modules/computer/users.c:49
 msgid "Group ID"
 msgstr "ID del grupo"
 
-#: modules/computer.c:811
-msgid "RAM"
-msgstr "RAM"
+#. / <value> <unit> "usable memory"
+#: modules/computer.c:909
+#, c-format
+msgid "%0.1f %s available to Linux"
+msgstr ""
 
-#: modules/computer.c:811 modules/devices/devicetree/pmac_data.c:82
+#: modules/computer.c:911 modules/devices/dmi_memory.c:661
+#: modules/devices/dmi_memory.c:809 modules/devices/dmi_memory.c:936
+msgid "GiB"
+msgstr ""
+
+#: modules/computer.c:913 modules/devices/dmi_memory.c:581
+#: modules/devices/dmi_memory.c:663 modules/devices/dmi_memory.c:723
+#: modules/devices/dmi_memory.c:811 modules/devices/dmi_memory.c:857
+#: modules/devices/dmi_memory.c:938 modules/network/net.c:395
+#: modules/network/net.c:417 modules/network/net.c:418
+msgid "MiB"
+msgstr "MiB"
+
+#: modules/computer.c:915 modules/computer/memory_usage.c:77
+#: modules/computer/modules.c:149
+msgid "KiB"
+msgstr ""
+
+#: modules/computer.c:972 modules/devices/devicetree/pmac_data.c:82
 msgid "Motherboard"
 msgstr "Tarjeta madre"
 
-#: modules/computer.c:811
+#: modules/computer.c:1000
 msgid "Graphics"
 msgstr "Graficos"
 
-#: modules/computer.c:812 modules/devices.c:107
+#: modules/computer.c:1001 modules/devices.c:109
 msgid "Storage"
 msgstr "Almacenamiento"
 
-#: modules/computer.c:812 modules/devices.c:103
+#: modules/computer.c:1001 modules/devices.c:105
 msgid "Printers"
 msgstr "Impresoras"
 
-#: modules/computer.c:812
+#: modules/computer.c:1001
 msgid "Audio"
 msgstr "Audio"
 
-#: modules/computer.c:857
+#: modules/computer.c:1050
 msgid "Gathers high-level computer information"
 msgstr "Obtiene información del equipo de alto nivel"
 
@@ -1536,7 +1988,9 @@ msgstr "Lectura-escritura"
 msgid "Read-Only"
 msgstr "Solo-lectura"
 
-#: modules/computer/filesystem.c:86 modules/devices/spd-decode.c:1510
+#: modules/computer/filesystem.c:86 modules/devices/dmi_memory.c:609
+#: modules/devices/dmi_memory.c:754 modules/devices/dmi_memory.c:786
+#: modules/devices/dmi_memory.c:825 modules/devices/dmi_memory.c:894
 msgid "Size"
 msgstr "Tamaño"
 
@@ -1548,37 +2002,32 @@ msgstr "Usado"
 msgid "Available"
 msgstr "Disponible"
 
-#: modules/computer/languages.c:103
+#: modules/computer/languages.c:94
 msgid "Locale Information"
 msgstr "Información regional"
 
-#: modules/computer/languages.c:105
+#: modules/computer/languages.c:96 modules/devices/dmi_memory.c:599
+#: modules/devices/gpu.c:204
 msgid "Source"
 msgstr "Origen"
 
-#: modules/computer/languages.c:106
+#: modules/computer/languages.c:97
 msgid "Address"
 msgstr "Direccion"
 
-#: modules/computer/languages.c:107
+#: modules/computer/languages.c:98
 msgid "E-mail"
 msgstr "Correo-e"
 
-#: modules/computer/languages.c:109
+#: modules/computer/languages.c:100
 msgid "Territory"
 msgstr "Territorio"
 
-#: modules/computer/languages.c:110 modules/devices/arm/processor.c:341
-#: modules/devices/gpu.c:146 modules/devices/ia64/processor.c:166
-#: modules/devices/pci.c:114 modules/devices/ppc/processor.c:159
-msgid "Revision"
-msgstr "Revision"
-
-#: modules/computer/languages.c:111 modules/devices/dmi.c:42
+#: modules/computer/languages.c:102 modules/devices/dmi.c:44
 msgid "Date"
 msgstr "Fecha"
 
-#: modules/computer/languages.c:112
+#: modules/computer/languages.c:103
 msgid "Codeset"
 msgstr ""
 
@@ -1586,106 +2035,188 @@ msgstr ""
 msgid "Couldn't obtain load average"
 msgstr "No se pudo obtener estadisticas"
 
-#: modules/computer/modules.c:125 modules/computer/modules.c:126
-#: modules/computer/modules.c:127 modules/computer/modules.c:128
-#: modules/computer/modules.c:129 modules/devices/dmi.c:115
+#: modules/computer/memory_usage.c:106
+msgid "Total Memory"
+msgstr "Memoria total"
+
+#: modules/computer/memory_usage.c:107
+msgid "Free Memory"
+msgstr "Memoria Libre"
+
+#: modules/computer/memory_usage.c:108
+msgid "Cached Swap"
+msgstr "Intercambio"
+
+#: modules/computer/memory_usage.c:109
+msgid "High Memory"
+msgstr "Memoria alta"
+
+#: modules/computer/memory_usage.c:110
+msgid "Free High Memory"
+msgstr "Memoria alta libre"
+
+#: modules/computer/memory_usage.c:111
+msgid "Low Memory"
+msgstr "Memoria base"
+
+#: modules/computer/memory_usage.c:112
+msgid "Free Low Memory"
+msgstr "Memoria base libre"
+
+#: modules/computer/memory_usage.c:113
+msgid "Virtual Memory"
+msgstr "Memoria virtual"
+
+#: modules/computer/memory_usage.c:114
+msgid "Free Virtual Memory"
+msgstr "Memoria virtual libre"
+
+#: modules/computer/modules.c:117 modules/computer/modules.c:118
+#: modules/computer/modules.c:119 modules/computer/modules.c:120
+#: modules/computer/modules.c:121 modules/computer/modules.c:122
+#: modules/devices/dmi.c:111 modules/devices/dmi_memory.c:881
+#: modules/devices/firmware.c:246 modules/devices/x86/processor.c:693
 msgid "(Not available)"
 msgstr "(No disponible)"
 
-#: modules/computer/modules.c:142
+#: modules/computer/modules.c:148
 msgid "Module Information"
 msgstr "Información de modulo"
 
-#: modules/computer/modules.c:143
+#: modules/computer/modules.c:148 modules/devices/gpu.c:230
 msgid "Path"
 msgstr "Ruta"
 
-#: modules/computer/modules.c:144
+#: modules/computer/modules.c:148
 msgid "Used Memory"
 msgstr "Memoria usada"
 
-#: modules/computer/modules.c:144 modules/devices/devmemory.c:72
-msgid "KiB"
-msgstr ""
-
-#: modules/computer/modules.c:148
+#: modules/computer/modules.c:150
 msgid "Version Magic"
 msgstr ""
 
-#: modules/computer/modules.c:149
+#: modules/computer/modules.c:151
+msgid "In Linus' Tree"
+msgstr ""
+
+#: modules/computer/modules.c:152
+msgid "Retpoline Enabled"
+msgstr ""
+
+#: modules/computer/modules.c:152
 msgid "Copyright"
 msgstr ""
 
-#: modules/computer/modules.c:150
+#: modules/computer/modules.c:152
 msgid "Author"
 msgstr "Autor"
 
-#: modules/computer/modules.c:151
+#: modules/computer/modules.c:153
 msgid "License"
 msgstr "Licencia"
 
-#: modules/computer/modules.c:158
+#: modules/computer/modules.c:159
 msgid "Dependencies"
 msgstr "Dependencias"
 
-#: modules/computer/os.c:35 modules/computer/os.c:36 modules/computer/os.c:37
-#: modules/computer/os.c:38
+#: modules/computer/os.c:36 modules/computer/os.c:37 modules/computer/os.c:38
+#: modules/computer/os.c:39
 msgid "GNU C Library"
 msgstr "Libreria C GNU"
 
-#: modules/computer/os.c:39
+#: modules/computer/os.c:40
 msgid "uClibc or uClibc-ng"
 msgstr "Libreria uClibc/uClibc-ng"
 
-#: modules/computer/os.c:40
+#: modules/computer/os.c:41
 msgid "diet libc"
 msgstr "Libreria diet libc"
 
-#: modules/computer/os.c:112 modules/computer/os.c:115
+#: modules/computer/os.c:113 modules/computer/os.c:116
 msgid "GNOME Shell "
 msgstr ""
 
-#: modules/computer/os.c:123 modules/computer/os.c:126
+#: modules/computer/os.c:124 modules/computer/os.c:127
 msgid "Version: "
 msgstr "Versión"
 
-#: modules/computer/os.c:157
+#: modules/computer/os.c:146 modules/computer/os.c:149
+msgid "MATE Desktop Environment "
+msgstr ""
+
+#: modules/computer/os.c:180
 #, c-format
 msgid "Unknown (Window Manager: %s)"
 msgstr "Desconocido (Gestor de ventanas: %s)"
 
 #. /{desktop environment} on {session type}
-#: modules/computer/os.c:168
+#: modules/computer/os.c:191
 #, c-format
 msgid "%s on %s"
 msgstr "%s en %s"
 
-#: modules/computer/os.c:232
+#: modules/computer/os.c:261
 msgid "Terminal"
 msgstr "Terminal"
 
+#: modules/computer/os.c:278
+msgid "User access allowed"
+msgstr ""
+
+#: modules/computer/os.c:280
+msgid "User access forbidden"
+msgstr ""
+
+#: modules/computer/os.c:282
+msgid "Access allowed (running as superuser)"
+msgstr ""
+
+#: modules/computer/os.c:284
+msgid "Access forbidden? (running as superuser)"
+msgstr ""
+
+#: modules/computer/os.c:294 modules/computer/os.c:560
+msgid "Disabled"
+msgstr ""
+
+#: modules/computer/os.c:296
+msgid "Partially enabled (mmap base+stack+VDSO base)"
+msgstr ""
+
+#: modules/computer/os.c:298
+msgid "Fully enabled (mmap base+stack+VDSO base+heap)"
+msgstr ""
+
 #. /bits of entropy for rng (0)
-#: modules/computer/os.c:241
+#: modules/computer/os.c:308
 msgid "(None or not available)"
 msgstr "(Ninguno o no disponible)"
 
 #. /bits of entropy for rng (low/poor value)
-#: modules/computer/os.c:242
+#: modules/computer/os.c:309
 #, c-format
 msgid "%d bits (low)"
 msgstr "%d bits (bajo)"
 
 #. /bits of entropy for rng (medium value)
-#: modules/computer/os.c:243
+#: modules/computer/os.c:310
 #, c-format
 msgid "%d bits (medium)"
 msgstr "%d bits (promedio)"
 
 #. /bits of entropy for rng (high/good value)
-#: modules/computer/os.c:244
+#: modules/computer/os.c:311
 #, c-format
 msgid "%d bits (healthy)"
 msgstr "%d bits (saludable)"
+
+#: modules/computer/os.c:555
+msgid "Not installed"
+msgstr ""
+
+#: modules/computer/os.c:558
+msgid "Enabled"
+msgstr ""
 
 #: modules/computer/users.c:47
 msgid "User Information"
@@ -1699,13 +2230,13 @@ msgstr "ID usuario"
 msgid "Default Shell"
 msgstr "Shell principal"
 
-#: modules/devices/alpha/processor.c:88 modules/devices/devicetree.c:161
-#: modules/devices/devicetree.c:207 modules/devices/devicetree/pmac_data.c:80
-#: modules/devices/gpu.c:124 modules/devices/ia64/processor.c:165
+#: modules/devices/alpha/processor.c:88 modules/devices/devicetree.c:163
+#: modules/devices/devicetree.c:209 modules/devices/devicetree/pmac_data.c:80
+#: modules/devices/gpu.c:106 modules/devices/ia64/processor.c:165
 #: modules/devices/m68k/processor.c:84 modules/devices/mips/processor.c:75
-#: modules/devices/parisc/processor.c:155 modules/devices/ppc/processor.c:158
-#: modules/devices/riscv/processor.c:182 modules/devices/s390/processor.c:132
-#: modules/devices/spd-decode.c:1510
+#: modules/devices/monitors.c:400 modules/devices/parisc/processor.c:155
+#: modules/devices/ppc/processor.c:158 modules/devices/riscv/processor.c:182
+#: modules/devices/s390/processor.c:132
 msgid "Model"
 msgstr "Modelo"
 
@@ -1713,28 +2244,28 @@ msgstr "Modelo"
 msgid "Platform String"
 msgstr "Plataforma"
 
-#: modules/devices/alpha/processor.c:90 modules/devices/arm/processor.c:331
+#: modules/devices/alpha/processor.c:90 modules/devices/arm/processor.c:345
 #: modules/devices/ia64/processor.c:167 modules/devices/m68k/processor.c:87
 #: modules/devices/mips/processor.c:77 modules/devices/parisc/processor.c:158
 #: modules/devices/ppc/processor.c:160 modules/devices/riscv/processor.c:186
-#: modules/devices/sh/processor.c:87 modules/devices/x86/processor.c:655
+#: modules/devices/sh/processor.c:87 modules/devices/x86/processor.c:657
 msgid "Frequency"
 msgstr "Frecuencia"
 
-#: modules/devices/alpha/processor.c:91 modules/devices/arm/processor.c:332
+#: modules/devices/alpha/processor.c:91 modules/devices/arm/processor.c:346
 #: modules/devices/ia64/processor.c:168 modules/devices/m68k/processor.c:88
 #: modules/devices/mips/processor.c:78 modules/devices/parisc/processor.c:159
 #: modules/devices/ppc/processor.c:161 modules/devices/s390/processor.c:134
-#: modules/devices/sh/processor.c:90 modules/devices/x86/processor.c:656
+#: modules/devices/sh/processor.c:90 modules/devices/x86/processor.c:658
 msgid "BogoMips"
 msgstr "BogoMips"
 
-#: modules/devices/alpha/processor.c:92 modules/devices/arm/processor.c:333
+#: modules/devices/alpha/processor.c:92 modules/devices/arm/processor.c:347
 #: modules/devices/ia64/processor.c:169 modules/devices/m68k/processor.c:89
 #: modules/devices/mips/processor.c:79 modules/devices/parisc/processor.c:160
 #: modules/devices/ppc/processor.c:162 modules/devices/riscv/processor.c:187
 #: modules/devices/s390/processor.c:135 modules/devices/sh/processor.c:91
-#: modules/devices/sparc/processor.c:77 modules/devices/x86/processor.c:657
+#: modules/devices/sparc/processor.c:77 modules/devices/x86/processor.c:659
 msgid "Byte Order"
 msgstr "Orden Byte"
 
@@ -1910,76 +2441,77 @@ msgctxt "arm-flag"
 msgid "Advanced SIMD/NEON on AArch64 (arch>8)"
 msgstr "SIMD/NEON Avanzado en AArch64 (arch>8)"
 
-#: modules/devices/arm/processor.c:142
+#: modules/devices/arm/processor.c:143
 msgid "ARM Processor"
 msgstr "Procesador ARM"
 
-#: modules/devices/arm/processor.c:200 modules/devices/riscv/processor.c:147
-#: modules/devices/x86/processor.c:606
+#: modules/devices/arm/processor.c:214 modules/devices/riscv/processor.c:147
+#: modules/devices/x86/processor.c:608
 msgid "Empty List"
 msgstr "Lista vacia"
 
-#: modules/devices/arm/processor.c:226 modules/devices/x86/processor.c:268
+#: modules/devices/arm/processor.c:240 modules/devices/gpu.c:148
+#: modules/devices/gpu.c:226 modules/devices/x86/processor.c:268
 msgid "Clocks"
 msgstr "Ciclos"
 
-#: modules/devices/arm/processor.c:272 modules/devices/arm/processor.c:285
+#: modules/devices/arm/processor.c:286 modules/devices/arm/processor.c:299
 #: modules/devices/x86/processor.c:314 modules/devices/x86/processor.c:327
 #, c-format
 msgid "%.2f-%.2f %s=%dx\n"
 msgstr ""
 
-#: modules/devices/arm/processor.c:328
+#: modules/devices/arm/processor.c:342
 msgid "Linux Name"
 msgstr "Nombre Linux"
 
-#: modules/devices/arm/processor.c:329
+#: modules/devices/arm/processor.c:343
 msgid "Decoded Name"
 msgstr "Nombre decodificado"
 
-#: modules/devices/arm/processor.c:330 modules/network/net.c:453
+#: modules/devices/arm/processor.c:344 modules/network/net.c:453
 msgid "Mode"
 msgstr "Modo"
 
-#: modules/devices/arm/processor.c:336
+#: modules/devices/arm/processor.c:350
 msgid "ARM"
 msgstr "ARM"
 
-#: modules/devices/arm/processor.c:337
+#: modules/devices/arm/processor.c:351
 msgid "Implementer"
 msgstr "Implementador"
 
-#: modules/devices/arm/processor.c:338
+#: modules/devices/arm/processor.c:352 modules/devices/dmi_memory.c:896
 msgid "Part"
 msgstr "Parte"
 
-#: modules/devices/arm/processor.c:339 modules/devices/ia64/processor.c:162
+#: modules/devices/arm/processor.c:353 modules/devices/ia64/processor.c:162
 #: modules/devices/parisc/processor.c:156 modules/devices/riscv/processor.c:183
 msgid "Architecture"
 msgstr "Arquitectura"
 
-#: modules/devices/arm/processor.c:340
+#: modules/devices/arm/processor.c:354
 msgid "Variant"
 msgstr "Variante"
 
-#: modules/devices/arm/processor.c:342 modules/devices/riscv/processor.c:190
-#: modules/devices/sparc/processor.c:78 modules/devices/x86/processor.c:663
+#: modules/devices/arm/processor.c:356 modules/devices/riscv/processor.c:190
+#: modules/devices/sparc/processor.c:78 modules/devices/x86/processor.c:665
 msgid "Capabilities"
 msgstr "Capacidades"
 
-#: modules/devices/arm/processor.c:446
+#: modules/devices/arm/processor.c:468
 msgid "SOC/Package"
 msgstr "SOC/Paquete"
 
-#: modules/devices/arm/processor.c:450 modules/devices/x86/processor.c:698
+#: modules/devices/arm/processor.c:472 modules/devices/x86/processor.c:751
 msgid "Logical CPU Config"
 msgstr ""
 
-#: modules/devices/arm/processor.c:467
+#: modules/devices/arm/processor.c:489
 msgid "SOC/Package Information"
 msgstr "Información SOC/Paquete"
 
-#: modules/devices/battery.c:181
+#: modules/devices/battery.c:178
 #, c-format
 msgid ""
 "\n"
@@ -2000,7 +2532,7 @@ msgstr ""
 "Numero de modelo=%s\n"
 "Numero de serie=%s\n"
 
-#: modules/devices/battery.c:258
+#: modules/devices/battery.c:255
 #, c-format
 msgid ""
 "\n"
@@ -2021,7 +2553,7 @@ msgstr ""
 "Numero de modelo=%s\n"
 "Numero de serial=%s\n"
 
-#: modules/devices/battery.c:346
+#: modules/devices/battery.c:343
 #, c-format
 msgid ""
 "\n"
@@ -2040,7 +2572,7 @@ msgstr ""
 "Versión del driver APM=%s\n"
 "APM BIOS version=%s\n"
 
-#: modules/devices/battery.c:358
+#: modules/devices/battery.c:355
 #, c-format
 msgid ""
 "\n"
@@ -2057,7 +2589,7 @@ msgstr ""
 "Versión del driver APM=%s\n"
 "Versión del BIOS APM=%s\n"
 
-#: modules/devices/battery.c:385
+#: modules/devices/battery.c:382
 msgid ""
 "[No batteries]\n"
 "No batteries found on this system=\n"
@@ -2069,31 +2601,40 @@ msgstr ""
 msgid "Graphics Processors"
 msgstr ""
 
-#: modules/devices.c:101 modules/devices/pci.c:143
+#: modules/devices.c:101 modules/devices/monitors.c:445
+#: modules/devices/monitors.c:492
+msgid "Monitors"
+msgstr "Monitores"
+
+#: modules/devices.c:102 modules/devices/pci.c:163
 msgid "PCI Devices"
 msgstr "Dispositivos PCI"
 
-#: modules/devices.c:102 modules/devices/usb.c:92
+#: modules/devices.c:103 modules/devices/usb.c:210
 msgid "USB Devices"
 msgstr "Dispositivos USB"
 
 #: modules/devices.c:104
+msgid "Firmware"
+msgstr ""
+
+#: modules/devices.c:106
 msgid "Battery"
 msgstr "Batería"
 
-#: modules/devices.c:105
+#: modules/devices.c:107
 msgid "Sensors"
 msgstr "Sensores"
 
-#: modules/devices.c:109
-msgid "DMI"
-msgstr "DMI"
-
 #: modules/devices.c:110
-msgid "Memory SPD"
-msgstr "Memoria SPD"
+msgid "System DMI"
+msgstr ""
 
-#: modules/devices.c:115
+#: modules/devices.c:111
+msgid "Memory Devices"
+msgstr ""
+
+#: modules/devices.c:113 modules/devices.c:115
 msgid "Device Tree"
 msgstr "Arbol de dispositivos"
 
@@ -2101,21 +2642,21 @@ msgstr "Arbol de dispositivos"
 msgid "Resources"
 msgstr "Recursos"
 
-#: modules/devices.c:162
+#: modules/devices.c:177
 #, c-format
 msgid "%d physical processor"
 msgid_plural "%d physical processors"
 msgstr[0] "%d procesador real"
 msgstr[1] "%d procesadores reales"
 
-#: modules/devices.c:163
+#: modules/devices.c:178
 #, c-format
 msgid "%d core"
 msgid_plural "%d cores"
 msgstr[0] "%d nucleo"
 msgstr[1] "%d nucleos"
 
-#: modules/devices.c:164
+#: modules/devices.c:179
 #, c-format
 msgid "%d thread"
 msgid_plural "%d threads"
@@ -2123,106 +2664,102 @@ msgstr[0] "%d hilo"
 msgstr[1] "%d hilos"
 
 #. /NP procs; NC cores; NT threads
-#: modules/devices.c:165
+#: modules/devices.c:180
 #, c-format
 msgid "%s; %s; %s"
 msgstr ""
 
-#: modules/devices.c:575
-msgid "Field"
-msgstr "Campo"
-
-#: modules/devices.c:575 modules/devices.c:614
-msgid "Value"
-msgstr "Valor"
-
-#: modules/devices.c:614
+#: modules/devices.c:726
 msgid "Sensor"
 msgstr "Sensor"
 
-#: modules/devices.c:661
+#: modules/devices.c:773 modules/devices/dmi_memory.c:826
 msgid "Devices"
 msgstr "Dispositivos"
 
-#: modules/devices.c:673
+#: modules/devices.c:785
 msgid "Update PCI ID listing"
 msgstr "Actualizar listado de ids PCI"
 
-#: modules/devices.c:685
+#: modules/devices.c:797
 msgid "Update CPU feature database"
 msgstr "Actualizar base de datos de características de CPU"
 
-#: modules/devices.c:713
+#: modules/devices.c:825
 msgid "Gathers information about hardware devices"
 msgstr "Obtiene información acerca de los dispositivos de hardware"
 
-#: modules/devices.c:732
+#: modules/devices.c:844
 msgid "Resource information requires superuser privileges"
 msgstr "Información de recursos require privilegios de superusuario"
 
-#: modules/devices/devicetree.c:50
+#: modules/devices.c:850
+msgid ""
+"Any NVMe storage devices present are not listed.\n"
+"<b><i>udisksd</i></b> is required for NVMe devices."
+msgstr ""
+
+#: modules/devices/devicetree.c:52
 msgid "Properties"
 msgstr "Propiedades"
 
-#: modules/devices/devicetree.c:51
+#: modules/devices/devicetree.c:53
 msgid "Children"
 msgstr "Hijos"
 
-#: modules/devices/devicetree.c:87
+#: modules/devices/devicetree.c:89
 msgid "Node"
 msgstr "Nodo"
 
-#: modules/devices/devicetree.c:88
+#: modules/devices/devicetree.c:90
 msgid "Node Path"
 msgstr "Ruta nodo"
 
-#: modules/devices/devicetree.c:89
+#: modules/devices/devicetree.c:91
 msgid "Alias"
 msgstr "Alterno"
 
-#: modules/devices/devicetree.c:89 modules/devices/devicetree.c:90
-msgid "(None)"
-msgstr "(ninguno)"
-
-#: modules/devices/devicetree.c:90
+#: modules/devices/devicetree.c:92
 msgid "Symbol"
 msgstr "Simbolo"
 
-#: modules/devices/devicetree.c:143 modules/devices/devicetree/pmac_data.c:79
+#: modules/devices/devicetree.c:145 modules/devices/devicetree/pmac_data.c:79
 msgid "Platform"
 msgstr "Plataforma"
 
-#: modules/devices/devicetree.c:144 modules/devices/devicetree.c:209
+#: modules/devices/devicetree.c:146 modules/devices/devicetree.c:211
+#: modules/devices/gpu.c:231
 msgid "Compatible"
 msgstr "Compatible"
 
-#: modules/devices/devicetree.c:145
+#: modules/devices/devicetree.c:147
 msgid "GPU-compatible"
 msgstr "GPU-compatble"
 
-#: modules/devices/devicetree.c:160
+#: modules/devices/devicetree.c:162
 msgid "Raspberry Pi or Compatible"
 msgstr "Raspberry Pi o similar"
 
-#: modules/devices/devicetree.c:162 modules/devices/devicetree.c:189
-#: modules/devices/devicetree.c:208 modules/devices/devicetree/rpi_data.c:161
-#: modules/devices/dmi.c:49 modules/devices/dmi.c:55
+#: modules/devices/devicetree.c:164 modules/devices/devicetree.c:191
+#: modules/devices/devicetree.c:210 modules/devices/devicetree/rpi_data.c:168
+#: modules/devices/dmi.c:41 modules/devices/dmi.c:51 modules/devices/dmi.c:57
+#: modules/devices/usb.c:178
 msgid "Serial Number"
 msgstr "Numero serial"
 
-#: modules/devices/devicetree.c:163 modules/devices/devicetree/rpi_data.c:158
+#: modules/devices/devicetree.c:165 modules/devices/devicetree/rpi_data.c:165
 msgid "RCode"
 msgstr "Codigo R"
 
-#: modules/devices/devicetree.c:163
+#: modules/devices/devicetree.c:165
 msgid "No revision code available; unable to lookup model details."
 msgstr "No hay codigo de revision disponible, imposible obtener detalles"
 
-#: modules/devices/devicetree.c:188
+#: modules/devices/devicetree.c:190
 msgid "More"
 msgstr "Mas"
 
-#: modules/devices/devicetree.c:268
+#: modules/devices/devicetree.c:271
 msgid "Messages"
 msgstr "Mensajes"
 
@@ -2246,87 +2783,51 @@ msgstr "Cache L2"
 msgid "PMAC Generation"
 msgstr "PMAC generacion"
 
-#: modules/devices/devicetree/rpi_data.c:153
-#: modules/devices/devicetree/rpi_data.c:154
+#: modules/devices/devicetree/rpi_data.c:160
+#: modules/devices/devicetree/rpi_data.c:161
 msgid "Raspberry Pi"
 msgstr "Raspberry Pi"
 
-#: modules/devices/devicetree/rpi_data.c:154
+#: modules/devices/devicetree/rpi_data.c:161
 msgid "Board Name"
 msgstr "Nombre Tarjeta"
 
-#: modules/devices/devicetree/rpi_data.c:155
+#: modules/devices/devicetree/rpi_data.c:162
 msgid "PCB Revision"
 msgstr "Revision PCB"
 
-#: modules/devices/devicetree/rpi_data.c:156
+#: modules/devices/devicetree/rpi_data.c:163
 msgid "Introduction"
 msgstr "Introducido"
 
-#: modules/devices/devicetree/rpi_data.c:157 modules/devices/spd-decode.c:1510
+#: modules/devices/devicetree/rpi_data.c:164 modules/devices/usb.c:170
 msgid "Manufacturer"
 msgstr "Manufacturado"
 
-#: modules/devices/devicetree/rpi_data.c:159
+#: modules/devices/devicetree/rpi_data.c:166
 msgid "SOC (spec)"
 msgstr "SOC (specif)"
 
-#: modules/devices/devicetree/rpi_data.c:160
+#: modules/devices/devicetree/rpi_data.c:167
 msgid "Memory (spec)"
 msgstr "Memoria (specif)"
 
-#: modules/devices/devicetree/rpi_data.c:162
+#: modules/devices/devicetree/rpi_data.c:169
 msgid "Permanent overvolt bit"
 msgstr "Bit de sobrevoltage permanente"
 
-#: modules/devices/devicetree/rpi_data.c:162
+#: modules/devices/devicetree/rpi_data.c:169
 msgctxt "rpi-ov-bit"
 msgid "Set"
 msgstr "Asignado"
 
-#: modules/devices/devicetree/rpi_data.c:162
+#: modules/devices/devicetree/rpi_data.c:169
 msgctxt "rpi-ov-bit"
 msgid "Not set"
 msgstr "Sin ajustar"
 
-#: modules/devices/devmemory.c:101
-msgid "Total Memory"
-msgstr "Memoria total"
-
-#: modules/devices/devmemory.c:102
-msgid "Free Memory"
-msgstr "Memoria Libre"
-
-#: modules/devices/devmemory.c:103
-msgid "Cached Swap"
-msgstr "Intercambio"
-
-#: modules/devices/devmemory.c:104
-msgid "High Memory"
-msgstr "Memoria alta"
-
-#: modules/devices/devmemory.c:105
-msgid "Free High Memory"
-msgstr "Memoria alta libre"
-
-#: modules/devices/devmemory.c:106
-msgid "Low Memory"
-msgstr "Memoria base"
-
-#: modules/devices/devmemory.c:107
-msgid "Free Low Memory"
-msgstr "Memoria base libre"
-
-#: modules/devices/devmemory.c:108
-msgid "Virtual Memory"
-msgstr "Memoria virtual"
-
-#: modules/devices/devmemory.c:109
-msgid "Free Virtual Memory"
-msgstr "Memoria virtual libre"
-
-#: modules/devices/dmi.c:36 modules/devices/inputdevices.c:120
-#: modules/devices/usb.c:63
+#: modules/devices/dmi.c:36 modules/devices/inputdevices.c:115
+#: modules/devices/usb.c:167
 msgid "Product"
 msgstr "Producto"
 
@@ -2335,90 +2836,402 @@ msgstr "Producto"
 msgid "Family"
 msgstr "Familia"
 
-#: modules/devices/dmi.c:41
+#: modules/devices/dmi.c:42
+msgid "SKU"
+msgstr ""
+
+#: modules/devices/dmi.c:43
 msgid "BIOS"
 msgstr ""
 
-#: modules/devices/dmi.c:50 modules/devices/dmi.c:56
+#: modules/devices/dmi.c:52 modules/devices/dmi.c:58
 msgid "Asset Tag"
 msgstr ""
 
-#: modules/devices/dmi.c:51
-msgid "Chassis"
-msgstr ""
-
-#: modules/devices/dmi.c:116
+#: modules/devices/dmi.c:115 modules/devices/dmi_memory.c:882
+#: modules/devices/x86/processor.c:694
 msgid "(Not available; Perhaps try running HardInfo as root.)"
 msgstr ""
 
-#: modules/devices/gpu.c:102 modules/devices/pci.c:79
+#: modules/devices/dmi.c:156
+msgid "DMI Unavailable"
+msgstr ""
+
+#: modules/devices/dmi.c:158
+msgid "DMI is not avaliable. Perhaps this platform does not provide DMI."
+msgstr ""
+
+#: modules/devices/dmi.c:159
+msgid "DMI is not available; Perhaps try running HardInfo as root."
+msgstr ""
+
+#: modules/devices/dmi_memory.c:598
+msgid "Serial Presence Detect (SPD)"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:601
+msgid "SPD Revision"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:602 modules/devices/dmi_memory.c:748
+msgid "Form Factor"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:604
+msgid "Module Vendor"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:606
+msgid "DRAM Vendor"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:608 modules/devices/dmi_memory.c:753
+msgid "Part Number"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:610
+msgid "Manufacturing Date (Week / Year)"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:644 modules/devices/dmi_memory.c:879
+msgid "Memory Device List"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:686
+msgid "Memory Array"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:687 modules/devices/x86/processor.c:713
+msgid "DMI Handle"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:688 modules/devices/dmi_memory.c:746
+#: modules/devices/dmi_memory.c:784 modules/devices/dmi_memory.c:893
+msgid "Locator"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:689
+msgid "Use"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:690
+msgid "Error Correction Type"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:691
+msgid "Size (Present / Max)"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:692
+msgid "Devices (Populated / Sockets)"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:693 modules/devices/dmi_memory.c:827
+msgid "Types Present"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:744 modules/devices/dmi_memory.c:782
+msgid "Memory Socket"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:745 modules/devices/dmi_memory.c:783
+msgid "DMI Handles (Array, Socket)"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:747 modules/devices/dmi_memory.c:785
+msgid "Bank Locator"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:755
+msgid "Rated Speed"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:756
+msgid "Configured Speed"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:757
+msgid "Data Width/Total Width"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:758
+msgid "Rank"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:759
+msgid "Minimum Voltage"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:760
+msgid "Maximum Voltage"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:761
+msgid "Configured Voltage"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:786 modules/devices/dmi_memory.c:793
+#: modules/devices/monitors.c:492
+msgid "(Empty)"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:824
+msgid "Serial Presence Detect (SPD) Summary"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:947
+msgid " <b><i>dmidecode</i></b> utility available"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:948
+msgid " ... <i>and</i> HardInfo running with superuser privileges"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:949
+msgid " <b><i>eeprom</i></b> module loaded (for SDR, DDR, DDR2, DDR3)"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:950
+msgid ""
+" ... <i>or</i> <b><i>ee1004</i></b> module loaded <b>and configured!</b> "
+"(for DDR4)"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:961
+msgid "Memory information requires <b>one or both</b> of the following:"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:982
+msgid ""
+"\"More often than not, information contained in the DMI tables is "
+"inaccurate,\n"
+"incomplete or simply wrong.\" -<i><b>dmidecode</b></i> manual page"
+msgstr ""
+
+#: modules/devices/firmware.c:69
+msgid "Device cannot be removed easily"
+msgstr ""
+
+#: modules/devices/firmware.c:70
+msgid "Device is updatable in this or any other mode"
+msgstr ""
+
+#: modules/devices/firmware.c:71
+msgid "Update can only be done from offline mode"
+msgstr ""
+
+#: modules/devices/firmware.c:72
+msgid "Requires AC power"
+msgstr ""
+
+#: modules/devices/firmware.c:73
+msgid "Is locked and can be unlocked"
+msgstr ""
+
+#: modules/devices/firmware.c:74
+msgid "Is found in current metadata"
+msgstr ""
+
+#: modules/devices/firmware.c:75
+msgid "Requires a bootloader mode to be manually enabled by the user"
+msgstr ""
+
+#: modules/devices/firmware.c:76
+msgid "Has been registered with other plugins"
+msgstr ""
+
+#: modules/devices/firmware.c:77
+msgid "Requires a reboot to apply firmware or to reload hardware"
+msgstr ""
+
+#: modules/devices/firmware.c:78
+msgid "Requires system shutdown to apply firmware"
+msgstr ""
+
+#: modules/devices/firmware.c:79
+msgid "Has been reported to a metadata server"
+msgstr ""
+
+#: modules/devices/firmware.c:80
+msgid "User has been notified"
+msgstr ""
+
+#: modules/devices/firmware.c:81
+msgid "Always use the runtime version rather than the bootloader"
+msgstr ""
+
+#: modules/devices/firmware.c:82
+msgid "Install composite firmware on the parent before the child"
+msgstr ""
+
+#: modules/devices/firmware.c:83
+msgid "Is currently in bootloader mode"
+msgstr ""
+
+#: modules/devices/firmware.c:84
+msgid "The hardware is waiting to be replugged"
+msgstr ""
+
+#: modules/devices/firmware.c:85
+msgid "Ignore validation safety checks when flashing this device"
+msgstr ""
+
+#: modules/devices/firmware.c:86
+msgid "Requires the update to be retried with a new plugin"
+msgstr ""
+
+#: modules/devices/firmware.c:87
+msgid "Do not add instance IDs from the device baseclass"
+msgstr ""
+
+#: modules/devices/firmware.c:88
+msgid "Device update needs to be separately activated"
+msgstr ""
+
+#: modules/devices/firmware.c:89
+msgid ""
+"Ensure the version is a valid semantic version, e.g. numbers separated with "
+"dots"
+msgstr ""
+
+#: modules/devices/firmware.c:90
+msgid "Extra metadata can be exposed about this device"
+msgstr ""
+
+#: modules/devices/firmware.c:104
+msgid "DeviceId"
+msgstr ""
+
+#: modules/devices/firmware.c:104
+msgid "Guid"
+msgstr ""
+
+#: modules/devices/firmware.c:104
+msgid "Plugin"
+msgstr ""
+
+#: modules/devices/firmware.c:104 modules/network.c:380
+msgid "Flags"
+msgstr "Marcas"
+
+#: modules/devices/firmware.c:105
+msgid "VendorId"
+msgstr ""
+
+#: modules/devices/firmware.c:105
+msgid "VersionBootloader"
+msgstr ""
+
+#: modules/devices/firmware.c:106
+msgid "Icon"
+msgstr ""
+
+#: modules/devices/firmware.c:106
+msgid "InstallDuration"
+msgstr ""
+
+#: modules/devices/firmware.c:106
+msgid "Created"
+msgstr ""
+
+#: modules/devices/firmware.c:245
+msgid "Firmware List"
+msgstr ""
+
+#: modules/devices/firmware.c:258
+msgid "Requires the <i><b>fwupdmgr</b></i> utility."
+msgstr ""
+
+#: modules/devices/gpu.c:84 modules/devices/pci.c:97
 msgid "SVendor"
 msgstr ""
 
-#: modules/devices/gpu.c:103 modules/devices/pci.c:80
+#: modules/devices/gpu.c:85 modules/devices/pci.c:98
 msgid "SDevice"
 msgstr ""
 
-#: modules/devices/gpu.c:111 modules/devices/pci.c:90
+#: modules/devices/gpu.c:93 modules/devices/pci.c:108
 msgid "PCI Express"
 msgstr ""
 
-#: modules/devices/gpu.c:112 modules/devices/pci.c:92
+#: modules/devices/gpu.c:94 modules/devices/pci.c:110
 msgid "Maximum Link Width"
 msgstr ""
 
-#: modules/devices/gpu.c:113 modules/devices/pci.c:94
+#: modules/devices/gpu.c:95 modules/devices/pci.c:112
 msgid "Maximum Link Speed"
 msgstr ""
 
-#: modules/devices/gpu.c:113 modules/devices/pci.c:93 modules/devices/pci.c:94
+#: modules/devices/gpu.c:95 modules/devices/pci.c:111 modules/devices/pci.c:112
 msgid "GT/s"
 msgstr ""
 
-#: modules/devices/gpu.c:123
+#: modules/devices/gpu.c:105
 msgid "NVIDIA"
 msgstr ""
 
-#: modules/devices/gpu.c:125
+#: modules/devices/gpu.c:107
 msgid "BIOS Version"
 msgstr ""
 
-#: modules/devices/gpu.c:126
+#: modules/devices/gpu.c:108
 msgid "UUID"
 msgstr ""
 
-#: modules/devices/gpu.c:141 modules/devices/gpu.c:183
-#: modules/devices/inputdevices.c:115 modules/devices/pci.c:111
-#: modules/devices/usb.c:62
+#: modules/devices/gpu.c:142 modules/devices/gpu.c:222
+#: modules/devices/inputdevices.c:110 modules/devices/pci.c:129
+#: modules/devices/usb.c:166
 msgid "Device Information"
 msgstr "Información de dispositivo"
 
-#: modules/devices/gpu.c:142 modules/devices/gpu.c:184
+#: modules/devices/gpu.c:143 modules/devices/gpu.c:223
 msgid "Location"
 msgstr ""
 
-#: modules/devices/gpu.c:143
+#: modules/devices/gpu.c:144
 msgid "DRM Device"
 msgstr ""
 
-#: modules/devices/gpu.c:144 modules/devices/pci.c:112 modules/devices/usb.c:67
+#: modules/devices/gpu.c:145 modules/devices/pci.c:130
+#: modules/devices/usb.c:133 modules/devices/usb.c:174
 msgid "Class"
 msgstr "clase"
 
-#: modules/devices/gpu.c:150 modules/devices/pci.c:117
+#: modules/devices/gpu.c:154 modules/devices/pci.c:135
 msgid "In Use"
 msgstr ""
 
-#: modules/devices/gpu.c:174
+#: modules/devices/gpu.c:185
 msgid "Unknown integrated GPU"
 msgstr ""
 
-#: modules/devices/gpu.c:185
-msgid "DT Compatibility"
+#: modules/devices/gpu.c:191
+msgid "clock-frequency property"
 msgstr ""
 
-#: modules/devices/gpu.c:201
+#: modules/devices/gpu.c:192
+msgid "Operating Points (OPPv1)"
+msgstr ""
+
+#: modules/devices/gpu.c:193
+msgid "Operating Points (OPPv2)"
+msgstr ""
+
+#: modules/devices/gpu.c:229
+msgid "Device Tree Node"
+msgstr ""
+
+#: modules/devices/gpu.c:232 modules/devices/monitors.c:471
+#: modules/network/net.c:454
+msgid "Status"
+msgstr "Estado"
+
+#: modules/devices/gpu.c:249
 msgid "GPUs"
+msgstr ""
+
+#: modules/devices/gpu.c:273
+msgid "No GPU devices found"
 msgstr ""
 
 #: modules/devices/ia64/processor.c:108
@@ -2437,16 +3250,16 @@ msgstr "Registros"
 msgid "Features"
 msgstr "Capacidades"
 
-#: modules/devices/inputdevices.c:118 modules/devices/pci.c:121
-#: modules/devices/usb.c:71
+#: modules/devices/inputdevices.c:113 modules/devices/pci.c:139
+#: modules/devices/usb.c:180
 msgid "Bus"
 msgstr "Bus"
 
-#: modules/devices/inputdevices.c:124
+#: modules/devices/inputdevices.c:119
 msgid "Connected to"
 msgstr "Connectado a"
 
-#: modules/devices/inputdevices.c:128
+#: modules/devices/inputdevices.c:123
 msgid "InfraRed port"
 msgstr "Puerto Infrarojo"
 
@@ -2466,13 +3279,157 @@ msgstr "Calibracion"
 msgid "System Type"
 msgstr "Tipo sistema"
 
+#: modules/devices/monitors.c:29 modules/devices/monitors.c:253
+#: modules/devices/monitors.c:346 modules/devices/spd-decode.c:595
+msgid "(Unspecified)"
+msgstr ""
+
+#: modules/devices/monitors.c:228
+#, c-format
+msgid "Week %d of %d"
+msgstr ""
+
+#: modules/devices/monitors.c:238
+msgid "Ok"
+msgstr ""
+
+#: modules/devices/monitors.c:238
+msgid "Fail"
+msgstr ""
+
+#: modules/devices/monitors.c:266 modules/devices/monitors.c:274
+#: modules/devices/monitors.c:282 modules/devices/monitors.c:293
+#: modules/devices/monitors.c:301 modules/devices/monitors.c:308
+#: modules/devices/monitors.c:316 modules/devices/monitors.c:324
+#: modules/devices/monitors.c:332 modules/devices/monitors.c:338
+msgid "(Empty List)"
+msgstr ""
+
+#: modules/devices/monitors.c:390
+msgid "Signal Type"
+msgstr ""
+
+#: modules/devices/monitors.c:390
+msgid "Digital"
+msgstr ""
+
+#: modules/devices/monitors.c:390
+msgid "Analog"
+msgstr ""
+
+#: modules/devices/monitors.c:391 modules/devices/usb.c:132
+#: modules/network.c:310 modules/network.c:363 modules/network.c:380
+msgid "Interface"
+msgstr "Interfaz"
+
+#: modules/devices/monitors.c:392
+msgid "Bits per Color Channel"
+msgstr ""
+
+#: modules/devices/monitors.c:393
+msgid "Speaker Allocation"
+msgstr ""
+
+#: modules/devices/monitors.c:394
+msgid "Output (Max)"
+msgstr ""
+
+#: modules/devices/monitors.c:397
+msgid "EDID Device"
+msgstr ""
+
+#: modules/devices/monitors.c:401
+msgid "Serial"
+msgstr ""
+
+#: modules/devices/monitors.c:402
+msgid "Manufacture Date"
+msgstr ""
+
+#: modules/devices/monitors.c:403
+msgid "EDID Meta"
+msgstr ""
+
+#: modules/devices/monitors.c:404
+msgid "Data Size"
+msgstr ""
+
+#: modules/devices/monitors.c:404
+msgid "bytes"
+msgstr ""
+
+#: modules/devices/monitors.c:406
+msgid "Extension Blocks"
+msgstr ""
+
+#: modules/devices/monitors.c:407
+msgid "Extended to"
+msgstr ""
+
+#: modules/devices/monitors.c:408
+msgid "Checksum"
+msgstr ""
+
+#: modules/devices/monitors.c:409
+msgid "EDID Descriptors"
+msgstr ""
+
+#: modules/devices/monitors.c:410
+msgid "Detailed Timing Descriptors (DTD)"
+msgstr ""
+
+#: modules/devices/monitors.c:411
+msgid "Established Timings Bitmap (ETB)"
+msgstr ""
+
+#: modules/devices/monitors.c:412
+msgid "Standard Timings (STD)"
+msgstr ""
+
+#: modules/devices/monitors.c:413
+msgid "E-EDID Extension Blocks"
+msgstr ""
+
+#: modules/devices/monitors.c:414
+msgid "EIA/CEA-861 Data Blocks"
+msgstr ""
+
+#: modules/devices/monitors.c:415
+msgid "EIA/CEA-861 Short Audio Descriptors"
+msgstr ""
+
+#: modules/devices/monitors.c:416
+msgid "EIA/CEA-861 Short Video Descriptors"
+msgstr ""
+
+#: modules/devices/monitors.c:417
+msgid "DisplayID Timings"
+msgstr ""
+
+#: modules/devices/monitors.c:418
+msgid "DisplayID Strings"
+msgstr ""
+
+#: modules/devices/monitors.c:419
+msgid "Hex Dump"
+msgstr ""
+
+#: modules/devices/monitors.c:419
+msgid "Data"
+msgstr ""
+
+#: modules/devices/monitors.c:469 modules/devices/monitors.c:501
+#: modules/devices/pci.c:137 modules/devices/usb.c:179
+msgid "Connection"
+msgstr ""
+
+#: modules/devices/monitors.c:470
+msgid "DRM"
+msgstr ""
+
 #: modules/devices/parisc/processor.c:107
 msgid "PA-RISC Processor"
 msgstr "Procesador PA-RISC"
-
-#: modules/devices/parisc/processor.c:157
-msgid "System"
-msgstr "Sistema"
 
 #: modules/devices/parisc/processor.c:161
 msgid "HVersion"
@@ -2482,31 +3439,23 @@ msgstr "HVersion"
 msgid "SVersion"
 msgstr "SVersion"
 
-#: modules/devices/parisc/processor.c:163 modules/devices/x86/processor.c:660
-msgid "Cache"
-msgstr "Cache"
-
-#: modules/devices/pci.c:91
+#: modules/devices/pci.c:109
 msgid "Link Width"
 msgstr ""
 
-#: modules/devices/pci.c:93
+#: modules/devices/pci.c:111
 msgid "Link Speed"
 msgstr ""
 
-#: modules/devices/pci.c:119 modules/devices/usb.c:70
-msgid "Connection"
-msgstr ""
-
-#: modules/devices/pci.c:120
+#: modules/devices/pci.c:138
 msgid "Domain"
 msgstr "Dominio"
 
-#: modules/devices/pci.c:123
+#: modules/devices/pci.c:141
 msgid "Function"
 msgstr ""
 
-#: modules/devices/pci.c:161
+#: modules/devices/pci.c:185
 msgid "No PCI devices found"
 msgstr "No se encontro dispositivos PCI"
 
@@ -2714,35 +3663,416 @@ msgstr "Frecuencya de Bus"
 msgid "Module Frequency"
 msgstr "Frecuencia modular"
 
-#: modules/devices/spd-decode.c:1475
-msgid ""
-"[SPD]\n"
-"Please load the eeprom module to obtain information about memory SPD=\n"
-"[$ShellParam$]\n"
-"ReloadInterval=500\n"
+#: modules/devices/spd-decode.c:306
+msgid "Row address bits"
 msgstr ""
-"[SPD]\n"
-"Por favor carge el modulo eeprom para obtener información de memorias SPD=\n"
-"[$ShellParam$]\n"
-"ReloadInterval=500\n"
 
-#: modules/devices/spd-decode.c:1480
-msgid ""
-"[SPD]\n"
-"Reading memory SPD not supported on this system=\n"
+#: modules/devices/spd-decode.c:307
+msgid "Column address bits"
 msgstr ""
-"[SPD]\n"
-"Lectura de memorias no soportado en este sistema=\n"
 
-#: modules/devices/spd-decode.c:1509
-msgid "SPD"
-msgstr "SPD"
+#: modules/devices/spd-decode.c:308
+msgid "Number of rows"
+msgstr ""
 
-#: modules/devices/spd-decode.c:1510
-msgid "Bank"
-msgstr "Ranura"
+#: modules/devices/spd-decode.c:309
+msgid "Data width"
+msgstr ""
 
-#: modules/devices/storage.c:43
+#: modules/devices/spd-decode.c:310
+msgid "Interface signal levels"
+msgstr ""
+
+#: modules/devices/spd-decode.c:311
+msgid "Configuration type"
+msgstr ""
+
+#: modules/devices/spd-decode.c:312
+msgid "Refresh"
+msgstr ""
+
+#: modules/devices/spd-decode.c:313 modules/devices/spd-decode.c:397
+#: modules/devices/spd-decode.c:492 modules/devices/spd-decode.c:617
+msgid "Timings"
+msgstr ""
+
+#: modules/devices/spd-decode.c:593
+msgid "Ranks"
+msgstr ""
+
+#: modules/devices/spd-decode.c:594
+msgid "IO Pins per Chip"
+msgstr ""
+
+#: modules/devices/spd-decode.c:595
+msgid "Die count"
+msgstr ""
+
+#: modules/devices/spd-decode.c:596
+msgid "Thermal Sensor"
+msgstr ""
+
+#: modules/devices/spd-decode.c:596
+msgid "Present"
+msgstr ""
+
+#: modules/devices/spd-decode.c:596
+msgid "Not present"
+msgstr ""
+
+#: modules/devices/spd-decode.c:597
+msgid "Supported Voltages"
+msgstr ""
+
+#: modules/devices/spd-decode.c:601
+msgid "Supported CAS Latencies"
+msgstr ""
+
+#: modules/devices/spd-decode.c:638
+msgid "Invalid"
+msgstr ""
+
+#: modules/devices/spd-decode.c:870
+msgid "XMP Profile"
+msgstr ""
+
+#: modules/devices/spd-decode.c:871 modules/devices/usb.c:173
+msgid "Speed"
+msgstr "Velocidad"
+
+#: modules/devices/spd-decode.c:872 modules/devices/spd-decode.c:914
+#: modules/devices/x86/processor.c:715
+msgid "Voltage"
+msgstr ""
+
+#: modules/devices/spd-decode.c:873
+msgid "XMP Timings"
+msgstr ""
+
+#: modules/devices/spd-decode.c:915
+msgid "XMP"
+msgstr ""
+
+#: modules/devices/spd-decode.c:916
+msgid "JEDEC Timings"
+msgstr ""
+
+#: modules/devices/storage.c:84
+msgid "Read Error Rate"
+msgstr ""
+
+#: modules/devices/storage.c:85
+msgid "Throughput Performance"
+msgstr ""
+
+#: modules/devices/storage.c:86
+msgid "Spin-Up Time"
+msgstr ""
+
+#: modules/devices/storage.c:87
+msgid "Start/Stop Count"
+msgstr ""
+
+#: modules/devices/storage.c:88
+msgid "Reallocated Sector Count"
+msgstr ""
+
+#: modules/devices/storage.c:89
+msgid "Read Channel Margin"
+msgstr ""
+
+#: modules/devices/storage.c:90
+msgid "Seek Error Rate"
+msgstr ""
+
+#: modules/devices/storage.c:91
+msgid "Seek Timer Performance"
+msgstr ""
+
+#: modules/devices/storage.c:92 modules/devices/storage.c:131
+msgid "Power-On Hours"
+msgstr ""
+
+#: modules/devices/storage.c:93
+msgid "Spin Retry Count"
+msgstr ""
+
+#: modules/devices/storage.c:94
+msgid "Calibration Retry Count"
+msgstr ""
+
+#: modules/devices/storage.c:95
+msgid "Power Cycle Count"
+msgstr ""
+
+#: modules/devices/storage.c:96 modules/devices/storage.c:113
+msgid "Soft Read Error Rate"
+msgstr ""
+
+#: modules/devices/storage.c:97
+msgid "Runtime Bad Block"
+msgstr ""
+
+#: modules/devices/storage.c:98
+msgid "End-to-End error"
+msgstr ""
+
+#: modules/devices/storage.c:99
+msgid "Reported Uncorrectable Errors"
+msgstr ""
+
+#: modules/devices/storage.c:100
+msgid "Command Timeout"
+msgstr ""
+
+#: modules/devices/storage.c:101
+msgid "High Fly Writes"
+msgstr ""
+
+#: modules/devices/storage.c:102
+msgid "Airflow Temperature"
+msgstr ""
+
+#: modules/devices/storage.c:103
+msgid "G-sense Error Rate"
+msgstr ""
+
+#: modules/devices/storage.c:104
+msgid "Power-off Retract Count"
+msgstr ""
+
+#: modules/devices/storage.c:105
+msgid "Load Cycle Count"
+msgstr ""
+
+#: modules/devices/storage.c:106 modules/devices/storage.c:129
+msgid "Temperature"
+msgstr ""
+
+#: modules/devices/storage.c:107
+msgid "Hardware ECC Recovered"
+msgstr ""
+
+#: modules/devices/storage.c:108
+msgid "Reallocation Event Count"
+msgstr ""
+
+#: modules/devices/storage.c:109
+msgid "Current Pending Sector Count"
+msgstr ""
+
+#: modules/devices/storage.c:110
+msgid "Uncorrectable Sector Count"
+msgstr ""
+
+#: modules/devices/storage.c:111
+msgid "UltraDMA CRC Error Count"
+msgstr ""
+
+#: modules/devices/storage.c:112
+msgid "Multi-Zone Error Rate"
+msgstr ""
+
+#: modules/devices/storage.c:114
+msgid "Run Out Cancel"
+msgstr ""
+
+#: modules/devices/storage.c:115
+msgid "Flying Height"
+msgstr ""
+
+#: modules/devices/storage.c:116
+msgid "Spin High Current"
+msgstr ""
+
+#: modules/devices/storage.c:117
+msgid "Spin Buzz"
+msgstr ""
+
+#: modules/devices/storage.c:118
+msgid "Offline Seek Performance"
+msgstr ""
+
+#: modules/devices/storage.c:119
+msgid "Disk Shift"
+msgstr ""
+
+#: modules/devices/storage.c:120
+msgid "G-Sense Error Rate"
+msgstr ""
+
+#: modules/devices/storage.c:121
+msgid "Loaded Hours"
+msgstr ""
+
+#: modules/devices/storage.c:122
+msgid "Load/Unload Retry Count"
+msgstr ""
+
+#: modules/devices/storage.c:123
+msgid "Load Friction"
+msgstr ""
+
+#: modules/devices/storage.c:124
+msgid "Load/Unload Cycle Count"
+msgstr ""
+
+#: modules/devices/storage.c:125
+msgid "Load-in time"
+msgstr ""
+
+#: modules/devices/storage.c:126
+msgid "Torque Amplification Count"
+msgstr ""
+
+#: modules/devices/storage.c:127
+msgid "Power-Off Retract Count"
+msgstr ""
+
+#: modules/devices/storage.c:128
+msgid "GMR Head Amplitude"
+msgstr ""
+
+#: modules/devices/storage.c:130
+msgid "Endurance Remaining"
+msgstr ""
+
+#: modules/devices/storage.c:132
+msgid "Good Block Rate"
+msgstr ""
+
+#: modules/devices/storage.c:133
+msgid "Head Flying Hours"
+msgstr ""
+
+#: modules/devices/storage.c:134
+msgid "Read Error Retry Rate"
+msgstr ""
+
+#: modules/devices/storage.c:135
+msgid "Total LBAs Written"
+msgstr ""
+
+#: modules/devices/storage.c:136
+msgid "Total LBAs Read"
+msgstr ""
+
+#: modules/devices/storage.c:141
+msgid ""
+"\n"
+"[UDisks2]\n"
+msgstr ""
+
+#: modules/devices/storage.c:199
+msgid "Removable"
+msgstr ""
+
+#: modules/devices/storage.c:199
+msgid "Fixed"
+msgstr ""
+
+#: modules/devices/storage.c:202
+msgid "Ejectable"
+msgstr ""
+
+#: modules/devices/storage.c:205
+msgid "Self-monitoring (S.M.A.R.T.)"
+msgstr ""
+
+#: modules/devices/storage.c:208 modules/devices/x86/processor.c:663
+msgid "Power Management"
+msgstr "Manejador energia"
+
+#: modules/devices/storage.c:211
+msgid "Advanced Power Management"
+msgstr ""
+
+#: modules/devices/storage.c:214
+msgid "Automatic Acoustic Management"
+msgstr ""
+
+#: modules/devices/storage.c:217
+#, c-format
+msgid ""
+"[Drive Information]\n"
+"Model=%s\n"
+msgstr ""
+
+#: modules/devices/storage.c:221 modules/devices/storage.c:449
+#: modules/devices/storage.c:648
+#, c-format
+msgid "Vendor=%s\n"
+msgstr "Proveedor=%s\n"
+
+#: modules/devices/storage.c:226
+#, c-format
+msgid ""
+"Revision=%s\n"
+"Block Device=%s\n"
+"Serial=%s\n"
+"Size=%s\n"
+"Features=%s\n"
+msgstr ""
+
+#: modules/devices/storage.c:240
+#, c-format
+msgid "Rotation Rate=%d RPM\n"
+msgstr ""
+
+#: modules/devices/storage.c:243
+#, c-format
+msgid ""
+"Media=%s\n"
+"Media compatibility=%s\n"
+msgstr ""
+
+#: modules/devices/storage.c:250
+#, c-format
+msgid "Connection bus=%s\n"
+msgstr ""
+
+#: modules/devices/storage.c:253
+#, c-format
+msgid ""
+"[Self-monitoring (S.M.A.R.T.)]\n"
+"Status=%s\n"
+"Bad Sectors=%ld\n"
+"Power on time=%d days %d hours\n"
+"Temperature=%d°C\n"
+msgstr ""
+
+#: modules/devices/storage.c:259
+msgid "Failing"
+msgstr ""
+
+#: modules/devices/storage.c:259
+msgid "OK"
+msgstr ""
+
+#: modules/devices/storage.c:265
+msgid ""
+"[S.M.A.R.T. Attributes]\n"
+"Attribute=Normalized Value / Worst / Threshold\n"
+msgstr ""
+
+#: modules/devices/storage.c:297
+#, c-format
+msgid "(%d) %s=%s\n"
+msgstr ""
+
+#: modules/devices/storage.c:306
+#, c-format
+msgid ""
+"[Partition table]\n"
+"Type=%s\n"
+msgstr ""
+
+#: modules/devices/storage.c:325
+#, c-format
+msgid "Partition %s=%s\n"
+msgstr ""
+
+#: modules/devices/storage.c:375
 msgid ""
 "\n"
 "[SCSI Disks]\n"
@@ -2750,7 +4080,7 @@ msgstr ""
 "\n"
 "[Discos SCSI]\n"
 
-#: modules/devices/storage.c:114 modules/devices/storage.c:320
+#: modules/devices/storage.c:446 modules/devices/storage.c:645
 #, c-format
 msgid ""
 "[Device Information]\n"
@@ -2759,17 +4089,7 @@ msgstr ""
 "[Información de dispositivo]\n"
 "Modelo=%s\n"
 
-#: modules/devices/storage.c:119 modules/devices/storage.c:326
-#, c-format
-msgid "Vendor=%s (%s)\n"
-msgstr "Proveedor=%s (%s)\n"
-
-#: modules/devices/storage.c:124 modules/devices/storage.c:328
-#, c-format
-msgid "Vendor=%s\n"
-msgstr "Proveedor=%s\n"
-
-#: modules/devices/storage.c:129
+#: modules/devices/storage.c:453
 #, c-format
 msgid ""
 "Type=%s\n"
@@ -2788,7 +4108,7 @@ msgstr ""
 "ID=%d\n"
 "LUN=%d\n"
 
-#: modules/devices/storage.c:174
+#: modules/devices/storage.c:499
 msgid ""
 "\n"
 "[IDE Disks]\n"
@@ -2796,12 +4116,12 @@ msgstr ""
 "\n"
 "[Discos IDE]\n"
 
-#: modules/devices/storage.c:257
+#: modules/devices/storage.c:582
 #, c-format
 msgid "Driver=%s\n"
 msgstr "Driver=%s\n"
 
-#: modules/devices/storage.c:331
+#: modules/devices/storage.c:650
 #, c-format
 msgid ""
 "Device Name=hd%c\n"
@@ -2812,7 +4132,7 @@ msgstr ""
 "Medio=%s\n"
 "Cache=%dkb\n"
 
-#: modules/devices/storage.c:341
+#: modules/devices/storage.c:660
 #, c-format
 msgid ""
 "[Geometry]\n"
@@ -2823,7 +4143,7 @@ msgstr ""
 "Física=%s\n"
 "Lógica=%s\n"
 
-#: modules/devices/storage.c:351
+#: modules/devices/storage.c:670
 #, c-format
 msgid ""
 "[Capabilities]\n"
@@ -2832,7 +4152,7 @@ msgstr ""
 "[Capacidades]\n"
 "%s"
 
-#: modules/devices/storage.c:358
+#: modules/devices/storage.c:677
 #, c-format
 msgid ""
 "[Speeds]\n"
@@ -2841,27 +4161,35 @@ msgstr ""
 "[Velocidades]\n"
 "%s"
 
-#: modules/devices/usb.c:65
-msgid "Max Current"
-msgstr "Max Actual"
-
-#: modules/devices/usb.c:65
-msgid "mA"
-msgstr ""
-
-#: modules/devices/usb.c:66
-msgid "USB Version"
-msgstr "USB Versión"
-
-#: modules/devices/usb.c:68
+#: modules/devices/usb.c:134 modules/devices/usb.c:175
 msgid "Sub-class"
 msgstr ""
 
-#: modules/devices/usb.c:69
+#: modules/devices/usb.c:135 modules/devices/usb.c:176 modules/network.c:347
+msgid "Protocol"
+msgstr "Protocolo"
+
+#: modules/devices/usb.c:143 modules/network/net.c:451
+msgid "Mb/s"
+msgstr "Mb/s"
+
+#: modules/devices/usb.c:171
+msgid "Max Current"
+msgstr "Max Actual"
+
+#: modules/devices/usb.c:171
+msgid "mA"
+msgstr ""
+
+#: modules/devices/usb.c:172
+msgid "USB Version"
+msgstr "USB Versión"
+
+#: modules/devices/usb.c:177
 msgid "Device Version"
 msgstr ""
 
-#: modules/devices/usb.c:103
+#: modules/devices/usb.c:221
 msgid "No USB devices found."
 msgstr ""
 
@@ -2901,47 +4229,59 @@ msgstr ""
 msgid "Level %d (%s)#%d=%dx %dKB (%dKB), %d-way set-associative, %d sets\n"
 msgstr ""
 
-#: modules/devices/x86/processor.c:645
+#: modules/devices/x86/processor.c:647
 msgid "Model Name"
 msgstr "Nombre Modelo"
 
-#: modules/devices/x86/processor.c:646
+#: modules/devices/x86/processor.c:648
 msgid "Family, model, stepping"
 msgstr "Familia, modelo, escalado"
 
-#: modules/devices/x86/processor.c:652
+#: modules/devices/x86/processor.c:654
 msgid "Microcode Version"
 msgstr ""
 
-#: modules/devices/x86/processor.c:653
+#: modules/devices/x86/processor.c:655
 msgid "Configuration"
 msgstr "Configuracion"
 
-#: modules/devices/x86/processor.c:654
+#: modules/devices/x86/processor.c:656
 msgid "Cache Size"
 msgstr "Tamaño cache"
 
-#: modules/devices/x86/processor.c:654
+#: modules/devices/x86/processor.c:656
 msgid "kb"
 msgstr "kb"
 
-#: modules/devices/x86/processor.c:661
-msgid "Power Management"
-msgstr "Manejador energia"
-
-#: modules/devices/x86/processor.c:662
+#: modules/devices/x86/processor.c:664
 msgid "Bug Workarounds"
 msgstr "Manejo de errores"
 
-#: modules/devices/x86/processor.c:695 modules/devices/x86/processor.c:715
+#: modules/devices/x86/processor.c:691
+msgid "Socket Information"
+msgstr ""
+
+#: modules/devices/x86/processor.c:712
+msgid "CPU Socket"
+msgstr ""
+
+#: modules/devices/x86/processor.c:716
+msgid "External Clock"
+msgstr ""
+
+#: modules/devices/x86/processor.c:717
+msgid "Max Frequency"
+msgstr ""
+
+#: modules/devices/x86/processor.c:748 modules/devices/x86/processor.c:769
 msgid "Package Information"
 msgstr "Información paquete"
 
-#: modules/devices/x86/processor.c:742
+#: modules/devices/x86/processor.c:796
 msgid "Socket:Core"
 msgstr ""
 
-#: modules/devices/x86/processor.c:742
+#: modules/devices/x86/processor.c:796
 msgid "Thread"
 msgstr ""
 
@@ -4300,181 +5640,175 @@ msgctxt "x86-flag"
 msgid "CPU is affected by speculative store bypass attack"
 msgstr ""
 
+#. /bug:l1tf
+#: modules/devices/x86/x86_data.c:286
+msgctxt "x86-flag"
+msgid "CPU is affected by L1 Terminal Fault"
+msgstr ""
+
 #. /x86/kernel/cpu/powerflags.h
 #. /flag:pm:ts
-#: modules/devices/x86/x86_data.c:288
+#: modules/devices/x86/x86_data.c:289
 msgctxt "x86-flag"
 msgid "temperature sensor"
 msgstr "sensor de temparatura"
 
 #. /flag:pm:fid
-#: modules/devices/x86/x86_data.c:289
+#: modules/devices/x86/x86_data.c:290
 msgctxt "x86-flag"
 msgid "frequency id control"
 msgstr "id de control frecuencia"
 
 #. /flag:pm:vid
-#: modules/devices/x86/x86_data.c:290
+#: modules/devices/x86/x86_data.c:291
 msgctxt "x86-flag"
 msgid "voltage id control"
 msgstr "id control voltage"
 
 #. /flag:pm:ttp
-#: modules/devices/x86/x86_data.c:291
+#: modules/devices/x86/x86_data.c:292
 msgctxt "x86-flag"
 msgid "thermal trip"
 msgstr "limite termico"
 
 #. /flag:pm:tm
-#: modules/devices/x86/x86_data.c:292
+#: modules/devices/x86/x86_data.c:293
 msgctxt "x86-flag"
 msgid "hardware thermal control"
 msgstr "control terminco por hardware"
 
 #. /flag:pm:stc
-#: modules/devices/x86/x86_data.c:293
+#: modules/devices/x86/x86_data.c:294
 msgctxt "x86-flag"
 msgid "software thermal control"
 msgstr "control terminco por software"
 
 #. /flag:pm:100mhzsteps
-#: modules/devices/x86/x86_data.c:294
+#: modules/devices/x86/x86_data.c:295
 msgctxt "x86-flag"
 msgid "100 MHz multiplier control"
 msgstr "control multiplicador 100MHz"
 
 #. /flag:pm:hwpstate
-#: modules/devices/x86/x86_data.c:295
+#: modules/devices/x86/x86_data.c:296
 msgctxt "x86-flag"
 msgid "hardware P-state control"
 msgstr "control hardware de P-state"
 
 #. /flag:pm:cpb
-#: modules/devices/x86/x86_data.c:296
+#: modules/devices/x86/x86_data.c:297
 msgctxt "x86-flag"
 msgid "core performance boost"
 msgstr "Impulso de rendimiento básico"
 
 #. /flag:pm:eff_freq_ro
-#: modules/devices/x86/x86_data.c:297
+#: modules/devices/x86/x86_data.c:298
 msgctxt "x86-flag"
 msgid "Readonly aperf/mperf"
 msgstr ""
 
 #. /flag:pm:proc_feedback
-#: modules/devices/x86/x86_data.c:298
+#: modules/devices/x86/x86_data.c:299
 msgctxt "x86-flag"
 msgid "processor feedback interface"
 msgstr "interfez de retroalimentacion de procesador"
 
 #. /flag:pm:acc_power
-#: modules/devices/x86/x86_data.c:299
+#: modules/devices/x86/x86_data.c:300
 msgctxt "x86-flag"
 msgid "accumulated power mechanism"
 msgstr "mecanismo de energia acumulada"
 
-#: modules/network.c:59
+#: modules/network.c:61
 msgid "Interfaces"
 msgstr "Interfaces"
 
-#: modules/network.c:60
+#: modules/network.c:62
 msgid "IP Connections"
 msgstr "Conexiones IP"
 
-#: modules/network.c:61
+#: modules/network.c:63
 msgid "Routing Table"
 msgstr "Tabla de ruteo"
 
-#: modules/network.c:62 modules/network.c:303
+#: modules/network.c:64 modules/network.c:309
 msgid "ARP Table"
 msgstr "Tabla ARP"
 
-#: modules/network.c:63
+#: modules/network.c:65
 msgid "DNS Servers"
 msgstr "Servidores DNS"
 
-#: modules/network.c:64
+#: modules/network.c:66
 msgid "Statistics"
 msgstr "Estadísticas"
 
-#: modules/network.c:65
+#: modules/network.c:67
 msgid "Shared Directories"
 msgstr "Directorios compartidos"
 
-#: modules/network.c:304 modules/network.c:326 modules/network.c:357
+#: modules/network.c:310 modules/network.c:332 modules/network.c:363
 #: modules/network/net.c:472
 msgid "IP Address"
 msgstr "Dirección IP"
 
-#: modules/network.c:304 modules/network.c:357 modules/network.c:374
-msgid "Interface"
-msgstr "Interfaz"
-
-#: modules/network.c:304
+#: modules/network.c:310
 msgid "MAC Address"
 msgstr "Dirección MAC"
 
-#: modules/network.c:313
+#: modules/network.c:319
 msgid "SAMBA"
 msgstr "SAMBA"
 
-#: modules/network.c:314
+#: modules/network.c:320
 msgid "NFS"
 msgstr "NFS"
 
-#: modules/network.c:325
+#: modules/network.c:331
 msgid "Name Servers"
 msgstr "Servidores de nombres"
 
-#: modules/network.c:340
+#: modules/network.c:346
 msgid "Connections"
 msgstr "Conexiones"
 
-#: modules/network.c:341
+#: modules/network.c:347
 msgid "Local Address"
 msgstr "Direccion local"
 
-#: modules/network.c:341
-msgid "Protocol"
-msgstr "Protocolo"
-
-#: modules/network.c:341
+#: modules/network.c:347
 msgid "Foreign Address"
 msgstr "Direccion enlazada"
 
-#: modules/network.c:341
+#: modules/network.c:347
 msgid "State"
 msgstr "Estado"
 
-#: modules/network.c:357
+#: modules/network.c:363
 msgid "Sent"
 msgstr "Enviado"
 
-#: modules/network.c:357
+#: modules/network.c:363
 msgid "Received"
 msgstr "Recibido"
 
-#: modules/network.c:373
+#: modules/network.c:379
 msgid "IP routing table"
 msgstr "Tabla de ruteo IP"
 
-#: modules/network.c:374
+#: modules/network.c:380
 msgid "Destination/Gateway"
 msgstr "Destino/Puerta de enlace"
 
-#: modules/network.c:374
-msgid "Flags"
-msgstr "Marcas"
-
-#: modules/network.c:374 modules/network/net.c:473
+#: modules/network.c:380 modules/network/net.c:473
 msgid "Mask"
 msgstr "Máscara"
 
-#: modules/network.c:402
+#: modules/network.c:408
 msgid "Network"
 msgstr "Red"
 
-#: modules/network.c:435
+#: modules/network.c:441
 msgid "Gathers information about this computer's network connection"
 msgstr "Obtiene información sobre la conexión de red de esta computadora"
 
@@ -4644,11 +5978,6 @@ msgstr "Interfaces de Red"
 msgid "None Found"
 msgstr "Ninguna encontrada"
 
-#: modules/network/net.c:395 modules/network/net.c:417
-#: modules/network/net.c:418
-msgid "MiB"
-msgstr "MiB"
-
 #: modules/network/net.c:409
 msgid "Network Adapter Properties"
 msgstr "Propiedades de adaptador"
@@ -4698,17 +6027,9 @@ msgstr "Nombre de red (SSID)"
 msgid "Bit Rate"
 msgstr "Velocidad de bits"
 
-#: modules/network/net.c:451
-msgid "Mb/s"
-msgstr "Mb/s"
-
 #: modules/network/net.c:452
 msgid "Transmission Power"
 msgstr "Intensidad transmision"
-
-#: modules/network/net.c:454
-msgid "Status"
-msgstr "Estado"
 
 #: modules/network/net.c:455
 msgid "Link Quality"
@@ -4731,6 +6052,52 @@ msgstr "(sin asignar)"
 msgid "Broadcast Address"
 msgstr "Dirección de Difusión"
 
+#~ msgid "chooses a report format (text, html)"
+#~ msgstr "elige un formato para el reporte (texto, html)"
+
+#~ msgid "Couldn't find a Web browser to open URL %s."
+#~ msgstr "No se pudo encontrar un navegador Web para abrir la URL %s."
+
+#~ msgid "CSharp (Mono, old)"
+#~ msgstr "CSharp (Mono, antiguo)"
+
+#~ msgid "RAM"
+#~ msgstr "RAM"
+
+#~ msgid "DMI"
+#~ msgstr "DMI"
+
+#~ msgid "Memory SPD"
+#~ msgstr "Memoria SPD"
+
+#~ msgid ""
+#~ "[SPD]\n"
+#~ "Please load the eeprom module to obtain information about memory SPD=\n"
+#~ "[$ShellParam$]\n"
+#~ "ReloadInterval=500\n"
+#~ msgstr ""
+#~ "[SPD]\n"
+#~ "Por favor carge el modulo eeprom para obtener información de memorias "
+#~ "SPD=\n"
+#~ "[$ShellParam$]\n"
+#~ "ReloadInterval=500\n"
+
+#~ msgid ""
+#~ "[SPD]\n"
+#~ "Reading memory SPD not supported on this system=\n"
+#~ msgstr ""
+#~ "[SPD]\n"
+#~ "Lectura de memorias no soportado en este sistema=\n"
+
+#~ msgid "SPD"
+#~ msgstr "SPD"
+
+#~ msgid "Bank"
+#~ msgstr "Ranura"
+
+#~ msgid "Vendor=%s (%s)\n"
+#~ msgstr "Proveedor=%s (%s)\n"
+
 #~ msgid "Unknown benchmark ``%s'' or libbenchmark.so not loaded"
 #~ msgstr "Benchmark desconocido ``%s'' o no se cargó libbenchmark.so"
 
@@ -4739,9 +6106,6 @@ msgstr "Dirección de Difusión"
 
 #~ msgid "X11 Vendor"
 #~ msgstr "Proveedor X11"
-
-#~ msgid "Monitors"
-#~ msgstr "Monitores"
 
 #~ msgid "OpenGL"
 #~ msgstr "OpenGL (3D)"
@@ -4779,9 +6143,6 @@ msgstr "Dirección de Difusión"
 #~ msgid "Unknown USB %.2f Device (class %d)"
 #~ msgstr "USB desconocido %.2f (class %d)"
 
-#~ msgid "Speed"
-#~ msgstr "Velocidad"
-
 #~ msgid "Vendor ID"
 #~ msgstr "ID Vendedor"
 
@@ -4796,6 +6157,3 @@ msgstr "Dirección de Difusión"
 
 #~ msgid "pixels"
 #~ msgstr "pixeles"
-
-#~ msgid "Desktop Environment"
-#~ msgstr "Entorno de escritorio"

--- a/po/fr.po
+++ b/po/fr.po
@@ -2,8 +2,8 @@
 # This file is distributed under the same license as the PACKAGE package.
 # Yolateng0 <http://kreizenn-dafar.org>, 2014.
 #
-msgid "En"
-msgstr "FR"
+msgid ""
+msgstr ""
 "Project-Id-Version: hardinfo\n"
 "Report-Msgid-Bugs-To: https://github.com/lpereira/hardinfo/edit/master/po/fr.po\n"
 "POT-Creation-Date: 2018-06-09 14:09-0500\n"
@@ -2007,26 +2007,6 @@ msgstr ""
 "Modele=%s\n"
 "Numéro de série=%s\n"
 
-#: modules/devices/battery.c:258
-#, c-format
-msgid ""
-"\n"
-"[Battery: %s]\n"
-"State=%s\n"
-"Capacity=%s / %s\n"
-"Battery Technology=%s\n"
-"Manufacturer=%s\n"
-"Model Number=%s\n"
-"Serial Number=%s\n"
-msgstr ""
-"[Batterie: %s]\n"
-"Etat=%s (load: %s)\n"
-"Capacité=%s / %s (%.2f%%)\n"
-"Technologie=%s (%s)\n"
-"Fabriquant=%s\n"
-"Modele=%s\n"
-"Numéro de série=%s\n"
-
 #: modules/devices/battery.c:346
 #, c-format
 msgid ""
@@ -2731,12 +2711,6 @@ msgstr ""
 "Télécharger le module eeprom pour avoir les informations de mémoire SPD=\n"
 "[$ShellParam$]\n"
 
-#: modules/devices/spd-decode.c:1480
-msgid ""
-"[SPD]\n"
-"Reading memory SPD not supported on this system=\n"
-msgstr "Mémoire de lecture SPD non prise en charge sur ce système"
-
 #: modules/devices/spd-decode.c:1509
 msgid "SPD"
 msgstr ""
@@ -2813,7 +2787,7 @@ msgid ""
 msgstr ""
 "Nom du Périphérique=hd%c\n"
 "Media=%s\n"
-"Cache=%dkb\n
+"Cache=%dkb\n"
 
 #: modules/devices/storage.c:341
 #, c-format
@@ -3125,7 +3099,7 @@ msgid ""
 "Intel Itanium Architecture 64-bit (not to be confused with Intel's 64-bit "
 "x86 architecture with flag x86-64 or \"AMD64\" bit indicated by flag lm)"
 msgstr ""
-"Intel Itanium Architecture 64-bit (à ne pas confondre avec le 64-bit d'Intel) ".
+"Intel Itanium Architecture 64-bit (à ne pas confondre avec le 64-bit d'Intel) "
 "Architecture x86 avec drapeau x86-64 ou \"AMD64\" bit indiqué par drapeau lm)"
 
 #. /flag:pbe

--- a/po/fr.po
+++ b/po/fr.po
@@ -5,8 +5,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: hardinfo\n"
-"Report-Msgid-Bugs-To: https://github.com/lpereira/hardinfo/edit/master/po/fr.po\n"
-"POT-Creation-Date: 2018-06-09 14:09-0500\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-10-24 15:16-0500\n"
 "PO-Revision-Date: 2019-09-28\n"
 "Last-Translator: yolateng0\n"
 "Language-Team: KreizennDafar\n"
@@ -26,19 +26,20 @@ msgstr ""
 msgid "Big Endian"
 msgstr ""
 
-#: hardinfo/cpu_util.c:184 hardinfo/cpu_util.c:195
+#: hardinfo/cpu_util.c:184 hardinfo/cpu_util.c:195 modules/devices/gpu.c:200
 msgid "Frequency Scaling"
 msgstr ""
 
-#: hardinfo/cpu_util.c:185
+#: hardinfo/cpu_util.c:185 modules/devices/gpu.c:201
 msgid "Minimum"
 msgstr "Minimum"
 
 #: hardinfo/cpu_util.c:185 hardinfo/cpu_util.c:186 hardinfo/cpu_util.c:187
+#: hardinfo/dt_util.c:589 modules/devices/gpu.c:201 modules/devices/gpu.c:202
 msgid "kHz"
 msgstr ""
 
-#: hardinfo/cpu_util.c:186
+#: hardinfo/cpu_util.c:186 modules/devices/gpu.c:202
 msgid "Maximum"
 msgstr "Maximum"
 
@@ -46,11 +47,11 @@ msgstr "Maximum"
 msgid "Current"
 msgstr "Actuel"
 
-#: hardinfo/cpu_util.c:188
+#: hardinfo/cpu_util.c:188 modules/devices/gpu.c:203
 msgid "Transition Latency"
 msgstr ""
 
-#: hardinfo/cpu_util.c:188
+#: hardinfo/cpu_util.c:188 modules/devices/gpu.c:203
 msgid "ns"
 msgstr ""
 
@@ -58,13 +59,13 @@ msgstr ""
 msgid "Governor"
 msgstr ""
 
-#: hardinfo/cpu_util.c:190 hardinfo/cpu_util.c:196 modules/devices/gpu.c:149
-#: modules/devices/pci.c:116
+#: hardinfo/cpu_util.c:190 hardinfo/cpu_util.c:196 modules/devices/gpu.c:153
+#: modules/devices/pci.c:134 modules/devices/usb.c:136
 msgid "Driver"
 msgstr ""
 
-#: hardinfo/cpu_util.c:202 modules/computer.c:596
-#: modules/devices/arm/processor.c:242 modules/devices/x86/processor.c:284
+#: hardinfo/cpu_util.c:202 modules/computer.c:737
+#: modules/devices/arm/processor.c:256 modules/devices/x86/processor.c:284
 #: modules/devices/x86/processor.c:388 modules/devices/x86/processor.c:524
 msgid "(Not Available)"
 msgstr "(Non Disponible)"
@@ -73,7 +74,8 @@ msgstr "(Non Disponible)"
 msgid "Socket"
 msgstr "Socket"
 
-#: hardinfo/cpu_util.c:215 hardinfo/cpu_util.c:217
+#: hardinfo/cpu_util.c:215 hardinfo/cpu_util.c:217 modules/devices/gpu.c:149
+#: modules/devices/gpu.c:227
 msgid "Core"
 msgstr "Coeur"
 
@@ -85,8 +87,8 @@ msgstr "Book"
 msgid "Drawer"
 msgstr ""
 
-#: hardinfo/cpu_util.c:228 modules/devices/arm/processor.c:449
-#: modules/devices/x86/processor.c:697
+#: hardinfo/cpu_util.c:228 modules/devices/arm/processor.c:471
+#: modules/devices/x86/processor.c:750
 msgid "Topology"
 msgstr "Topologie"
 
@@ -94,112 +96,336 @@ msgstr "Topologie"
 msgid "ID"
 msgstr ""
 
-#: hardinfo/dmi_util.c:130
+#: hardinfo/dmi_util.c:25
+msgid "BIOS Information"
+msgstr ""
+
+#: hardinfo/dmi_util.c:26 modules/devices/parisc/processor.c:157
+msgid "System"
+msgstr "Système"
+
+#: hardinfo/dmi_util.c:27
+msgid "Base Board"
+msgstr ""
+
+#: hardinfo/dmi_util.c:28 modules/devices/dmi.c:53
+msgid "Chassis"
+msgstr ""
+
+#: hardinfo/dmi_util.c:29 modules/computer.c:529 modules/computer.c:1000
+#: modules/devices/alpha/processor.c:87 modules/devices/arm/processor.c:341
+#: modules/devices.c:99 modules/devices/ia64/processor.c:159
+#: modules/devices/m68k/processor.c:83 modules/devices/mips/processor.c:74
+#: modules/devices/parisc/processor.c:154 modules/devices/ppc/processor.c:157
+#: modules/devices/riscv/processor.c:181 modules/devices/s390/processor.c:131
+#: modules/devices/sh/processor.c:83 modules/devices/sparc/processor.c:74
+#: modules/devices/x86/processor.c:646
+msgid "Processor"
+msgstr "Processeur"
+
+#: hardinfo/dmi_util.c:30
+msgid "Memory Controller"
+msgstr ""
+
+#: hardinfo/dmi_util.c:31
+msgid "Memory Module"
+msgstr ""
+
+#: hardinfo/dmi_util.c:32 modules/devices/parisc/processor.c:163
+#: modules/devices/x86/processor.c:662
+msgid "Cache"
+msgstr ""
+
+#: hardinfo/dmi_util.c:33
+msgid "Port Connector"
+msgstr ""
+
+#: hardinfo/dmi_util.c:34
+msgid "System Slots"
+msgstr ""
+
+#: hardinfo/dmi_util.c:35
+msgid "On Board Devices"
+msgstr ""
+
+#: hardinfo/dmi_util.c:36
+msgid "OEM Strings"
+msgstr ""
+
+#: hardinfo/dmi_util.c:37
+msgid "System Configuration Options"
+msgstr ""
+
+#: hardinfo/dmi_util.c:38
+msgid "BIOS Language"
+msgstr ""
+
+#: hardinfo/dmi_util.c:39
+msgid "Group Associations"
+msgstr ""
+
+#: hardinfo/dmi_util.c:40
+msgid "System Event Log"
+msgstr ""
+
+#: hardinfo/dmi_util.c:41
+msgid "Physical Memory Array"
+msgstr ""
+
+#: hardinfo/dmi_util.c:42
+msgid "Memory Device"
+msgstr ""
+
+#: hardinfo/dmi_util.c:43
+msgid "32-bit Memory Error"
+msgstr ""
+
+#: hardinfo/dmi_util.c:44
+msgid "Memory Array Mapped Address"
+msgstr ""
+
+#: hardinfo/dmi_util.c:45
+msgid "Memory Device Mapped Address"
+msgstr ""
+
+#: hardinfo/dmi_util.c:46
+msgid "Built-in Pointing Device"
+msgstr ""
+
+#: hardinfo/dmi_util.c:47
+msgid "Portable Battery"
+msgstr ""
+
+#: hardinfo/dmi_util.c:48
+msgid "System Reset"
+msgstr ""
+
+#: hardinfo/dmi_util.c:49
+msgid "Hardware Security"
+msgstr ""
+
+#: hardinfo/dmi_util.c:50
+msgid "System Power Controls"
+msgstr ""
+
+#: hardinfo/dmi_util.c:51
+msgid "Voltage Probe"
+msgstr ""
+
+#: hardinfo/dmi_util.c:52
+msgid "Cooling Device"
+msgstr ""
+
+#: hardinfo/dmi_util.c:53
+msgid "Temperature Probe"
+msgstr ""
+
+#: hardinfo/dmi_util.c:54
+msgid "Electrical Current Probe"
+msgstr ""
+
+#: hardinfo/dmi_util.c:55
+msgid "Out-of-band Remote Access"
+msgstr ""
+
+#: hardinfo/dmi_util.c:56
+msgid "Boot Integrity Services"
+msgstr ""
+
+#: hardinfo/dmi_util.c:57
+msgid "System Boot"
+msgstr ""
+
+#: hardinfo/dmi_util.c:58
+msgid "64-bit Memory Error"
+msgstr ""
+
+#: hardinfo/dmi_util.c:59
+msgid "Management Device"
+msgstr ""
+
+#: hardinfo/dmi_util.c:60
+msgid "Management Device Component"
+msgstr ""
+
+#: hardinfo/dmi_util.c:61
+msgid "Management Device Threshold Data"
+msgstr ""
+
+#: hardinfo/dmi_util.c:62
+msgid "Memory Channel"
+msgstr ""
+
+#: hardinfo/dmi_util.c:63
+msgid "IPMI Device"
+msgstr ""
+
+#: hardinfo/dmi_util.c:64
+msgid "Power Supply"
+msgstr ""
+
+#: hardinfo/dmi_util.c:65
+msgid "Additional Information"
+msgstr ""
+
+#: hardinfo/dmi_util.c:66
+msgid "Onboard Device"
+msgstr ""
+
+#: hardinfo/dmi_util.c:226
 msgid "Invalid chassis type (0)"
 msgstr "Type de châssis Invalide (0)"
 
-#: hardinfo/dmi_util.c:131 hardinfo/dmi_util.c:132
+#: hardinfo/dmi_util.c:227 hardinfo/dmi_util.c:228
 msgid "Unknown chassis type"
 msgstr "Type de châssis inconnu"
 
-#: hardinfo/dmi_util.c:133
+#: hardinfo/dmi_util.c:229
 msgid "Desktop"
 msgstr "Ordinateur de bureau"
 
-#: hardinfo/dmi_util.c:134
+#: hardinfo/dmi_util.c:230
 msgid "Low-profile Desktop"
 msgstr ""
 
-#: hardinfo/dmi_util.c:135
+#: hardinfo/dmi_util.c:231
 msgid "Pizza Box"
 msgstr ""
 
-#: hardinfo/dmi_util.c:136
+#: hardinfo/dmi_util.c:232
 msgid "Mini Tower"
 msgstr "Mini Tour"
 
-#: hardinfo/dmi_util.c:137
+#: hardinfo/dmi_util.c:233
 msgid "Tower"
 msgstr "Tour"
 
-#: hardinfo/dmi_util.c:138
+#: hardinfo/dmi_util.c:234
 msgid "Portable"
 msgstr ""
 
-#: hardinfo/dmi_util.c:139 modules/computer.c:330 modules/computer.c:339
-#: modules/computer.c:361
+#: hardinfo/dmi_util.c:235 modules/computer.c:391 modules/computer.c:400
+#: modules/computer.c:422
 msgid "Laptop"
 msgstr "Portable"
 
-#: hardinfo/dmi_util.c:140
+#: hardinfo/dmi_util.c:236
 msgid "Notebook"
 msgstr ""
 
-#: hardinfo/dmi_util.c:141
+#: hardinfo/dmi_util.c:237
 msgid "Handheld"
 msgstr ""
 
-#: hardinfo/dmi_util.c:142
+#: hardinfo/dmi_util.c:238
 msgid "Docking Station"
 msgstr "Station d'accueil"
 
-#: hardinfo/dmi_util.c:143
+#: hardinfo/dmi_util.c:239
 msgid "All-in-one"
 msgstr "Tout en Un"
 
-#: hardinfo/dmi_util.c:144
+#: hardinfo/dmi_util.c:240
 msgid "Subnotebook"
 msgstr ""
 
-#: hardinfo/dmi_util.c:145
+#: hardinfo/dmi_util.c:241
 msgid "Space-saving"
 msgstr ""
 
-#: hardinfo/dmi_util.c:146
+#: hardinfo/dmi_util.c:242
 msgid "Lunch Box"
 msgstr ""
 
-#: hardinfo/dmi_util.c:147
+#: hardinfo/dmi_util.c:243
 msgid "Main Server Chassis"
 msgstr "Châssis du serveur principal"
 
-#: hardinfo/dmi_util.c:148
+#: hardinfo/dmi_util.c:244
 msgid "Expansion Chassis"
 msgstr ""
 
-#: hardinfo/dmi_util.c:149
+#: hardinfo/dmi_util.c:245
 msgid "Sub Chassis"
 msgstr ""
 
-#: hardinfo/dmi_util.c:150
+#: hardinfo/dmi_util.c:246
 msgid "Bus Expansion Chassis"
 msgstr "Châssis BUS Extension"
 
-#: hardinfo/dmi_util.c:151
+#: hardinfo/dmi_util.c:247
 msgid "Peripheral Chassis"
 msgstr "Châssis Périphériques"
 
-#: hardinfo/dmi_util.c:152
+#: hardinfo/dmi_util.c:248
 msgid "RAID Chassis"
 msgstr "Châssis RAID"
 
-#: hardinfo/dmi_util.c:153
+#: hardinfo/dmi_util.c:249
 msgid "Rack Mount Chassis"
 msgstr "Châssis de Montage Rack"
 
-#: hardinfo/dmi_util.c:154
+#: hardinfo/dmi_util.c:250
 msgid "Sealed-case PC"
 msgstr "Boîtier étanche"
 
-#: hardinfo/dt_util.c:1011
+#: hardinfo/dmi_util.c:251
+msgid "Multi-system"
+msgstr ""
+
+#: hardinfo/dmi_util.c:252
+msgid "CompactPCI"
+msgstr ""
+
+#: hardinfo/dmi_util.c:253
+msgid "AdvancedTCA"
+msgstr ""
+
+#: hardinfo/dmi_util.c:254
+msgid "Blade"
+msgstr ""
+
+#: hardinfo/dmi_util.c:255
+msgid "Blade Enclosing"
+msgstr ""
+
+#: hardinfo/dmi_util.c:256
+msgid "Tablet"
+msgstr ""
+
+#: hardinfo/dmi_util.c:257
+msgid "Convertible"
+msgstr ""
+
+#: hardinfo/dmi_util.c:258
+msgid "Detachable"
+msgstr ""
+
+#: hardinfo/dmi_util.c:259
+msgid "IoT Gateway"
+msgstr ""
+
+#: hardinfo/dmi_util.c:260
+msgid "Embedded PC"
+msgstr ""
+
+#: hardinfo/dmi_util.c:261
+msgid "Mini PC"
+msgstr ""
+
+#: hardinfo/dmi_util.c:262
+msgid "Stick PC"
+msgstr ""
+
+#: hardinfo/dt_util.c:1179
 msgid "phandle Map"
 msgstr ""
 
-#: hardinfo/dt_util.c:1012
+#: hardinfo/dt_util.c:1180
 msgid "Alias Map"
 msgstr ""
 
-#: hardinfo/dt_util.c:1013
+#: hardinfo/dt_util.c:1181
 msgid "Symbol Map"
 msgstr ""
 
@@ -230,12 +456,16 @@ msgstr ""
 " Library prefix:    %s\n"
 " Compilation:       %s\n"
 
-#: hardinfo/hardinfo.c:58 hardinfo/hardinfo.c:59 modules/computer.c:644
-#: modules/devices/inputdevices.c:128 modules/devices/printers.c:138
+#: hardinfo/hardinfo.c:58 hardinfo/hardinfo.c:59 modules/computer.c:785
+#: modules/computer/modules.c:131 modules/computer/modules.c:132
+#: modules/devices/inputdevices.c:123 modules/devices/printers.c:138
+#: modules/devices/spd-decode.c:903
 msgid "Yes"
 msgstr "Oui"
 
-#: hardinfo/hardinfo.c:59 modules/computer.c:644 modules/devices/printers.c:138
+#: hardinfo/hardinfo.c:59 modules/computer.c:785 modules/computer/modules.c:131
+#: modules/computer/modules.c:132 modules/devices/printers.c:138
+#: modules/devices/spd-decode.c:900
 msgid "No"
 msgstr "Non"
 
@@ -263,31 +493,39 @@ msgstr "Modules:\n"
 msgid "File Name"
 msgstr "Nom du fichier"
 
-#: hardinfo/hardinfo.c:78 modules/computer.c:528 modules/computer.c:556
-#: modules/computer.c:674 modules/computer/languages.c:104
-#: modules/computer/modules.c:146 modules/devices/arm/processor.c:447
-#: modules/devices/dmi.c:37 modules/devices/dmi.c:46
-#: modules/devices/ia64/processor.c:160 modules/devices/inputdevices.c:116
-#: modules/devices/sh/processor.c:84 modules/devices/x86/processor.c:696
-#: modules/network.c:326
+#: hardinfo/hardinfo.c:78 modules/computer.c:666 modules/computer.c:694
+#: modules/computer.c:815 modules/computer/languages.c:95
+#: modules/computer/modules.c:149 modules/devices/arm/processor.c:469
+#: modules/devices/dmi.c:37 modules/devices/dmi.c:48 modules/devices/gpu.c:233
+#: modules/devices/ia64/processor.c:160 modules/devices/inputdevices.c:111
+#: modules/devices/monitors.c:399 modules/devices/monitors.c:502
+#: modules/devices/sh/processor.c:84 modules/devices/x86/processor.c:749
+#: modules/network.c:332
 msgid "Name"
 msgstr "Nom"
 
-#: hardinfo/hardinfo.c:78 modules/computer.c:304 modules/computer.c:499
-#: modules/computer.c:501 modules/computer.c:602 modules/devices/dmi.c:40
-#: modules/devices/dmi.c:44 modules/devices/dmi.c:48 modules/devices/dmi.c:54
-#: modules/devices/inputdevices.c:121
+#: hardinfo/hardinfo.c:78 modules/computer.c:347 modules/computer.c:572
+#: modules/computer.c:574 modules/computer.c:743 modules/computer/modules.c:151
+#: modules/devices/dmi.c:40 modules/devices/dmi.c:46 modules/devices/dmi.c:50
+#: modules/devices/dmi.c:56 modules/devices/firmware.c:105
+#: modules/devices/inputdevices.c:116 modules/devices/monitors.c:405
 msgid "Version"
 msgstr "Version"
 
-#: hardinfo/hardinfo.c:125
+#: hardinfo/hardinfo.c:129
 #, c-format
 msgid "Unknown benchmark ``%s'' or benchmark.so not loaded"
 msgstr "Benchmark inconnu ``%s'' ou benchmark.so non chargé"
 
-#: hardinfo/hardinfo.c:155
+#: hardinfo/hardinfo.c:159
 msgid "Don't know what to do. Exiting."
 msgstr "Que faire. Sortir."
+
+#: hardinfo/usb_util.c:290 modules/devices/devicetree.c:91
+#: modules/devices/devicetree.c:92 modules/devices/monitors.c:407
+#: modules/devices/storage.c:246
+msgid "(None)"
+msgstr "(Aucun)"
 
 #: hardinfo/util.c:104 modules/computer/uptime.c:54
 #, c-format
@@ -359,51 +597,65 @@ msgstr "Attention"
 msgid "Fatal Error"
 msgstr "Erreur Fatale"
 
-#: hardinfo/util.c:403
+#: hardinfo/util.c:406
 msgid "creates a report and prints to standard output"
 msgstr "créer un rapport et imprimer sur la sortie standard"
 
-#: hardinfo/util.c:409
-msgid "chooses a report format (text, html)"
-msgstr "choisir un format de rapport (texte, html)"
+#: hardinfo/util.c:412
+msgid "chooses a report format ([text], html)"
+msgstr ""
 
-#: hardinfo/util.c:415
+#: hardinfo/util.c:418
 msgid "run benchmark; requires benchmark.so to be loaded"
 msgstr "Envoyer le benchmark; nécessite benchmark.so"
 
-#: hardinfo/util.c:421
+#: hardinfo/util.c:424
+msgid "note attached to benchmark results"
+msgstr ""
+
+#: hardinfo/util.c:430
 msgid "benchmark result format ([short], conf, shell)"
 msgstr "Format Résultat du benchmark ([short], conf, shell)"
 
-#: hardinfo/util.c:427
+#: hardinfo/util.c:436
+msgid ""
+"maximum number of benchmark results to include (-1 for no limit, default is "
+"10)"
+msgstr ""
+
+#: hardinfo/util.c:442
 msgid "lists modules"
 msgstr "Listes des modules"
 
-#: hardinfo/util.c:433
+#: hardinfo/util.c:448
 msgid "specify module to load"
 msgstr "spécifie les modules à charger"
 
-#: hardinfo/util.c:439
+#: hardinfo/util.c:454
 msgid "automatically load module dependencies"
 msgstr "charger automatiquement les dépendances entre modules"
 
-#: hardinfo/util.c:446
+#: hardinfo/util.c:461
 msgid "run in XML-RPC server mode"
 msgstr "fonctionner en mode serveur XML-RPC"
 
-#: hardinfo/util.c:453
+#: hardinfo/util.c:468
 msgid "shows program version and quit"
 msgstr "Affiche la version du programme et quitter"
 
-#: hardinfo/util.c:459
+#: hardinfo/util.c:474
 msgid "do not run benchmarks"
 msgstr "Ne pas activer de Benchmark"
 
-#: hardinfo/util.c:464
+#: hardinfo/util.c:480
+msgid "show all details"
+msgstr ""
+
+#: hardinfo/util.c:485
 msgid "- System Profiler and Benchmark tool"
 msgstr "- Profil du Systeme et outil d'évaluation Benchmark"
 
-#: hardinfo/util.c:474
+#: hardinfo/util.c:495
 #, c-format
 msgid ""
 "Unrecognized arguments.\n"
@@ -412,44 +664,52 @@ msgstr ""
 "commandes inconnues.\n"
 "Essayer ``%s --help'' pour plus d'informations.\n"
 
-#: hardinfo/util.c:542
-#, c-format
-msgid "Couldn't find a Web browser to open URL %s."
-msgstr "Impossible de trouver un navigateur Web pour ouvrir l'URL %s."
-
-#: hardinfo/util.c:891
+#: hardinfo/util.c:903
 #, c-format
 msgid "Module \"%s\" depends on module \"%s\", load it?"
 msgstr "Module \"%s\" depends du module \"%s\", le charger?"
 
-#: hardinfo/util.c:914
+#: hardinfo/util.c:926
 #, c-format
 msgid "Module \"%s\" depends on module \"%s\"."
 msgstr "Module \"%s\" depends du module \"%s\"."
 
-#: hardinfo/util.c:959
+#: hardinfo/util.c:971
 #, c-format
 msgid "No module could be loaded. Check permissions on \"%s\" and try again."
 msgstr ""
-"Aucun module peut être chargé. Vérifiez les permissions sur \"%s\" et essayer à nouveau."
+"Aucun module peut être chargé. Vérifiez les permissions sur \"%s\" et "
+"essayer à nouveau."
 
-#: hardinfo/util.c:963
+#: hardinfo/util.c:975
 msgid ""
 "No module could be loaded. Please use hardinfo -l to list all available "
 "modules and try again with a valid module list."
 msgstr ""
 "Aucun module peut être chargé. S'il vous plaît utiliser hardinfo -l pour "
-"répertorier tous les modules disponibles et essayez à nouveau avec une liste de modules valides."
+"répertorier tous les modules disponibles et essayez à nouveau avec une liste "
+"de modules valides."
 
-#: hardinfo/util.c:1040
+#: hardinfo/util.c:1030
 #, c-format
 msgid "Scanning: %s..."
 msgstr "Scanne: %s..."
 
-#: hardinfo/util.c:1050 shell/shell.c:301 shell/shell.c:772 shell/shell.c:1850
-#: modules/benchmark.c:549 modules/benchmark.c:557
+#: hardinfo/util.c:1040 shell/shell.c:310 shell/shell.c:795 shell/shell.c:1962
+#: modules/benchmark.c:583 modules/benchmark.c:591
 msgid "Done."
 msgstr "Réalisé."
+
+#: hardinfo/vendor.c:440 modules/computer.c:573 modules/computer.c:765
+#: modules/computer/os.c:79 modules/computer/os.c:263 modules/computer/os.c:300
+#: modules/computer/os.c:499 modules/computer/os.c:569 modules/devices.c:359
+#: modules/devices.c:505 modules/devices/printers.c:99
+#: modules/devices/printers.c:106 modules/devices/printers.c:116
+#: modules/devices/printers.c:131 modules/devices/printers.c:140
+#: modules/devices/printers.c:243 modules/devices/spd-decode.c:312
+#: modules/devices/usb.c:146
+msgid "Unknown"
+msgstr "Inconnu"
 
 #: shell/callbacks.c:128
 #, c-format
@@ -473,65 +733,63 @@ msgstr "Auteur:"
 msgid "Contributors:"
 msgstr "Contributeurs:"
 
-#: shell/callbacks.c:166
+#: shell/callbacks.c:167
 msgid "Based on work by:"
 msgstr "Basé sur le travail de:"
 
-#: shell/callbacks.c:167
+#: shell/callbacks.c:168
 msgid "MD5 implementation by Colin Plumb (see md5.c for details)"
 msgstr "Implémentation  MD5 par Colin Plumb (détails voir md5.c)"
 
-#: shell/callbacks.c:168
+#: shell/callbacks.c:169
 msgid "SHA1 implementation by Steve Reid (see sha1.c for details)"
 msgstr "implémentation SHA1 par Steve Reid (détails voir sha1.c)"
 
-#: shell/callbacks.c:169
+#: shell/callbacks.c:170
 msgid "Blowfish implementation by Paul Kocher (see blowfich.c for details)"
 msgstr "Implémentation Blowfish par Paul Kocher (voir blowchih.c)"
 
-
-#: shell/callbacks.c:170
-msgid "Raytracing benchmark by John Walker (see fbench.c for details)"
-msgstr ""
-"Raytracing benchmark par John Walker (détails voir fbench.c)"
-
 #: shell/callbacks.c:171
+msgid "Raytracing benchmark by John Walker (see fbench.c for details)"
+msgstr "Raytracing benchmark par John Walker (détails voir fbench.c)"
+
+#: shell/callbacks.c:172
 msgid "FFT benchmark by Scott Robert Ladd (see fftbench.c for details)"
 msgstr "FFT benchmark par Scott Robert Ladd (détails voir fftbench.c)"
 
-#: shell/callbacks.c:172
+#: shell/callbacks.c:173
 msgid "Some code partly based on x86cpucaps by Osamu Kayasono"
 msgstr "Une partie du code est basée sur x86cpucaps par Osamu Kayasono"
 
-#: shell/callbacks.c:173
+#: shell/callbacks.c:174
 msgid "Vendor list based on GtkSysInfo by Pissens Sebastien"
 msgstr "La liste des fabricants est basée sur GtkSysInfo par Pissens Sebastien"
 
-#: shell/callbacks.c:174
+#: shell/callbacks.c:175
 msgid "DMI support based on code by Stewart Adam"
 msgstr "Les supports DMI sont basés sur le code de Stewart Adam"
 
-#: shell/callbacks.c:175
+#: shell/callbacks.c:176
 msgid "SCSI support based on code by Pascal F. Martin"
 msgstr "Les supports SCSI sont basés sur le code de Pascal F. Martin"
 
-#: shell/callbacks.c:180
+#: shell/callbacks.c:181
 msgid "Tango Project"
 msgstr "Projet Tango"
 
-#: shell/callbacks.c:181
+#: shell/callbacks.c:182
 msgid "The GNOME Project"
 msgstr "Projet Gnome"
 
-#: shell/callbacks.c:182
+#: shell/callbacks.c:183
 msgid "VMWare, Inc. (USB icon from VMWare Workstation 6)"
 msgstr "VMWare, Inc. (icône USB VMWare Workstation 6)"
 
-#: shell/callbacks.c:200
+#: shell/callbacks.c:201
 msgid "System information and benchmark tool"
 msgstr "Information du systeme et outil d'évaluation"
 
-#: shell/callbacks.c:205
+#: shell/callbacks.c:206
 msgid ""
 "HardInfo is free software; you can redistribute it and/or modify it under "
 "the terms of the GNU General Public License as published by the Free "
@@ -555,135 +813,135 @@ msgstr ""
 "FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for "
 "more details.\n"
 "\n"
-"Recevoir une copie de GNU General Public License  "
-"de ce programme ou écrire à the Free Software Foundation, Inc., 51 "
-"Franklin St, Fifth Floor, Boston, MA  02110-1301 USA"
+"Recevoir une copie de GNU General Public License  de ce programme ou écrire "
+"à the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, "
+"MA  02110-1301 USA"
 
-#: shell/callbacks.c:220
+#: shell/callbacks.c:221
 msgid "translator-credits"
 msgstr "Crédits Traducteurs"
 
-#: shell/menu.c:35
+#: shell/menu.c:43
 msgid "_Information"
 msgstr "_Information"
 
-#: shell/menu.c:36
+#: shell/menu.c:44
 msgid "_Remote"
 msgstr "_Périphériques distants"
 
-#: shell/menu.c:37
+#: shell/menu.c:45
 msgid "_View"
 msgstr "_Voir"
 
-#: shell/menu.c:38
+#: shell/menu.c:46
 msgid "_Help"
 msgstr "_Aide"
 
-#: shell/menu.c:39
+#: shell/menu.c:47
 msgid "About _Modules"
 msgstr "A propos des _modules"
 
-#: shell/menu.c:43
+#: shell/menu.c:51
 msgid "Generate _Report"
 msgstr "Générer _Rapport"
 
-#: shell/menu.c:48
+#: shell/menu.c:56
 msgid "_Network Updater..."
 msgstr "_Mise à jour des données"
 
-#: shell/menu.c:53
+#: shell/menu.c:61
 msgid "_Open..."
 msgstr "_Ouvrir..."
 
-#: shell/menu.c:58
+#: shell/menu.c:66
 msgid "_Copy to Clipboard"
 msgstr "_Copier dans le presse-papier"
 
-#: shell/menu.c:59
+#: shell/menu.c:67
 msgid "Copy to clipboard"
 msgstr "Copie dans le presse-papier"
 
-#: shell/menu.c:63
+#: shell/menu.c:71
 msgid "_Refresh"
 msgstr "_Rafraichir"
 
-#: shell/menu.c:68
+#: shell/menu.c:76
 msgid "_Open HardInfo Web Site"
 msgstr "_HardInfo Site Web"
 
-#: shell/menu.c:73
+#: shell/menu.c:81
 msgid "_Report bug"
 msgstr "_Rapporter un bug"
 
-#: shell/menu.c:78
+#: shell/menu.c:86
 msgid "_About HardInfo"
 msgstr "_A Propos de HardInfo"
 
-#: shell/menu.c:79
+#: shell/menu.c:87
 msgid "Displays program version information"
 msgstr "Affiche les informations de version du programme"
 
-#: shell/menu.c:83
+#: shell/menu.c:91
 msgid "_Quit"
 msgstr "_Quitter"
 
-#: shell/menu.c:90
+#: shell/menu.c:98
 msgid "_Side Pane"
 msgstr "_Volet latéral"
 
-#: shell/menu.c:91
+#: shell/menu.c:99
 msgid "Toggles side pane visibility"
 msgstr "Basculer visibilité du panneau latéral "
 
-#: shell/menu.c:94
+#: shell/menu.c:102
 msgid "_Toolbar"
 msgstr "_Barre d'outils"
 
-#: shell/report.c:500 shell/report.c:508
+#: shell/report.c:769 shell/report.c:777
 msgid "Save File"
 msgstr "Sauvegarder le fichier"
 
-#: shell/report.c:503 shell/report.c:935 shell/syncmanager.c:748
+#: shell/report.c:772 shell/report.c:1243 shell/syncmanager.c:748
 msgid "_Cancel"
 msgstr "Annuler"
 
-#: shell/report.c:505
+#: shell/report.c:774
 msgid "_Save"
 msgstr "_Sauvegarder"
 
-#: shell/report.c:635
+#: shell/report.c:943
 msgid "Cannot create ReportContext. Programming bug?"
 msgstr "Impossible de créer un rapport général. Bug?"
 
-#: shell/report.c:654
+#: shell/report.c:962
 msgid "Open the report with your web browser?"
 msgstr "Ouvrez le rapport dans votre navigateur Web?"
 
-#: shell/report.c:657
+#: shell/report.c:965
 msgid "_No"
 msgstr "_Non"
 
-#: shell/report.c:658
+#: shell/report.c:966
 msgid "_Open"
 msgstr "_Ouvrir"
 
-#: shell/report.c:688
+#: shell/report.c:996
 msgid "Generating report..."
 msgstr "Création du rapport..."
 
-#: shell/report.c:698
+#: shell/report.c:1006
 msgid "Report saved."
 msgstr "Rapport sauvegardé"
 
-#: shell/report.c:700
+#: shell/report.c:1008
 msgid "Error while creating the report."
 msgstr "Erreur lors de la création du rapport."
 
-#: shell/report.c:802
+#: shell/report.c:1110
 msgid "Generate Report"
 msgstr "Réalisation du Rapport"
 
-#: shell/report.c:827
+#: shell/report.c:1135
 msgid ""
 "<big><b>Generate Report</b></big>\n"
 "Please choose the information that you wish to view in your report:"
@@ -691,47 +949,49 @@ msgstr ""
 "<big> <b>Générer un rapport</b> </big> \n"
 " Choisissez les informations que vous souhaitez afficher dans votre rapport:"
 
-#: shell/report.c:899
+#: shell/report.c:1207
 msgid "Select _None"
 msgstr "Désélectionner _Tout"
 
-#: shell/report.c:910
+#: shell/report.c:1218
 msgid "Select _All"
 msgstr "Sélectionner _Tout"
 
-#: shell/report.c:945
+#: shell/report.c:1253
 msgid "_Generate"
 msgstr "_Création"
 
-#: shell/shell.c:402
+#: shell/shell.c:407
 #, c-format
 msgid "%s - System Information"
 msgstr "%s - Informations du Système"
 
-#: shell/shell.c:407
+#: shell/shell.c:412
 msgid "System Information"
 msgstr "Informations du Système"
 
-#: shell/shell.c:759
+#: shell/shell.c:782
 msgid "Loading modules..."
 msgstr "Chargement des modules..."
 
-#: shell/shell.c:1715
+#: shell/shell.c:1828
 #, c-format
 msgid "<b>%s → Summary</b>"
 msgstr "<b>%s → Résumé</b>"
 
-#: shell/shell.c:1824
+#: shell/shell.c:1936
 msgid "Updating..."
 msgstr "Mise à jour..."
 
 #: shell/syncmanager.c:69
 msgid ""
 "<big><b>Synchronize with Central Database</b></big>\n"
-"The following information may be synchronized with the HardInfo central database."
+"The following information may be synchronized with the HardInfo central "
+"database."
 msgstr ""
 "<big><b>Synchroniser avec la base de données centrale</b></big>\n"
-"Les informations suivantes seront synchronisées avec la base de données de HardInfo."
+"Les informations suivantes seront synchronisées avec la base de données de "
+"HardInfo."
 
 #: shell/syncmanager.c:72
 msgid ""
@@ -745,7 +1005,8 @@ msgstr ""
 msgid ""
 "HardInfo was compiled without libsoup support. (Network Updater requires it.)"
 msgstr ""
-"HARDiNFO a été compilé sans le support libsoup. (Exigé pour mise à jour des données.)"
+"HARDiNFO a été compilé sans le support libsoup. (Exigé pour mise à jour des "
+"données.)"
 
 #: shell/syncmanager.c:161 shell/syncmanager.c:189
 #, c-format
@@ -811,47 +1072,91 @@ msgstr "Mises à jour"
 msgid "_Synchronize"
 msgstr "_Synchronisation"
 
-#: modules/benchmark/benches.c:74
-msgid "CPU Blowfish"
-msgstr "Test CPU Blowfish"
+#: modules/benchmark/benches.c:82
+msgid "CPU Blowfish (Single-thread)"
+msgstr ""
 
-#: modules/benchmark/benches.c:75
-msgid "CPU CryptoHash"
-msgstr "Test CPU CryptoHash"
+#: modules/benchmark/benches.c:84
+msgid "CPU Blowfish (Multi-thread)"
+msgstr ""
 
-#: modules/benchmark/benches.c:76
-msgid "CPU Fibonacci"
-msgstr "Test CPU Fibonacci "
+#: modules/benchmark/benches.c:86
+msgid "CPU Blowfish (Multi-core)"
+msgstr ""
 
-#: modules/benchmark/benches.c:77
-msgid "CPU N-Queens"
-msgstr "Test CPU N-Queens"
-
-#: modules/benchmark/benches.c:78
+#: modules/benchmark/benches.c:88
 msgid "CPU Zlib"
 msgstr "Test CPU Zlib"
 
-#: modules/benchmark/benches.c:79
+#: modules/benchmark/benches.c:90
+msgid "CPU CryptoHash"
+msgstr "Test CPU CryptoHash"
+
+#: modules/benchmark/benches.c:92
+msgid "CPU Fibonacci"
+msgstr "Test CPU Fibonacci "
+
+#: modules/benchmark/benches.c:94
+msgid "CPU N-Queens"
+msgstr "Test CPU N-Queens"
+
+#: modules/benchmark/benches.c:96
 msgid "FPU FFT"
 msgstr "Test FPU FFT"
 
-#: modules/benchmark/benches.c:80
+#: modules/benchmark/benches.c:98
 msgid "FPU Raytracing"
 msgstr "Test FPU Raytracing"
 
-#: modules/benchmark/benches.c:82
+#: modules/benchmark/benches.c:100
+msgid "SysBench CPU (Single-thread)"
+msgstr ""
+
+#: modules/benchmark/benches.c:102
+msgid "SysBench CPU (Multi-thread)"
+msgstr ""
+
+#: modules/benchmark/benches.c:104
+msgid "SysBench CPU (Four threads)"
+msgstr ""
+
+#: modules/benchmark/benches.c:106
+msgid "SysBench Memory (Single-thread)"
+msgstr ""
+
+#: modules/benchmark/benches.c:108
+msgid "SysBench Memory (Two threads)"
+msgstr ""
+
+#: modules/benchmark/benches.c:110
+msgid "SysBench Memory"
+msgstr ""
+
+#: modules/benchmark/benches.c:113
 msgid "GPU Drawing"
 msgstr "Test GPU Drawing"
 
-#: modules/benchmark/benches.c:91
+#: modules/benchmark/benches.c:126
+msgid ""
+"Alexey Kopytov's <i><b>sysbench</b></i> is required.\n"
+"Results in events/second. Higher is better."
+msgstr ""
+
+#: modules/benchmark/benches.c:132
+msgid ""
+"Alexey Kopytov's <i><b>sysbench</b></i> is required.\n"
+"Results in MiB/second. Higher is better."
+msgstr ""
+
+#: modules/benchmark/benches.c:136
 msgid "Results in MiB/second. Higher is better."
 msgstr "Résultats en MiB/seconde. Plus c'est élevé, meilleur est le résultat."
 
-#: modules/benchmark/benches.c:95
+#: modules/benchmark/benches.c:143
 msgid "Results in HIMarks. Higher is better."
 msgstr "Résultats en HIMarks. Plus c'est élevé, meilleur est le résultat."
 
-#: modules/benchmark/benches.c:102
+#: modules/benchmark/benches.c:149
 msgid "Results in seconds. Lower is better."
 msgstr "Résultats en secondes. Plus c'est bas, meilleur est le résultat."
 
@@ -870,162 +1175,206 @@ msgstr "Résultats en secondes. Plus c'est bas, meilleur est le résultat."
 #.
 #. / Used for an unknown value. Having it in only one place cleans up the .po line references
 #: modules/benchmark/bench_results.c:22 modules/computer.c:41
-#: modules/computer/display.c:41 modules/computer/os.c:279
-#: modules/devices.c:383 modules/devices/gpu.c:42 modules/devices/gpu.c:58
-#: modules/devices/gpu.c:150 modules/devices/gpu.c:151 modules/devices/pci.c:25
-#: modules/devices/pci.c:117 modules/devices/pci.c:118 modules/devices/usb.c:27
-#: modules/network/net.c:437 includes/cpu_util.h:11
+#: modules/computer/display.c:41 modules/computer/display.c:58
+#: modules/computer/os.c:286 modules/computer/os.c:346 modules/devices.c:488
+#: modules/devices/dmi_memory.c:52 modules/devices/dmi_memory.c:53
+#: modules/devices/dmi_memory.c:579 modules/devices/dmi_memory.c:719
+#: modules/devices/dmi_memory.c:855 modules/devices/gpu.c:42
+#: modules/devices/gpu.c:58 modules/devices/gpu.c:112 modules/devices/gpu.c:120
+#: modules/devices/gpu.c:154 modules/devices/gpu.c:155
+#: modules/devices/gpu.c:176 modules/devices/monitors.c:27
+#: modules/devices/monitors.c:28 modules/devices/monitors.c:153
+#: modules/devices/monitors.c:162 modules/devices/pci.c:25
+#: modules/devices/pci.c:135 modules/devices/pci.c:136
+#: modules/devices/spd-decode.c:306 modules/devices/spd-decode.c:307
+#: modules/devices/spd-decode.c:310 modules/devices/spd-decode.c:311
+#: modules/devices/spd-decode.c:914 modules/devices/spd-decode.c:915
+#: modules/devices/storage.c:247 modules/devices/storage.c:309
+#: modules/devices/usb.c:28 modules/network/net.c:437 includes/cpu_util.h:11
 msgid "(Unknown)"
 msgstr "(Inconnu)"
 
-#: modules/benchmark/bench_results.c:47 modules/benchmark/bench_results.c:322
-#: modules/devices/alpha/processor.c:90 modules/devices/arm/processor.c:276
-#: modules/devices/arm/processor.c:289 modules/devices/arm/processor.c:331
-#: modules/devices/arm/processor.c:478 modules/devices.c:310
-#: modules/devices.c:318 modules/devices.c:346
-#: modules/devices/ia64/processor.c:167 modules/devices/ia64/processor.c:196
-#: modules/devices/m68k/processor.c:87 modules/devices/mips/processor.c:77
-#: modules/devices/parisc/processor.c:158
+#: modules/benchmark/bench_results.c:49 modules/benchmark/bench_results.c:330
+#: modules/devices/alpha/processor.c:90 modules/devices/arm/processor.c:290
+#: modules/devices/arm/processor.c:303 modules/devices/arm/processor.c:345
+#: modules/devices/arm/processor.c:500 modules/devices.c:325
+#: modules/devices.c:333 modules/devices.c:361 modules/devices/gpu.c:115
+#: modules/devices/gpu.c:117 modules/devices/gpu.c:123
+#: modules/devices/gpu.c:125 modules/devices/gpu.c:179
+#: modules/devices/gpu.c:181 modules/devices/ia64/processor.c:167
+#: modules/devices/ia64/processor.c:196 modules/devices/m68k/processor.c:87
+#: modules/devices/mips/processor.c:77 modules/devices/parisc/processor.c:158
 #: modules/devices/parisc/processor.c:191 modules/devices/ppc/processor.c:160
 #: modules/devices/ppc/processor.c:187 modules/devices/riscv/processor.c:186
 #: modules/devices/riscv/processor.c:214 modules/devices/s390/processor.c:160
 #: modules/devices/sh/processor.c:87 modules/devices/sh/processor.c:88
 #: modules/devices/sh/processor.c:89 modules/devices/x86/processor.c:318
-#: modules/devices/x86/processor.c:331 modules/devices/x86/processor.c:655
-#: modules/devices/x86/processor.c:726
+#: modules/devices/x86/processor.c:331 modules/devices/x86/processor.c:657
+#: modules/devices/x86/processor.c:780
 msgid "MHz"
 msgstr ""
 
-#: modules/benchmark/bench_results.c:374 modules/benchmark/bench_results.c:441
+#: modules/benchmark/bench_results.c:396 modules/benchmark/bench_results.c:495
 msgid "kiB"
 msgstr ""
 
-#: modules/benchmark/bench_results.c:389 modules/benchmark/bench_results.c:426
+#: modules/benchmark/bench_results.c:403 modules/benchmark/bench_results.c:453
+#, c-format
+msgid "%d-bit"
+msgstr ""
+
+#: modules/benchmark/bench_results.c:422 modules/benchmark/bench_results.c:477
 msgid "Benchmark Result"
 msgstr "Résultats du Benchmark"
 
-#: modules/benchmark/bench_results.c:390 modules/benchmark/bench_results.c:428
+#: modules/benchmark/bench_results.c:423 modules/benchmark/bench_results.c:479
 msgid "Threads"
 msgstr ""
 
-#: modules/benchmark/bench_results.c:391 modules/benchmark/bench_results.c:431
+#: modules/benchmark/bench_results.c:424 modules/benchmark/bench_results.c:481
+msgid "Elapsed Time"
+msgstr "Temps écoulé"
+
+#: modules/benchmark/bench_results.c:424 modules/benchmark/bench_results.c:481
+msgid "seconds"
+msgstr ""
+
+#: modules/benchmark/bench_results.c:425 modules/computer/languages.c:101
+#: modules/devices/arm/processor.c:355 modules/devices/gpu.c:147
+#: modules/devices/ia64/processor.c:166 modules/devices/pci.c:132
+#: modules/devices/ppc/processor.c:159
+msgid "Revision"
+msgstr ""
+
+#: modules/benchmark/bench_results.c:426 modules/benchmark/bench_results.c:482
+msgid "Extra Information"
+msgstr ""
+
+#: modules/benchmark/bench_results.c:427 modules/benchmark/bench_results.c:483
+msgid "User Note"
+msgstr ""
+
+#: modules/benchmark/bench_results.c:429 modules/benchmark/bench_results.c:485
 msgid "Note"
 msgstr "Notes"
 
-#: modules/benchmark/bench_results.c:392 modules/benchmark/bench_results.c:432
+#: modules/benchmark/bench_results.c:430 modules/benchmark/bench_results.c:486
 msgid ""
 "This result is from an old version of HardInfo. Results might not be "
 "comparable to current version. Some details are missing."
 msgstr ""
-"Ce résultat provient d'une ancienne version de HardInfo. Les résultats peuvent ne pas être"
-"comparable à la version actuelle. Il manque quelques détails."
+"Ce résultat provient d'une ancienne version de HardInfo. Les résultats "
+"peuvent ne pas êtrecomparable à la version actuelle. Il manque quelques "
+"détails."
 
-#: modules/benchmark/bench_results.c:393 modules/benchmark/bench_results.c:433
+#: modules/benchmark/bench_results.c:431 modules/benchmark/bench_results.c:487
 #: modules/devices/devicetree/pmac_data.c:81 modules/devices/sh/processor.c:85
 msgid "Machine"
 msgstr "Machine"
 
-#: modules/benchmark/bench_results.c:394 modules/benchmark/bench_results.c:434
-#: modules/devices/devicetree.c:206 modules/devices/dmi.c:45
+#: modules/benchmark/bench_results.c:432 modules/benchmark/bench_results.c:488
+#: modules/devices/devicetree.c:208 modules/devices/dmi.c:47
 msgid "Board"
 msgstr ""
 
-#: modules/benchmark/bench_results.c:395 modules/benchmark/bench_results.c:435
+#: modules/benchmark/bench_results.c:433 modules/benchmark/bench_results.c:489
 msgid "CPU Name"
 msgstr "Nom du CPU"
 
-#: modules/benchmark/bench_results.c:396 modules/benchmark/bench_results.c:436
+#: modules/benchmark/bench_results.c:434 modules/benchmark/bench_results.c:490
 msgid "CPU Description"
 msgstr "Description du CPU"
 
-#: modules/benchmark/bench_results.c:397 modules/benchmark/bench_results.c:437
-#: modules/benchmark.c:390
+#: modules/benchmark/bench_results.c:435 modules/benchmark/bench_results.c:491
+#: modules/benchmark.c:442
 msgid "CPU Config"
 msgstr "Configuration du CPU"
 
-#: modules/benchmark/bench_results.c:398 modules/benchmark/bench_results.c:438
+#: modules/benchmark/bench_results.c:436 modules/benchmark/bench_results.c:492
 msgid "Threads Available"
 msgstr "Sujets disponibles"
 
-#: modules/benchmark/bench_results.c:399 modules/benchmark/bench_results.c:439
+#: modules/benchmark/bench_results.c:437 modules/benchmark/bench_results.c:493
 msgid "GPU"
 msgstr ""
 
-#: modules/benchmark/bench_results.c:400 modules/benchmark/bench_results.c:440
-#: modules/computer.c:479
+#: modules/benchmark/bench_results.c:438 modules/benchmark/bench_results.c:494
+#: modules/computer.c:542
 msgid "OpenGL Renderer"
 msgstr ""
 
-#: modules/benchmark/bench_results.c:401 modules/benchmark/bench_results.c:441
-#: modules/computer.c:110 modules/computer.c:468 modules/devices.c:99
+#: modules/benchmark/bench_results.c:439 modules/benchmark/bench_results.c:495
+#: modules/computer.c:123 modules/computer.c:531 modules/computer.c:1000
+#: modules/devices/gpu.c:150
 msgid "Memory"
 msgstr "Mémoire"
 
-#: modules/benchmark/bench_results.c:427
+#: modules/benchmark/bench_results.c:440 modules/benchmark/bench_results.c:496
+msgid "Pointer Size"
+msgstr ""
+
+#: modules/benchmark/bench_results.c:478
 msgid "Benchmark"
 msgstr "Outil d'évaluation"
 
-#: modules/benchmark/bench_results.c:429
+#: modules/benchmark/bench_results.c:480 modules/devices/dmi_memory.c:879
+#: modules/devices/firmware.c:246 modules/devices/monitors.c:492
+#: modules/devices/x86/processor.c:691
 msgid "Result"
 msgstr "Résultat"
 
-#: modules/benchmark/bench_results.c:430
-msgid "Elapsed Time"
-msgstr "Temps écoulé"
-
-#: modules/benchmark/bench_results.c:442
+#: modules/benchmark/bench_results.c:498
 msgid "Handles"
 msgstr "identifiants"
 
-#: modules/benchmark/bench_results.c:443
+#: modules/benchmark/bench_results.c:499
 msgid "mid"
 msgstr ""
 
-#: modules/benchmark/bench_results.c:444
+#: modules/benchmark/bench_results.c:500
 msgid "cfg_val"
 msgstr ""
 
-#: modules/benchmark.c:390
+#: modules/benchmark.c:442
 msgid "Results"
 msgstr "Résultats"
 
-#: modules/benchmark.c:390 modules/computer.c:811
-#: modules/devices/sparc/processor.c:75
+#: modules/benchmark.c:442 modules/devices/sparc/processor.c:75
 msgid "CPU"
 msgstr ""
 
-#: modules/benchmark.c:460
+#: modules/benchmark.c:513
 #, c-format
 msgid "Benchmarking: <b>%s</b>."
 msgstr "Benchmarking: <b>%s</b>."
 
-#: modules/benchmark.c:479 modules/benchmark.c:498
-msgid "Cancel"
-msgstr "Annuler"
-
-#: modules/benchmark.c:483 modules/benchmark.c:495
+#: modules/benchmark.c:527
 msgid "Benchmarking. Please do not move your mouse or press any keys."
 msgstr ""
 "Benchmarking. S'il vous plaît ne pas déplacer votre souris ou appuyer sur "
 "les touches"
 
-#: modules/benchmark.c:567
+#: modules/benchmark.c:530
+msgid "Cancel"
+msgstr "Annuler"
+
+#: modules/benchmark.c:601
 msgid "Benchmarks"
 msgstr "Benchmarks"
 
-#: modules/benchmark.c:585
+#: modules/benchmark.c:619
 msgid "Perform tasks and compare with other systems"
 msgstr "Effectuer des tâches et les comparer avec d'autres systèmes"
 
-#: modules/benchmark.c:692
+#: modules/benchmark.c:730
 msgid "Send benchmark results"
 msgstr "Envoyer vos résultats de benchmark"
 
-#: modules/benchmark.c:697
+#: modules/benchmark.c:735
 msgid "Receive benchmark results"
 msgstr "Recevoir les résultats de benchmark"
 
-#: modules/computer/alsa.c:26 modules/computer.c:483
+#: modules/computer/alsa.c:26 modules/computer.c:546
 msgid "Audio Devices"
 msgstr "Matériels Audio"
 
@@ -1033,499 +1382,606 @@ msgstr "Matériels Audio"
 msgid "Audio Adapter"
 msgstr "Adapteur Audio"
 
-#: modules/computer.c:76
+#: modules/computer.c:80 modules/devices/firmware.c:104
 msgid "Summary"
 msgstr "Résumé"
 
-#: modules/computer.c:77 modules/computer.c:471 modules/computer.c:810
+#: modules/computer.c:81 modules/computer.c:534 modules/computer.c:999
 msgid "Operating System"
 msgstr "Systeme d'exploitation"
 
-#: modules/computer.c:78 modules/devices/gpu.c:151 modules/devices/pci.c:118
+#: modules/computer.c:82
+msgid "Security"
+msgstr ""
+
+#: modules/computer.c:83 modules/devices/gpu.c:155 modules/devices/pci.c:136
 msgid "Kernel Modules"
 msgstr "Modules du kernel"
 
-#: modules/computer.c:79 modules/computer.c:540
+#: modules/computer.c:84 modules/computer.c:678
 msgid "Boots"
 msgstr "Boots"
 
-#: modules/computer.c:80
+#: modules/computer.c:85
 msgid "Languages"
 msgstr "Langues"
 
-#: modules/computer.c:81
+#: modules/computer.c:86
+msgid "Memory Usage"
+msgstr ""
+
+#: modules/computer.c:87
 msgid "Filesystems"
 msgstr "Fichiers Système"
 
-#: modules/computer.c:82 modules/computer.c:476
+#: modules/computer.c:88 modules/computer.c:539
 msgid "Display"
 msgstr "Affichage"
 
-#: modules/computer.c:83 modules/computer/environment.c:32
+#: modules/computer.c:89 modules/computer/environment.c:32
 msgid "Environment Variables"
 msgstr "Variables d'environnement"
 
-#: modules/computer.c:85
+#: modules/computer.c:91
 msgid "Development"
 msgstr "Developpement"
 
-#: modules/computer.c:87 modules/computer.c:661
+#: modules/computer.c:93 modules/computer.c:802
 msgid "Users"
 msgstr "Utilisateurs"
 
-#: modules/computer.c:88
+#: modules/computer.c:94
 msgid "Groups"
 msgstr "Groupes"
 
-#: modules/computer.c:112
+#: modules/computer.c:125
 #, c-format
 msgid "%dMB (%dMB used)"
 msgstr "%dMB (%dMB utilisées)"
 
-#: modules/computer.c:114 modules/computer.c:514
+#: modules/computer.c:127 modules/computer.c:594
 msgid "Uptime"
 msgstr "durée de fonctionnent"
 
-#: modules/computer.c:116 modules/computer.c:473
+#: modules/computer.c:129 modules/computer.c:536
 msgid "Date/Time"
 msgstr "Date/Heure"
 
-#: modules/computer.c:121 modules/computer.c:515
+#: modules/computer.c:134 modules/computer.c:595
 msgid "Load Average"
 msgstr "Nombre de chargements"
 
-#: modules/computer.c:123 modules/computer.c:516
-msgid "Available entropy in /dev/random"
-msgstr "Entropie disponible dans /dev/random"
-
-#: modules/computer.c:211
+#: modules/computer.c:247
 msgid "Scripting Languages"
 msgstr "Langage de script"
 
-#: modules/computer.c:212
+#: modules/computer.c:248
 msgid "Gambas3 (gbr3)"
 msgstr ""
 
-#: modules/computer.c:213
-msgid "Python"
+#: modules/computer.c:249
+msgid "Python (default)"
 msgstr ""
 
-#: modules/computer.c:214
+#: modules/computer.c:250
 msgid "Python2"
 msgstr ""
 
-#: modules/computer.c:215
+#: modules/computer.c:251
 msgid "Python3"
 msgstr ""
 
-#: modules/computer.c:216
+#: modules/computer.c:252
 msgid "Perl"
 msgstr "Perl"
 
-#: modules/computer.c:217
+#: modules/computer.c:253
 msgid "Perl6 (VM)"
 msgstr ""
 
-#: modules/computer.c:218
+#: modules/computer.c:254
 msgid "Perl6"
 msgstr ""
 
-#: modules/computer.c:219
+#: modules/computer.c:255
 msgid "PHP"
 msgstr "PHP"
 
-#: modules/computer.c:220
+#: modules/computer.c:256
 msgid "Ruby"
 msgstr "Ruby"
 
-#: modules/computer.c:221
+#: modules/computer.c:257
 msgid "Bash"
 msgstr "Bash"
 
-#: modules/computer.c:222
+#: modules/computer.c:258
+msgid "JavaScript (Node.js)"
+msgstr ""
+
+#: modules/computer.c:259
+msgid "awk"
+msgstr ""
+
+#: modules/computer.c:260
 msgid "Compilers"
 msgstr "Compilateurs"
 
-#: modules/computer.c:223
+#: modules/computer.c:261
 msgid "C (GCC)"
 msgstr "C (GCC)"
 
-#: modules/computer.c:224
+#: modules/computer.c:262
 msgid "C (Clang)"
 msgstr ""
 
-#: modules/computer.c:225
+#: modules/computer.c:263
 msgid "D (dmd)"
 msgstr ""
 
-#: modules/computer.c:226
+#: modules/computer.c:264
 msgid "Gambas3 (gbc3)"
 msgstr ""
 
-#: modules/computer.c:227
+#: modules/computer.c:265
 msgid "Java"
 msgstr "Java"
 
-#: modules/computer.c:228
-msgid "CSharp (Mono, old)"
-msgstr "CSharp (Mono, old)"
+#: modules/computer.c:266
+msgid "C♯ (mcs)"
+msgstr ""
 
-#: modules/computer.c:229
-msgid "CSharp (Mono)"
-msgstr "CSharp (Mono)"
-
-#: modules/computer.c:230
+#: modules/computer.c:267
 msgid "Vala"
 msgstr "Vala"
 
-#: modules/computer.c:231
+#: modules/computer.c:268
 msgid "Haskell (GHC)"
 msgstr "Haskell (GHC)"
 
-#: modules/computer.c:232
+#: modules/computer.c:269
 msgid "FreePascal"
 msgstr "FreePascal"
 
-#: modules/computer.c:233
+#: modules/computer.c:270
 msgid "Go"
 msgstr ""
 
-#: modules/computer.c:234
+#: modules/computer.c:271
+msgid "Rust"
+msgstr ""
+
+#: modules/computer.c:272
 msgid "Tools"
 msgstr "Outils"
 
-#: modules/computer.c:235
+#: modules/computer.c:273
 msgid "make"
 msgstr ""
 
-#: modules/computer.c:236
+#: modules/computer.c:274
+msgid "ninja"
+msgstr ""
+
+#: modules/computer.c:275
 msgid "GDB"
 msgstr ""
 
-#: modules/computer.c:237
+#: modules/computer.c:276
+msgid "LLDB"
+msgstr ""
+
+#: modules/computer.c:277
 msgid "strace"
 msgstr ""
 
-#: modules/computer.c:238
+#: modules/computer.c:278
 msgid "valgrind"
 msgstr ""
 
-#: modules/computer.c:239
+#: modules/computer.c:279
 msgid "QMake"
 msgstr ""
 
-#: modules/computer.c:240
+#: modules/computer.c:280
 msgid "CMake"
 msgstr ""
 
-#: modules/computer.c:241
+#: modules/computer.c:281
 msgid "Gambas3 IDE"
 msgstr ""
 
 #: modules/computer.c:282
+msgid "Radare2"
+msgstr ""
+
+#: modules/computer.c:283
+msgid "ltrace"
+msgstr ""
+
+#: modules/computer.c:324
 msgid "Not found"
 msgstr "Non trouvé"
 
-#: modules/computer.c:287
+#: modules/computer.c:329
 #, c-format
 msgid "Detecting version: %s"
 msgstr "Version détectée: %s"
 
-#: modules/computer.c:304
+#: modules/computer.c:347
 msgid "Program"
 msgstr "Programme"
 
-#: modules/computer.c:324
+#: modules/computer.c:365
+msgid "Field"
+msgstr "Champ"
+
+#: modules/computer.c:365 modules/computer.c:667 modules/computer/modules.c:149
+#: modules/computer/modules.c:150 modules/devices/arm/processor.c:470
+msgid "Description"
+msgstr ""
+
+#: modules/computer.c:365 modules/devices.c:726
+msgid "Value"
+msgstr "Valeur"
+
+#: modules/computer.c:385
 msgid "Single-board computer"
 msgstr "Ordinateur monocarte"
 
 #. /proc/apm
-#: modules/computer.c:373
+#: modules/computer.c:434
 msgid "Unknown physical machine type"
 msgstr "Type de machine inconnu"
 
-#: modules/computer.c:393 modules/computer.c:394
+#: modules/computer.c:454 modules/computer.c:455
 msgid "Virtual (VMware)"
 msgstr ""
 
-#: modules/computer.c:396 modules/computer.c:397 modules/computer.c:398
-#: modules/computer.c:399
+#: modules/computer.c:457 modules/computer.c:458 modules/computer.c:459
+#: modules/computer.c:460
 msgid "Virtual (QEMU)"
 msgstr ""
 
-#: modules/computer.c:401 modules/computer.c:402
+#: modules/computer.c:462 modules/computer.c:463
 msgid "Virtual (Unknown)"
 msgstr "Virtual (Inconnu)"
 
-#: modules/computer.c:404 modules/computer.c:405 modules/computer.c:406
-#: modules/computer.c:427
+#: modules/computer.c:465 modules/computer.c:466 modules/computer.c:467
+#: modules/computer.c:488
 msgid "Virtual (VirtualBox)"
 msgstr ""
 
-#: modules/computer.c:408 modules/computer.c:409 modules/computer.c:410
-#: modules/computer.c:421
+#: modules/computer.c:469 modules/computer.c:470 modules/computer.c:471
+#: modules/computer.c:482
 msgid "Virtual (Xen)"
 msgstr ""
 
-#: modules/computer.c:412
+#: modules/computer.c:473
 msgid "Virtual (hypervisor present)"
 msgstr ""
 
-#: modules/computer.c:465 modules/computer.c:769
+#: modules/computer.c:528 modules/computer.c:953
 msgid "Computer"
 msgstr "Ordinateur"
 
-#: modules/computer.c:466 modules/devices/alpha/processor.c:87
-#: modules/devices/arm/processor.c:327 modules/devices.c:98
-#: modules/devices/ia64/processor.c:159 modules/devices/m68k/processor.c:83
-#: modules/devices/mips/processor.c:74 modules/devices/parisc/processor.c:154
-#: modules/devices/ppc/processor.c:157 modules/devices/riscv/processor.c:181
-#: modules/devices/s390/processor.c:131 modules/devices/sh/processor.c:83
-#: modules/devices/sparc/processor.c:74 modules/devices/x86/processor.c:644
-msgid "Processor"
-msgstr "Processeur"
-
-#: modules/computer.c:469
+#: modules/computer.c:532
 msgid "Machine Type"
 msgstr "Type de machine"
 
-#: modules/computer.c:472 modules/computer.c:508
+#: modules/computer.c:535 modules/computer.c:588
 msgid "User Name"
 msgstr "Utilisateur"
 
-#: modules/computer.c:477
+#: modules/computer.c:540
 msgid "Resolution"
 msgstr "Résolution"
 
-#: modules/computer.c:477 modules/computer.c:607
+#: modules/computer.c:540 modules/computer.c:748
 #, c-format
 msgid "%dx%d pixels"
 msgstr ""
 
-#: modules/computer.c:480
+#: modules/computer.c:543
 msgid "Session Display Server"
 msgstr "Serveur d'affichage de session"
 
-#: modules/computer.c:485 modules/devices.c:106
+#: modules/computer.c:548 modules/devices.c:108
 msgid "Input Devices"
 msgstr "Périphériques d'entrée"
 
-#: modules/computer.c:500
+#: modules/computer.c:572
 msgid "Kernel"
 msgstr ""
 
-#: modules/computer.c:502
+#: modules/computer.c:573
+msgid "Command Line"
+msgstr ""
+
+#: modules/computer.c:575
 msgid "C Library"
 msgstr ""
 
-#: modules/computer.c:503
+#: modules/computer.c:576
 msgid "Distribution"
 msgstr ""
 
-#: modules/computer.c:506
+#: modules/computer.c:582
+msgid "Spin/Flavor"
+msgstr ""
+
+#: modules/computer.c:586
 msgid "Current Session"
 msgstr "Session en cours"
 
-#: modules/computer.c:507
+#: modules/computer.c:587
 msgid "Computer Name"
 msgstr "Nom de l'Ordinateur"
 
-#: modules/computer.c:509 modules/computer/languages.c:108
+#: modules/computer.c:589 modules/computer/languages.c:99
 msgid "Language"
 msgstr "Langue"
 
-#: modules/computer.c:510 modules/computer/users.c:50
+#: modules/computer.c:590 modules/computer/users.c:50
 msgid "Home Directory"
 msgstr "Dossier Home"
 
-#: modules/computer.c:513
+#: modules/computer.c:591
+msgid "Desktop Environment"
+msgstr "Environnement de bureau"
+
+#: modules/computer.c:594
 msgid "Misc"
 msgstr "Divers"
 
-#: modules/computer.c:526
+#: modules/computer.c:607
+msgid "HardInfo"
+msgstr ""
+
+#: modules/computer.c:608
+msgid "HardInfo running as"
+msgstr ""
+
+#: modules/computer.c:609
+msgid "Superuser"
+msgstr ""
+
+#: modules/computer.c:609
+msgid "User"
+msgstr ""
+
+#: modules/computer.c:613
+msgid "Health"
+msgstr ""
+
+#: modules/computer.c:614
+msgid "Available entropy in /dev/random"
+msgstr "Entropie disponible dans /dev/random"
+
+#: modules/computer.c:618
+msgid "Hardening Features"
+msgstr ""
+
+#: modules/computer.c:619
+msgid "ASLR"
+msgstr ""
+
+#: modules/computer.c:620
+msgid "dmesg"
+msgstr ""
+
+#: modules/computer.c:624
+msgid "Linux Security Modules"
+msgstr ""
+
+#: modules/computer.c:625
+msgid "Modules available"
+msgstr ""
+
+#: modules/computer.c:626
+msgid "SELinux status"
+msgstr ""
+
+#: modules/computer.c:632
+msgid "CPU Vulnerabilities"
+msgstr ""
+
+#: modules/computer.c:664
 msgid "Loaded Modules"
 msgstr "Modules chargés"
 
-#: modules/computer.c:529 modules/computer/modules.c:145
-#: modules/computer/modules.c:147 modules/devices/arm/processor.c:448
-#: modules/devices.c:575
-msgid "Description"
-msgstr ""
-
-#: modules/computer.c:542
+#: modules/computer.c:680
 msgid "Date & Time"
 msgstr "Date et Heure"
 
-#: modules/computer.c:543
+#: modules/computer.c:681
 msgid "Kernel Version"
 msgstr ""
 
-#: modules/computer.c:553
+#: modules/computer.c:691
 msgid "Available Languages"
 msgstr "Langues disponibles"
 
-#: modules/computer.c:555
+#: modules/computer.c:693
 msgid "Language Code"
 msgstr "Langage Code"
 
-#: modules/computer.c:567
+#: modules/computer.c:705
 msgid "Mounted File Systems"
 msgstr "Systèmes de fichiers montés"
 
-#: modules/computer.c:569 modules/computer/filesystem.c:85
+#: modules/computer.c:707 modules/computer/filesystem.c:85
 msgid "Mount Point"
 msgstr "Point de montage"
 
-#: modules/computer.c:570
+#: modules/computer.c:708
 msgid "Usage"
 msgstr ""
 
-#: modules/computer.c:571 modules/devices/gpu.c:93 modules/devices/gpu.c:101
-#: modules/devices/gpu.c:187 modules/devices/pci.c:70 modules/devices/pci.c:78
-#: modules/devices/pci.c:122 modules/devices/usb.c:72
+#: modules/computer.c:709 modules/devices/gpu.c:75 modules/devices/gpu.c:83
+#: modules/devices/gpu.c:225 modules/devices/pci.c:88 modules/devices/pci.c:96
+#: modules/devices/pci.c:140 modules/devices/usb.c:169
+#: modules/devices/usb.c:181
 msgid "Device"
 msgstr "Périphérique"
 
-#: modules/computer.c:590
+#: modules/computer.c:731
 msgid "Session"
 msgstr ""
 
-#: modules/computer.c:591 modules/devices.c:614 modules/devices/dmi.c:53
-#: modules/devices/inputdevices.c:117
+#: modules/computer.c:732 modules/devices.c:726 modules/devices/dmi.c:55
+#: modules/devices/dmi_memory.c:603 modules/devices/dmi_memory.c:749
+#: modules/devices/inputdevices.c:112 modules/devices/x86/processor.c:714
 msgid "Type"
 msgstr ""
 
-#: modules/computer.c:594
+#: modules/computer.c:735
 msgid "Wayland"
 msgstr ""
 
-#: modules/computer.c:595 modules/computer.c:600
+#: modules/computer.c:736 modules/computer.c:741
 msgid "Current Display Name"
 msgstr "Nom de l'affichage actuel"
 
-#: modules/computer.c:599
+#: modules/computer.c:740
 msgid "X Server"
 msgstr ""
 
-#: modules/computer.c:601 modules/computer.c:641 modules/devices/dmi.c:39
-#: modules/devices/dmi.c:43 modules/devices/dmi.c:47 modules/devices/dmi.c:52
-#: modules/devices/gpu.c:92 modules/devices/gpu.c:100 modules/devices/gpu.c:186
-#: modules/devices/ia64/processor.c:161 modules/devices/inputdevices.c:119
-#: modules/devices/pci.c:69 modules/devices/pci.c:77 modules/devices/usb.c:64
-#: modules/devices/x86/processor.c:651
+#: modules/computer.c:742 modules/computer.c:782 modules/devices/dmi.c:39
+#: modules/devices/dmi.c:45 modules/devices/dmi.c:49 modules/devices/dmi.c:54
+#: modules/devices/dmi_memory.c:750 modules/devices/dmi_memory.c:895
+#: modules/devices/firmware.c:105 modules/devices/firmware.c:168
+#: modules/devices/firmware.c:190 modules/devices/firmware.c:228
+#: modules/devices/gpu.c:74 modules/devices/gpu.c:82 modules/devices/gpu.c:224
+#: modules/devices/ia64/processor.c:161 modules/devices/inputdevices.c:114
+#: modules/devices/monitors.c:398 modules/devices/pci.c:87
+#: modules/devices/pci.c:95 modules/devices/usb.c:168
+#: modules/devices/x86/processor.c:653
 msgid "Vendor"
 msgstr "Fabricant"
 
-#: modules/computer.c:603
+#: modules/computer.c:744
 msgid "Release Number"
 msgstr "Numéro de version"
 
-#: modules/computer.c:611
+#: modules/computer.c:752
 msgid "Screens"
 msgstr "Ecrans"
 
-#: modules/computer.c:617
+#: modules/computer.c:758
 msgid "Disconnected"
 msgstr "Déconnecté"
 
-#: modules/computer.c:620
+#: modules/computer.c:761
 msgid "Connected"
 msgstr "Connecté"
 
-#: modules/computer.c:624 modules/computer/os.c:78 modules/computer/os.c:234
-#: modules/computer/os.c:392 modules/devices.c:344 modules/devices.c:396
-#: modules/devices/printers.c:99 modules/devices/printers.c:106
-#: modules/devices/printers.c:116 modules/devices/printers.c:131
-#: modules/devices/printers.c:140 modules/devices/printers.c:243
-msgid "Unknown"
-msgstr "Inconnu"
-
-#: modules/computer.c:628
+#: modules/computer.c:769
 msgid "Unused"
 msgstr "Non utilisé"
 
-#: modules/computer.c:629
+#: modules/computer.c:770
 #, c-format
 msgid "%dx%d pixels, offset (%d, %d)"
 msgstr ""
 
-#: modules/computer.c:638
+#: modules/computer.c:779
 msgid "Outputs (XRandR)"
 msgstr ""
 
-#: modules/computer.c:640
+#: modules/computer.c:781
 msgid "OpenGL (GLX)"
 msgstr ""
 
-#: modules/computer.c:642
+#: modules/computer.c:783
 msgid "Renderer"
 msgstr "Moteur de rendu"
 
-#: modules/computer.c:643
+#: modules/computer.c:784
 msgid "Direct Rendering"
 msgstr ""
 
-#: modules/computer.c:645
+#: modules/computer.c:786
 msgid "Version (Compatibility)"
 msgstr "Version (compatible)"
 
-#: modules/computer.c:646
+#: modules/computer.c:787
 msgid "Shading Language Version (Compatibility)"
 msgstr "Shading Language Version (Compatibilité)"
 
-#: modules/computer.c:647
+#: modules/computer.c:788
 msgid "Version (Core)"
 msgstr "Version (Coeur)"
 
-#: modules/computer.c:648
+#: modules/computer.c:789
 msgid "Shading Language Version (Core)"
 msgstr ""
 
-#: modules/computer.c:649
+#: modules/computer.c:790
 msgid "Version (ES)"
 msgstr ""
 
-#: modules/computer.c:650
+#: modules/computer.c:791
 msgid "Shading Language Version (ES)"
 msgstr ""
 
-#: modules/computer.c:651
+#: modules/computer.c:792
 msgid "GLX Version"
 msgstr ""
 
-#: modules/computer.c:672
+#: modules/computer.c:813
 msgid "Group"
 msgstr ""
 
-#: modules/computer.c:675 modules/computer/users.c:49
+#: modules/computer.c:816 modules/computer/users.c:49
 msgid "Group ID"
 msgstr ""
 
-#: modules/computer.c:811
-msgid "RAM"
+#. / <value> <unit> "usable memory"
+#: modules/computer.c:909
+#, c-format
+msgid "%0.1f %s available to Linux"
 msgstr ""
 
-#: modules/computer.c:811 modules/devices/devicetree/pmac_data.c:82
+#: modules/computer.c:911 modules/devices/dmi_memory.c:661
+#: modules/devices/dmi_memory.c:809 modules/devices/dmi_memory.c:936
+msgid "GiB"
+msgstr ""
+
+#: modules/computer.c:913 modules/devices/dmi_memory.c:581
+#: modules/devices/dmi_memory.c:663 modules/devices/dmi_memory.c:723
+#: modules/devices/dmi_memory.c:811 modules/devices/dmi_memory.c:857
+#: modules/devices/dmi_memory.c:938 modules/network/net.c:395
+#: modules/network/net.c:417 modules/network/net.c:418
+msgid "MiB"
+msgstr ""
+
+#: modules/computer.c:915 modules/computer/memory_usage.c:77
+#: modules/computer/modules.c:149
+msgid "KiB"
+msgstr ""
+
+#: modules/computer.c:972 modules/devices/devicetree/pmac_data.c:82
 msgid "Motherboard"
 msgstr "Carte Mère"
 
-#: modules/computer.c:811
+#: modules/computer.c:1000
 msgid "Graphics"
 msgstr "Graphiques"
 
-#: modules/computer.c:812 modules/devices.c:107
+#: modules/computer.c:1001 modules/devices.c:109
 msgid "Storage"
 msgstr "Stockage"
 
-#: modules/computer.c:812 modules/devices.c:103
+#: modules/computer.c:1001 modules/devices.c:105
 msgid "Printers"
 msgstr "Imprimantes"
 
-#: modules/computer.c:812
+#: modules/computer.c:1001
 msgid "Audio"
 msgstr ""
 
-#: modules/computer.c:857
+#: modules/computer.c:1050
 msgid "Gathers high-level computer information"
 msgstr "Collecte des informations de l'ordinateur"
 
@@ -1545,7 +2001,9 @@ msgstr "Lecture-Ecriture"
 msgid "Read-Only"
 msgstr "Lecture seule"
 
-#: modules/computer/filesystem.c:86 modules/devices/spd-decode.c:1510
+#: modules/computer/filesystem.c:86 modules/devices/dmi_memory.c:609
+#: modules/devices/dmi_memory.c:754 modules/devices/dmi_memory.c:786
+#: modules/devices/dmi_memory.c:825 modules/devices/dmi_memory.c:894
 msgid "Size"
 msgstr "Taille"
 
@@ -1557,37 +2015,32 @@ msgstr "Utilisé"
 msgid "Available"
 msgstr "Disponible"
 
-#: modules/computer/languages.c:103
+#: modules/computer/languages.c:94
 msgid "Locale Information"
 msgstr "Inforamtion Locale"
 
-#: modules/computer/languages.c:105
+#: modules/computer/languages.c:96 modules/devices/dmi_memory.c:599
+#: modules/devices/gpu.c:204
 msgid "Source"
 msgstr ""
 
-#: modules/computer/languages.c:106
+#: modules/computer/languages.c:97
 msgid "Address"
 msgstr "Adresse"
 
-#: modules/computer/languages.c:107
+#: modules/computer/languages.c:98
 msgid "E-mail"
 msgstr ""
 
-#: modules/computer/languages.c:109
+#: modules/computer/languages.c:100
 msgid "Territory"
 msgstr "Territoire"
 
-#: modules/computer/languages.c:110 modules/devices/arm/processor.c:341
-#: modules/devices/gpu.c:146 modules/devices/ia64/processor.c:166
-#: modules/devices/pci.c:114 modules/devices/ppc/processor.c:159
-msgid "Revision"
-msgstr ""
-
-#: modules/computer/languages.c:111 modules/devices/dmi.c:42
+#: modules/computer/languages.c:102 modules/devices/dmi.c:44
 msgid "Date"
 msgstr ""
 
-#: modules/computer/languages.c:112
+#: modules/computer/languages.c:103
 msgid "Codeset"
 msgstr ""
 
@@ -1595,106 +2048,188 @@ msgstr ""
 msgid "Couldn't obtain load average"
 msgstr "Impossible d'obtenir la moyenne de charge"
 
-#: modules/computer/modules.c:125 modules/computer/modules.c:126
-#: modules/computer/modules.c:127 modules/computer/modules.c:128
-#: modules/computer/modules.c:129 modules/devices/dmi.c:115
+#: modules/computer/memory_usage.c:106
+msgid "Total Memory"
+msgstr "Mémoire totale"
+
+#: modules/computer/memory_usage.c:107
+msgid "Free Memory"
+msgstr "Mémoire libre"
+
+#: modules/computer/memory_usage.c:108
+msgid "Cached Swap"
+msgstr "Swap Cache"
+
+#: modules/computer/memory_usage.c:109
+msgid "High Memory"
+msgstr ""
+
+#: modules/computer/memory_usage.c:110
+msgid "Free High Memory"
+msgstr ""
+
+#: modules/computer/memory_usage.c:111
+msgid "Low Memory"
+msgstr ""
+
+#: modules/computer/memory_usage.c:112
+msgid "Free Low Memory"
+msgstr ""
+
+#: modules/computer/memory_usage.c:113
+msgid "Virtual Memory"
+msgstr ""
+
+#: modules/computer/memory_usage.c:114
+msgid "Free Virtual Memory"
+msgstr ""
+
+#: modules/computer/modules.c:117 modules/computer/modules.c:118
+#: modules/computer/modules.c:119 modules/computer/modules.c:120
+#: modules/computer/modules.c:121 modules/computer/modules.c:122
+#: modules/devices/dmi.c:111 modules/devices/dmi_memory.c:881
+#: modules/devices/firmware.c:246 modules/devices/x86/processor.c:693
 msgid "(Not available)"
 msgstr "(Non disponible)"
 
-#: modules/computer/modules.c:142
+#: modules/computer/modules.c:148
 msgid "Module Information"
 msgstr ""
 
-#: modules/computer/modules.c:143
+#: modules/computer/modules.c:148 modules/devices/gpu.c:230
 msgid "Path"
 msgstr "Chemin"
 
-#: modules/computer/modules.c:144
+#: modules/computer/modules.c:148
 msgid "Used Memory"
 msgstr "Usage de la mémoire"
 
-#: modules/computer/modules.c:144 modules/devices/devmemory.c:72
-msgid "KiB"
-msgstr ""
-
-#: modules/computer/modules.c:148
+#: modules/computer/modules.c:150
 msgid "Version Magic"
 msgstr ""
 
-#: modules/computer/modules.c:149
+#: modules/computer/modules.c:151
+msgid "In Linus' Tree"
+msgstr ""
+
+#: modules/computer/modules.c:152
+msgid "Retpoline Enabled"
+msgstr ""
+
+#: modules/computer/modules.c:152
 msgid "Copyright"
 msgstr ""
 
-#: modules/computer/modules.c:150
+#: modules/computer/modules.c:152
 msgid "Author"
 msgstr "Auteur"
 
-#: modules/computer/modules.c:151
+#: modules/computer/modules.c:153
 msgid "License"
 msgstr ""
 
-#: modules/computer/modules.c:158
+#: modules/computer/modules.c:159
 msgid "Dependencies"
 msgstr "Dépendances"
 
-#: modules/computer/os.c:35 modules/computer/os.c:36 modules/computer/os.c:37
-#: modules/computer/os.c:38
+#: modules/computer/os.c:36 modules/computer/os.c:37 modules/computer/os.c:38
+#: modules/computer/os.c:39
 msgid "GNU C Library"
 msgstr ""
 
-#: modules/computer/os.c:39
+#: modules/computer/os.c:40
 msgid "uClibc or uClibc-ng"
 msgstr ""
 
-#: modules/computer/os.c:40
+#: modules/computer/os.c:41
 msgid "diet libc"
 msgstr ""
 
-#: modules/computer/os.c:112 modules/computer/os.c:115
+#: modules/computer/os.c:113 modules/computer/os.c:116
 msgid "GNOME Shell "
 msgstr ""
 
-#: modules/computer/os.c:123 modules/computer/os.c:126
+#: modules/computer/os.c:124 modules/computer/os.c:127
 msgid "Version: "
 msgstr ""
 
-#: modules/computer/os.c:157
+#: modules/computer/os.c:146 modules/computer/os.c:149
+msgid "MATE Desktop Environment "
+msgstr ""
+
+#: modules/computer/os.c:180
 #, c-format
 msgid "Unknown (Window Manager: %s)"
 msgstr "(gestionnaire de fenêtres: %s) inconnu"
 
 #. /{desktop environment} on {session type}
-#: modules/computer/os.c:168
+#: modules/computer/os.c:191
 #, c-format
 msgid "%s on %s"
 msgstr ""
 
-#: modules/computer/os.c:232
+#: modules/computer/os.c:261
 msgid "Terminal"
 msgstr "Terminal"
 
+#: modules/computer/os.c:278
+msgid "User access allowed"
+msgstr ""
+
+#: modules/computer/os.c:280
+msgid "User access forbidden"
+msgstr ""
+
+#: modules/computer/os.c:282
+msgid "Access allowed (running as superuser)"
+msgstr ""
+
+#: modules/computer/os.c:284
+msgid "Access forbidden? (running as superuser)"
+msgstr ""
+
+#: modules/computer/os.c:294 modules/computer/os.c:560
+msgid "Disabled"
+msgstr ""
+
+#: modules/computer/os.c:296
+msgid "Partially enabled (mmap base+stack+VDSO base)"
+msgstr ""
+
+#: modules/computer/os.c:298
+msgid "Fully enabled (mmap base+stack+VDSO base+heap)"
+msgstr ""
+
 #. /bits of entropy for rng (0)
-#: modules/computer/os.c:241
+#: modules/computer/os.c:308
 msgid "(None or not available)"
 msgstr "(Aucun ou non disponible)"
 
 #. /bits of entropy for rng (low/poor value)
-#: modules/computer/os.c:242
+#: modules/computer/os.c:309
 #, c-format
 msgid "%d bits (low)"
 msgstr "%d bits (lent)"
 
 #. /bits of entropy for rng (medium value)
-#: modules/computer/os.c:243
+#: modules/computer/os.c:310
 #, c-format
 msgid "%d bits (medium)"
 msgstr "%d bits (moyen)"
 
 #. /bits of entropy for rng (high/good value)
-#: modules/computer/os.c:244
+#: modules/computer/os.c:311
 #, c-format
 msgid "%d bits (healthy)"
 msgstr "%d bits (élévé)"
+
+#: modules/computer/os.c:555
+msgid "Not installed"
+msgstr ""
+
+#: modules/computer/os.c:558
+msgid "Enabled"
+msgstr ""
 
 #: modules/computer/users.c:47
 msgid "User Information"
@@ -1708,13 +2243,13 @@ msgstr "ID utilisateur"
 msgid "Default Shell"
 msgstr "Shell par défaut"
 
-#: modules/devices/alpha/processor.c:88 modules/devices/devicetree.c:161
-#: modules/devices/devicetree.c:207 modules/devices/devicetree/pmac_data.c:80
-#: modules/devices/gpu.c:124 modules/devices/ia64/processor.c:165
+#: modules/devices/alpha/processor.c:88 modules/devices/devicetree.c:163
+#: modules/devices/devicetree.c:209 modules/devices/devicetree/pmac_data.c:80
+#: modules/devices/gpu.c:106 modules/devices/ia64/processor.c:165
 #: modules/devices/m68k/processor.c:84 modules/devices/mips/processor.c:75
-#: modules/devices/parisc/processor.c:155 modules/devices/ppc/processor.c:158
-#: modules/devices/riscv/processor.c:182 modules/devices/s390/processor.c:132
-#: modules/devices/spd-decode.c:1510
+#: modules/devices/monitors.c:400 modules/devices/parisc/processor.c:155
+#: modules/devices/ppc/processor.c:158 modules/devices/riscv/processor.c:182
+#: modules/devices/s390/processor.c:132
 msgid "Model"
 msgstr "Modèle"
 
@@ -1722,28 +2257,28 @@ msgstr "Modèle"
 msgid "Platform String"
 msgstr ""
 
-#: modules/devices/alpha/processor.c:90 modules/devices/arm/processor.c:331
+#: modules/devices/alpha/processor.c:90 modules/devices/arm/processor.c:345
 #: modules/devices/ia64/processor.c:167 modules/devices/m68k/processor.c:87
 #: modules/devices/mips/processor.c:77 modules/devices/parisc/processor.c:158
 #: modules/devices/ppc/processor.c:160 modules/devices/riscv/processor.c:186
-#: modules/devices/sh/processor.c:87 modules/devices/x86/processor.c:655
+#: modules/devices/sh/processor.c:87 modules/devices/x86/processor.c:657
 msgid "Frequency"
 msgstr "Fréquence"
 
-#: modules/devices/alpha/processor.c:91 modules/devices/arm/processor.c:332
+#: modules/devices/alpha/processor.c:91 modules/devices/arm/processor.c:346
 #: modules/devices/ia64/processor.c:168 modules/devices/m68k/processor.c:88
 #: modules/devices/mips/processor.c:78 modules/devices/parisc/processor.c:159
 #: modules/devices/ppc/processor.c:161 modules/devices/s390/processor.c:134
-#: modules/devices/sh/processor.c:90 modules/devices/x86/processor.c:656
+#: modules/devices/sh/processor.c:90 modules/devices/x86/processor.c:658
 msgid "BogoMips"
 msgstr ""
 
-#: modules/devices/alpha/processor.c:92 modules/devices/arm/processor.c:333
+#: modules/devices/alpha/processor.c:92 modules/devices/arm/processor.c:347
 #: modules/devices/ia64/processor.c:169 modules/devices/m68k/processor.c:89
 #: modules/devices/mips/processor.c:79 modules/devices/parisc/processor.c:160
 #: modules/devices/ppc/processor.c:162 modules/devices/riscv/processor.c:187
 #: modules/devices/s390/processor.c:135 modules/devices/sh/processor.c:91
-#: modules/devices/sparc/processor.c:77 modules/devices/x86/processor.c:657
+#: modules/devices/sparc/processor.c:77 modules/devices/x86/processor.c:659
 msgid "Byte Order"
 msgstr ""
 
@@ -1770,7 +2305,8 @@ msgstr ""
 #: modules/devices/arm/arm_data.c:45
 msgctxt "arm-flag"
 msgid "26-Bit Model (Processor status register folded into program counter)"
-msgstr "26-Bit Model (Registre d'état du cpu incorporé dans le compteur de programme)"
+msgstr ""
+"26-Bit Model (Registre d'état du cpu incorporé dans le compteur de programme)"
 
 #. /flag:fastmult
 #: modules/devices/arm/arm_data.c:46
@@ -1917,76 +2453,77 @@ msgctxt "arm-flag"
 msgid "Advanced SIMD/NEON on AArch64 (arch>8)"
 msgstr ""
 
-#: modules/devices/arm/processor.c:142
+#: modules/devices/arm/processor.c:143
 msgid "ARM Processor"
 msgstr "Processeur ARM"
 
-#: modules/devices/arm/processor.c:200 modules/devices/riscv/processor.c:147
-#: modules/devices/x86/processor.c:606
+#: modules/devices/arm/processor.c:214 modules/devices/riscv/processor.c:147
+#: modules/devices/x86/processor.c:608
 msgid "Empty List"
 msgstr "Liste Vide"
 
-#: modules/devices/arm/processor.c:226 modules/devices/x86/processor.c:268
+#: modules/devices/arm/processor.c:240 modules/devices/gpu.c:148
+#: modules/devices/gpu.c:226 modules/devices/x86/processor.c:268
 msgid "Clocks"
 msgstr ""
 
-#: modules/devices/arm/processor.c:272 modules/devices/arm/processor.c:285
+#: modules/devices/arm/processor.c:286 modules/devices/arm/processor.c:299
 #: modules/devices/x86/processor.c:314 modules/devices/x86/processor.c:327
 #, c-format
 msgid "%.2f-%.2f %s=%dx\n"
 msgstr ""
 
-#: modules/devices/arm/processor.c:328
+#: modules/devices/arm/processor.c:342
 msgid "Linux Name"
 msgstr "Nom version Linux"
 
-#: modules/devices/arm/processor.c:329
+#: modules/devices/arm/processor.c:343
 msgid "Decoded Name"
 msgstr ""
 
-#: modules/devices/arm/processor.c:330 modules/network/net.c:453
+#: modules/devices/arm/processor.c:344 modules/network/net.c:453
 msgid "Mode"
 msgstr ""
 
-#: modules/devices/arm/processor.c:336
+#: modules/devices/arm/processor.c:350
 msgid "ARM"
 msgstr ""
 
-#: modules/devices/arm/processor.c:337
+#: modules/devices/arm/processor.c:351
 msgid "Implementer"
 msgstr ""
 
-#: modules/devices/arm/processor.c:338
+#: modules/devices/arm/processor.c:352 modules/devices/dmi_memory.c:896
 msgid "Part"
 msgstr ""
 
-#: modules/devices/arm/processor.c:339 modules/devices/ia64/processor.c:162
+#: modules/devices/arm/processor.c:353 modules/devices/ia64/processor.c:162
 #: modules/devices/parisc/processor.c:156 modules/devices/riscv/processor.c:183
 msgid "Architecture"
 msgstr ""
 
-#: modules/devices/arm/processor.c:340
+#: modules/devices/arm/processor.c:354
 msgid "Variant"
 msgstr ""
 
-#: modules/devices/arm/processor.c:342 modules/devices/riscv/processor.c:190
-#: modules/devices/sparc/processor.c:78 modules/devices/x86/processor.c:663
+#: modules/devices/arm/processor.c:356 modules/devices/riscv/processor.c:190
+#: modules/devices/sparc/processor.c:78 modules/devices/x86/processor.c:665
 msgid "Capabilities"
 msgstr "Capacités"
 
-#: modules/devices/arm/processor.c:446
+#: modules/devices/arm/processor.c:468
 msgid "SOC/Package"
 msgstr ""
 
-#: modules/devices/arm/processor.c:450 modules/devices/x86/processor.c:698
+#: modules/devices/arm/processor.c:472 modules/devices/x86/processor.c:751
 msgid "Logical CPU Config"
 msgstr ""
 
-#: modules/devices/arm/processor.c:467
+#: modules/devices/arm/processor.c:489
 msgid "SOC/Package Information"
 msgstr ""
 
-#: modules/devices/battery.c:181
+#: modules/devices/battery.c:178
 #, c-format
 msgid ""
 "\n"
@@ -2007,7 +2544,20 @@ msgstr ""
 "Modele=%s\n"
 "Numéro de série=%s\n"
 
-#: modules/devices/battery.c:346
+#: modules/devices/battery.c:255
+#, c-format
+msgid ""
+"\n"
+"[Battery: %s]\n"
+"State=%s\n"
+"Capacity=%s / %s\n"
+"Battery Technology=%s\n"
+"Manufacturer=%s\n"
+"Model Number=%s\n"
+"Serial Number=%s\n"
+msgstr ""
+
+#: modules/devices/battery.c:343
 #, c-format
 msgid ""
 "\n"
@@ -2026,7 +2576,7 @@ msgstr ""
 "APM driver version=%s\n"
 "APM BIOS version=%s\n"
 
-#: modules/devices/battery.c:358
+#: modules/devices/battery.c:355
 #, c-format
 msgid ""
 "\n"
@@ -2043,7 +2593,7 @@ msgstr ""
 "APM driver version=%s\n"
 "APM BIOS version=%s\n"
 
-#: modules/devices/battery.c:385
+#: modules/devices/battery.c:382
 msgid ""
 "[No batteries]\n"
 "No batteries found on this system=\n"
@@ -2055,31 +2605,40 @@ msgstr ""
 msgid "Graphics Processors"
 msgstr "Processeurs Graphiques"
 
-#: modules/devices.c:101 modules/devices/pci.c:143
+#: modules/devices.c:101 modules/devices/monitors.c:445
+#: modules/devices/monitors.c:492
+msgid "Monitors"
+msgstr ""
+
+#: modules/devices.c:102 modules/devices/pci.c:163
 msgid "PCI Devices"
 msgstr "Périphériques PCI"
 
-#: modules/devices.c:102 modules/devices/usb.c:92
+#: modules/devices.c:103 modules/devices/usb.c:210
 msgid "USB Devices"
 msgstr "Périphériques USB"
 
 #: modules/devices.c:104
+msgid "Firmware"
+msgstr ""
+
+#: modules/devices.c:106
 msgid "Battery"
 msgstr "Batterie"
 
-#: modules/devices.c:105
+#: modules/devices.c:107
 msgid "Sensors"
 msgstr "Capteurs"
 
-#: modules/devices.c:109
-msgid "DMI"
-msgstr "DMI"
-
 #: modules/devices.c:110
-msgid "Memory SPD"
-msgstr "Mémoire SPD"
+msgid "System DMI"
+msgstr ""
 
-#: modules/devices.c:115
+#: modules/devices.c:111
+msgid "Memory Devices"
+msgstr ""
+
+#: modules/devices.c:113 modules/devices.c:115
 msgid "Device Tree"
 msgstr "Arborescence matériel"
 
@@ -2087,21 +2646,21 @@ msgstr "Arborescence matériel"
 msgid "Resources"
 msgstr "Ressources"
 
-#: modules/devices.c:162
+#: modules/devices.c:177
 #, c-format
 msgid "%d physical processor"
 msgid_plural "%d physical processors"
 msgstr[0] "%d processeur physique"
 msgstr[1] "%d processeurs physiques"
 
-#: modules/devices.c:163
+#: modules/devices.c:178
 #, c-format
 msgid "%d core"
 msgid_plural "%d cores"
 msgstr[0] "%d coeur"
 msgstr[1] "%d coeurs"
 
-#: modules/devices.c:164
+#: modules/devices.c:179
 #, c-format
 msgid "%d thread"
 msgid_plural "%d threads"
@@ -2109,106 +2668,106 @@ msgstr[0] ""
 msgstr[1] ""
 
 #. /NP procs; NC cores; NT threads
-#: modules/devices.c:165
+#: modules/devices.c:180
 #, c-format
 msgid "%s; %s; %s"
 msgstr ""
 
-#: modules/devices.c:575
-msgid "Field"
-msgstr "Champ"
-
-#: modules/devices.c:575 modules/devices.c:614
-msgid "Value"
-msgstr "Valeur"
-
-#: modules/devices.c:614
+#: modules/devices.c:726
 msgid "Sensor"
 msgstr "Capteur"
 
-#: modules/devices.c:661
+#: modules/devices.c:773 modules/devices/dmi_memory.c:826
 msgid "Devices"
 msgstr "Périphériques"
 
-#: modules/devices.c:673
+#: modules/devices.c:785
 msgid "Update PCI ID listing"
 msgstr "Mise à jour de la liste ID PCI "
 
-#: modules/devices.c:685
+#: modules/devices.c:797
 msgid "Update CPU feature database"
 msgstr "Mise à jour des bases de données caractéristiques CPU"
 
-#: modules/devices.c:713
+#: modules/devices.c:825
 msgid "Gathers information about hardware devices"
 msgstr "Collecte des informations des périphériques"
 
-#: modules/devices.c:732
+#: modules/devices.c:844
 msgid "Resource information requires superuser privileges"
-msgstr "L'information sur ces ressources nécessite des privilèges de super-utilisateur"
+msgstr ""
+"L'information sur ces ressources nécessite des privilèges de super-"
+"utilisateur"
 
-#: modules/devices/devicetree.c:50
+#: modules/devices.c:850
+msgid ""
+"Any NVMe storage devices present are not listed.\n"
+"<b><i>udisksd</i></b> is required for NVMe devices."
+msgstr ""
+
+#: modules/devices/devicetree.c:52
 msgid "Properties"
 msgstr "Propriétés"
 
-#: modules/devices/devicetree.c:51
+#: modules/devices/devicetree.c:53
 msgid "Children"
 msgstr ""
 
-#: modules/devices/devicetree.c:87
+#: modules/devices/devicetree.c:89
 msgid "Node"
 msgstr ""
 
-#: modules/devices/devicetree.c:88
+#: modules/devices/devicetree.c:90
 msgid "Node Path"
 msgstr ""
 
-#: modules/devices/devicetree.c:89
+#: modules/devices/devicetree.c:91
 msgid "Alias"
 msgstr ""
 
-#: modules/devices/devicetree.c:89 modules/devices/devicetree.c:90
-msgid "(None)"
-msgstr "(Aucun)"
-
-#: modules/devices/devicetree.c:90
+#: modules/devices/devicetree.c:92
 msgid "Symbol"
 msgstr "Symbole"
 
-#: modules/devices/devicetree.c:143 modules/devices/devicetree/pmac_data.c:79
+#: modules/devices/devicetree.c:145 modules/devices/devicetree/pmac_data.c:79
 msgid "Platform"
 msgstr "Plateforme"
 
-#: modules/devices/devicetree.c:144 modules/devices/devicetree.c:209
+#: modules/devices/devicetree.c:146 modules/devices/devicetree.c:211
+#: modules/devices/gpu.c:231
 msgid "Compatible"
 msgstr "Similaire"
 
-#: modules/devices/devicetree.c:145
+#: modules/devices/devicetree.c:147
 msgid "GPU-compatible"
 msgstr ""
 
-#: modules/devices/devicetree.c:160
+#: modules/devices/devicetree.c:162
 msgid "Raspberry Pi or Compatible"
 msgstr "Raspberry Pi ou Similaire"
 
-#: modules/devices/devicetree.c:162 modules/devices/devicetree.c:189
-#: modules/devices/devicetree.c:208 modules/devices/devicetree/rpi_data.c:161
-#: modules/devices/dmi.c:49 modules/devices/dmi.c:55
+#: modules/devices/devicetree.c:164 modules/devices/devicetree.c:191
+#: modules/devices/devicetree.c:210 modules/devices/devicetree/rpi_data.c:168
+#: modules/devices/dmi.c:41 modules/devices/dmi.c:51 modules/devices/dmi.c:57
+#: modules/devices/usb.c:178
 msgid "Serial Number"
 msgstr "Numéro de série"
 
-#: modules/devices/devicetree.c:163 modules/devices/devicetree/rpi_data.c:158
+#: modules/devices/devicetree.c:165 modules/devices/devicetree/rpi_data.c:165
 msgid "RCode"
 msgstr ""
 
-#: modules/devices/devicetree.c:163
+#: modules/devices/devicetree.c:165
 msgid "No revision code available; unable to lookup model details."
-msgstr "Aucun code de révision n'est disponible; il n'est pas possible de consulter les détails du modèle."
+msgstr ""
+"Aucun code de révision n'est disponible; il n'est pas possible de consulter "
+"les détails du modèle."
 
-#: modules/devices/devicetree.c:188
+#: modules/devices/devicetree.c:190
 msgid "More"
 msgstr "Plus"
 
-#: modules/devices/devicetree.c:268
+#: modules/devices/devicetree.c:271
 msgid "Messages"
 msgstr ""
 
@@ -2232,87 +2791,51 @@ msgstr ""
 msgid "PMAC Generation"
 msgstr ""
 
-#: modules/devices/devicetree/rpi_data.c:153
-#: modules/devices/devicetree/rpi_data.c:154
+#: modules/devices/devicetree/rpi_data.c:160
+#: modules/devices/devicetree/rpi_data.c:161
 msgid "Raspberry Pi"
 msgstr ""
 
-#: modules/devices/devicetree/rpi_data.c:154
+#: modules/devices/devicetree/rpi_data.c:161
 msgid "Board Name"
 msgstr "Nom de la carte"
 
-#: modules/devices/devicetree/rpi_data.c:155
+#: modules/devices/devicetree/rpi_data.c:162
 msgid "PCB Revision"
 msgstr ""
 
-#: modules/devices/devicetree/rpi_data.c:156
+#: modules/devices/devicetree/rpi_data.c:163
 msgid "Introduction"
 msgstr ""
 
-#: modules/devices/devicetree/rpi_data.c:157 modules/devices/spd-decode.c:1510
+#: modules/devices/devicetree/rpi_data.c:164 modules/devices/usb.c:170
 msgid "Manufacturer"
 msgstr "Fabricant"
 
-#: modules/devices/devicetree/rpi_data.c:159
+#: modules/devices/devicetree/rpi_data.c:166
 msgid "SOC (spec)"
 msgstr ""
 
-#: modules/devices/devicetree/rpi_data.c:160
+#: modules/devices/devicetree/rpi_data.c:167
 msgid "Memory (spec)"
 msgstr "Memoire (spec)"
 
-#: modules/devices/devicetree/rpi_data.c:162
+#: modules/devices/devicetree/rpi_data.c:169
 msgid "Permanent overvolt bit"
 msgstr ""
 
-#: modules/devices/devicetree/rpi_data.c:162
+#: modules/devices/devicetree/rpi_data.c:169
 msgctxt "rpi-ov-bit"
 msgid "Set"
 msgstr "Sélectionné"
 
-#: modules/devices/devicetree/rpi_data.c:162
+#: modules/devices/devicetree/rpi_data.c:169
 msgctxt "rpi-ov-bit"
 msgid "Not set"
 msgstr "Non séléctionné"
 
-#: modules/devices/devmemory.c:101
-msgid "Total Memory"
-msgstr "Mémoire totale"
-
-#: modules/devices/devmemory.c:102
-msgid "Free Memory"
-msgstr "Mémoire libre"
-
-#: modules/devices/devmemory.c:103
-msgid "Cached Swap"
-msgstr "Swap Cache"
-
-#: modules/devices/devmemory.c:104
-msgid "High Memory"
-msgstr ""
-
-#: modules/devices/devmemory.c:105
-msgid "Free High Memory"
-msgstr ""
-
-#: modules/devices/devmemory.c:106
-msgid "Low Memory"
-msgstr ""
-
-#: modules/devices/devmemory.c:107
-msgid "Free Low Memory"
-msgstr ""
-
-#: modules/devices/devmemory.c:108
-msgid "Virtual Memory"
-msgstr ""
-
-#: modules/devices/devmemory.c:109
-msgid "Free Virtual Memory"
-msgstr ""
-
-#: modules/devices/dmi.c:36 modules/devices/inputdevices.c:120
-#: modules/devices/usb.c:63
+#: modules/devices/dmi.c:36 modules/devices/inputdevices.c:115
+#: modules/devices/usb.c:167
 msgid "Product"
 msgstr "Produit"
 
@@ -2321,90 +2844,403 @@ msgstr "Produit"
 msgid "Family"
 msgstr "Famille"
 
-#: modules/devices/dmi.c:41
+#: modules/devices/dmi.c:42
+msgid "SKU"
+msgstr ""
+
+#: modules/devices/dmi.c:43
 msgid "BIOS"
 msgstr ""
 
-#: modules/devices/dmi.c:50 modules/devices/dmi.c:56
+#: modules/devices/dmi.c:52 modules/devices/dmi.c:58
 msgid "Asset Tag"
 msgstr ""
 
-#: modules/devices/dmi.c:51
-msgid "Chassis"
+#: modules/devices/dmi.c:115 modules/devices/dmi_memory.c:882
+#: modules/devices/x86/processor.c:694
+msgid "(Not available; Perhaps try running HardInfo as root.)"
+msgstr ""
+"(Non disponible; essayez peut-être d'exécuter HardInfo en tant que root.)"
+
+#: modules/devices/dmi.c:156
+msgid "DMI Unavailable"
 msgstr ""
 
-#: modules/devices/dmi.c:116
-msgid "(Not available; Perhaps try running HardInfo as root.)"
-msgstr "(Non disponible; essayez peut-être d'exécuter HardInfo en tant que root.)"
+#: modules/devices/dmi.c:158
+msgid "DMI is not avaliable. Perhaps this platform does not provide DMI."
+msgstr ""
 
-#: modules/devices/gpu.c:102 modules/devices/pci.c:79
+#: modules/devices/dmi.c:159
+msgid "DMI is not available; Perhaps try running HardInfo as root."
+msgstr ""
+
+#: modules/devices/dmi_memory.c:598
+msgid "Serial Presence Detect (SPD)"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:601
+msgid "SPD Revision"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:602 modules/devices/dmi_memory.c:748
+msgid "Form Factor"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:604
+msgid "Module Vendor"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:606
+msgid "DRAM Vendor"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:608 modules/devices/dmi_memory.c:753
+msgid "Part Number"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:610
+msgid "Manufacturing Date (Week / Year)"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:644 modules/devices/dmi_memory.c:879
+msgid "Memory Device List"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:686
+msgid "Memory Array"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:687 modules/devices/x86/processor.c:713
+msgid "DMI Handle"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:688 modules/devices/dmi_memory.c:746
+#: modules/devices/dmi_memory.c:784 modules/devices/dmi_memory.c:893
+msgid "Locator"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:689
+msgid "Use"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:690
+msgid "Error Correction Type"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:691
+msgid "Size (Present / Max)"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:692
+msgid "Devices (Populated / Sockets)"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:693 modules/devices/dmi_memory.c:827
+msgid "Types Present"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:744 modules/devices/dmi_memory.c:782
+msgid "Memory Socket"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:745 modules/devices/dmi_memory.c:783
+msgid "DMI Handles (Array, Socket)"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:747 modules/devices/dmi_memory.c:785
+msgid "Bank Locator"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:755
+msgid "Rated Speed"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:756
+msgid "Configured Speed"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:757
+msgid "Data Width/Total Width"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:758
+msgid "Rank"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:759
+msgid "Minimum Voltage"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:760
+msgid "Maximum Voltage"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:761
+msgid "Configured Voltage"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:786 modules/devices/dmi_memory.c:793
+#: modules/devices/monitors.c:492
+msgid "(Empty)"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:824
+msgid "Serial Presence Detect (SPD) Summary"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:947
+msgid " <b><i>dmidecode</i></b> utility available"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:948
+msgid " ... <i>and</i> HardInfo running with superuser privileges"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:949
+msgid " <b><i>eeprom</i></b> module loaded (for SDR, DDR, DDR2, DDR3)"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:950
+msgid ""
+" ... <i>or</i> <b><i>ee1004</i></b> module loaded <b>and configured!</b> "
+"(for DDR4)"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:961
+msgid "Memory information requires <b>one or both</b> of the following:"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:982
+msgid ""
+"\"More often than not, information contained in the DMI tables is "
+"inaccurate,\n"
+"incomplete or simply wrong.\" -<i><b>dmidecode</b></i> manual page"
+msgstr ""
+
+#: modules/devices/firmware.c:69
+msgid "Device cannot be removed easily"
+msgstr ""
+
+#: modules/devices/firmware.c:70
+msgid "Device is updatable in this or any other mode"
+msgstr ""
+
+#: modules/devices/firmware.c:71
+msgid "Update can only be done from offline mode"
+msgstr ""
+
+#: modules/devices/firmware.c:72
+msgid "Requires AC power"
+msgstr ""
+
+#: modules/devices/firmware.c:73
+msgid "Is locked and can be unlocked"
+msgstr ""
+
+#: modules/devices/firmware.c:74
+msgid "Is found in current metadata"
+msgstr ""
+
+#: modules/devices/firmware.c:75
+msgid "Requires a bootloader mode to be manually enabled by the user"
+msgstr ""
+
+#: modules/devices/firmware.c:76
+msgid "Has been registered with other plugins"
+msgstr ""
+
+#: modules/devices/firmware.c:77
+msgid "Requires a reboot to apply firmware or to reload hardware"
+msgstr ""
+
+#: modules/devices/firmware.c:78
+msgid "Requires system shutdown to apply firmware"
+msgstr ""
+
+#: modules/devices/firmware.c:79
+msgid "Has been reported to a metadata server"
+msgstr ""
+
+#: modules/devices/firmware.c:80
+msgid "User has been notified"
+msgstr ""
+
+#: modules/devices/firmware.c:81
+msgid "Always use the runtime version rather than the bootloader"
+msgstr ""
+
+#: modules/devices/firmware.c:82
+msgid "Install composite firmware on the parent before the child"
+msgstr ""
+
+#: modules/devices/firmware.c:83
+msgid "Is currently in bootloader mode"
+msgstr ""
+
+#: modules/devices/firmware.c:84
+msgid "The hardware is waiting to be replugged"
+msgstr ""
+
+#: modules/devices/firmware.c:85
+msgid "Ignore validation safety checks when flashing this device"
+msgstr ""
+
+#: modules/devices/firmware.c:86
+msgid "Requires the update to be retried with a new plugin"
+msgstr ""
+
+#: modules/devices/firmware.c:87
+msgid "Do not add instance IDs from the device baseclass"
+msgstr ""
+
+#: modules/devices/firmware.c:88
+msgid "Device update needs to be separately activated"
+msgstr ""
+
+#: modules/devices/firmware.c:89
+msgid ""
+"Ensure the version is a valid semantic version, e.g. numbers separated with "
+"dots"
+msgstr ""
+
+#: modules/devices/firmware.c:90
+msgid "Extra metadata can be exposed about this device"
+msgstr ""
+
+#: modules/devices/firmware.c:104
+msgid "DeviceId"
+msgstr ""
+
+#: modules/devices/firmware.c:104
+msgid "Guid"
+msgstr ""
+
+#: modules/devices/firmware.c:104
+msgid "Plugin"
+msgstr ""
+
+#: modules/devices/firmware.c:104 modules/network.c:380
+msgid "Flags"
+msgstr ""
+
+#: modules/devices/firmware.c:105
+msgid "VendorId"
+msgstr ""
+
+#: modules/devices/firmware.c:105
+msgid "VersionBootloader"
+msgstr ""
+
+#: modules/devices/firmware.c:106
+msgid "Icon"
+msgstr ""
+
+#: modules/devices/firmware.c:106
+msgid "InstallDuration"
+msgstr ""
+
+#: modules/devices/firmware.c:106
+msgid "Created"
+msgstr ""
+
+#: modules/devices/firmware.c:245
+msgid "Firmware List"
+msgstr ""
+
+#: modules/devices/firmware.c:258
+msgid "Requires the <i><b>fwupdmgr</b></i> utility."
+msgstr ""
+
+#: modules/devices/gpu.c:84 modules/devices/pci.c:97
 msgid "SVendor"
 msgstr ""
 
-#: modules/devices/gpu.c:103 modules/devices/pci.c:80
+#: modules/devices/gpu.c:85 modules/devices/pci.c:98
 msgid "SDevice"
 msgstr ""
 
-#: modules/devices/gpu.c:111 modules/devices/pci.c:90
+#: modules/devices/gpu.c:93 modules/devices/pci.c:108
 msgid "PCI Express"
 msgstr ""
 
-#: modules/devices/gpu.c:112 modules/devices/pci.c:92
+#: modules/devices/gpu.c:94 modules/devices/pci.c:110
 msgid "Maximum Link Width"
 msgstr ""
 
-#: modules/devices/gpu.c:113 modules/devices/pci.c:94
+#: modules/devices/gpu.c:95 modules/devices/pci.c:112
 msgid "Maximum Link Speed"
 msgstr ""
 
-#: modules/devices/gpu.c:113 modules/devices/pci.c:93 modules/devices/pci.c:94
+#: modules/devices/gpu.c:95 modules/devices/pci.c:111 modules/devices/pci.c:112
 msgid "GT/s"
 msgstr ""
 
-#: modules/devices/gpu.c:123
+#: modules/devices/gpu.c:105
 msgid "NVIDIA"
 msgstr ""
 
-#: modules/devices/gpu.c:125
+#: modules/devices/gpu.c:107
 msgid "BIOS Version"
 msgstr ""
 
-#: modules/devices/gpu.c:126
+#: modules/devices/gpu.c:108
 msgid "UUID"
 msgstr ""
 
-#: modules/devices/gpu.c:141 modules/devices/gpu.c:183
-#: modules/devices/inputdevices.c:115 modules/devices/pci.c:111
-#: modules/devices/usb.c:62
+#: modules/devices/gpu.c:142 modules/devices/gpu.c:222
+#: modules/devices/inputdevices.c:110 modules/devices/pci.c:129
+#: modules/devices/usb.c:166
 msgid "Device Information"
 msgstr "Information matériel"
 
-#: modules/devices/gpu.c:142 modules/devices/gpu.c:184
+#: modules/devices/gpu.c:143 modules/devices/gpu.c:223
 msgid "Location"
 msgstr ""
 
-#: modules/devices/gpu.c:143
+#: modules/devices/gpu.c:144
 msgid "DRM Device"
 msgstr ""
 
-#: modules/devices/gpu.c:144 modules/devices/pci.c:112 modules/devices/usb.c:67
+#: modules/devices/gpu.c:145 modules/devices/pci.c:130
+#: modules/devices/usb.c:133 modules/devices/usb.c:174
 msgid "Class"
 msgstr ""
 
-#: modules/devices/gpu.c:150 modules/devices/pci.c:117
+#: modules/devices/gpu.c:154 modules/devices/pci.c:135
 msgid "In Use"
 msgstr "En cours"
 
-#: modules/devices/gpu.c:174
+#: modules/devices/gpu.c:185
 msgid "Unknown integrated GPU"
 msgstr "GPU intégré inconnu"
 
-#: modules/devices/gpu.c:185
-msgid "DT Compatibility"
+#: modules/devices/gpu.c:191
+msgid "clock-frequency property"
 msgstr ""
 
-#: modules/devices/gpu.c:201
+#: modules/devices/gpu.c:192
+msgid "Operating Points (OPPv1)"
+msgstr ""
+
+#: modules/devices/gpu.c:193
+msgid "Operating Points (OPPv2)"
+msgstr ""
+
+#: modules/devices/gpu.c:229
+msgid "Device Tree Node"
+msgstr ""
+
+#: modules/devices/gpu.c:232 modules/devices/monitors.c:471
+#: modules/network/net.c:454
+msgid "Status"
+msgstr "Etats"
+
+#: modules/devices/gpu.c:249
 msgid "GPUs"
+msgstr ""
+
+#: modules/devices/gpu.c:273
+msgid "No GPU devices found"
 msgstr ""
 
 #: modules/devices/ia64/processor.c:108
@@ -2423,16 +3259,16 @@ msgstr ""
 msgid "Features"
 msgstr "Caractéristiques"
 
-#: modules/devices/inputdevices.c:118 modules/devices/pci.c:121
-#: modules/devices/usb.c:71
+#: modules/devices/inputdevices.c:113 modules/devices/pci.c:139
+#: modules/devices/usb.c:180
 msgid "Bus"
 msgstr ""
 
-#: modules/devices/inputdevices.c:124
+#: modules/devices/inputdevices.c:119
 msgid "Connected to"
 msgstr "Connecté à"
 
-#: modules/devices/inputdevices.c:128
+#: modules/devices/inputdevices.c:123
 msgid "InfraRed port"
 msgstr "Port infrarouge"
 
@@ -2452,13 +3288,157 @@ msgstr "Calibrage"
 msgid "System Type"
 msgstr "Type de système"
 
+#: modules/devices/monitors.c:29 modules/devices/monitors.c:253
+#: modules/devices/monitors.c:346 modules/devices/spd-decode.c:595
+msgid "(Unspecified)"
+msgstr ""
+
+#: modules/devices/monitors.c:228
+#, c-format
+msgid "Week %d of %d"
+msgstr ""
+
+#: modules/devices/monitors.c:238
+msgid "Ok"
+msgstr ""
+
+#: modules/devices/monitors.c:238
+msgid "Fail"
+msgstr ""
+
+#: modules/devices/monitors.c:266 modules/devices/monitors.c:274
+#: modules/devices/monitors.c:282 modules/devices/monitors.c:293
+#: modules/devices/monitors.c:301 modules/devices/monitors.c:308
+#: modules/devices/monitors.c:316 modules/devices/monitors.c:324
+#: modules/devices/monitors.c:332 modules/devices/monitors.c:338
+msgid "(Empty List)"
+msgstr ""
+
+#: modules/devices/monitors.c:390
+msgid "Signal Type"
+msgstr ""
+
+#: modules/devices/monitors.c:390
+msgid "Digital"
+msgstr ""
+
+#: modules/devices/monitors.c:390
+msgid "Analog"
+msgstr ""
+
+#: modules/devices/monitors.c:391 modules/devices/usb.c:132
+#: modules/network.c:310 modules/network.c:363 modules/network.c:380
+msgid "Interface"
+msgstr ""
+
+#: modules/devices/monitors.c:392
+msgid "Bits per Color Channel"
+msgstr ""
+
+#: modules/devices/monitors.c:393
+msgid "Speaker Allocation"
+msgstr ""
+
+#: modules/devices/monitors.c:394
+msgid "Output (Max)"
+msgstr ""
+
+#: modules/devices/monitors.c:397
+msgid "EDID Device"
+msgstr ""
+
+#: modules/devices/monitors.c:401
+msgid "Serial"
+msgstr ""
+
+#: modules/devices/monitors.c:402
+msgid "Manufacture Date"
+msgstr ""
+
+#: modules/devices/monitors.c:403
+msgid "EDID Meta"
+msgstr ""
+
+#: modules/devices/monitors.c:404
+msgid "Data Size"
+msgstr ""
+
+#: modules/devices/monitors.c:404
+msgid "bytes"
+msgstr ""
+
+#: modules/devices/monitors.c:406
+msgid "Extension Blocks"
+msgstr ""
+
+#: modules/devices/monitors.c:407
+msgid "Extended to"
+msgstr ""
+
+#: modules/devices/monitors.c:408
+msgid "Checksum"
+msgstr ""
+
+#: modules/devices/monitors.c:409
+msgid "EDID Descriptors"
+msgstr ""
+
+#: modules/devices/monitors.c:410
+msgid "Detailed Timing Descriptors (DTD)"
+msgstr ""
+
+#: modules/devices/monitors.c:411
+msgid "Established Timings Bitmap (ETB)"
+msgstr ""
+
+#: modules/devices/monitors.c:412
+msgid "Standard Timings (STD)"
+msgstr ""
+
+#: modules/devices/monitors.c:413
+msgid "E-EDID Extension Blocks"
+msgstr ""
+
+#: modules/devices/monitors.c:414
+msgid "EIA/CEA-861 Data Blocks"
+msgstr ""
+
+#: modules/devices/monitors.c:415
+msgid "EIA/CEA-861 Short Audio Descriptors"
+msgstr ""
+
+#: modules/devices/monitors.c:416
+msgid "EIA/CEA-861 Short Video Descriptors"
+msgstr ""
+
+#: modules/devices/monitors.c:417
+msgid "DisplayID Timings"
+msgstr ""
+
+#: modules/devices/monitors.c:418
+msgid "DisplayID Strings"
+msgstr ""
+
+#: modules/devices/monitors.c:419
+msgid "Hex Dump"
+msgstr ""
+
+#: modules/devices/monitors.c:419
+msgid "Data"
+msgstr ""
+
+#: modules/devices/monitors.c:469 modules/devices/monitors.c:501
+#: modules/devices/pci.c:137 modules/devices/usb.c:179
+msgid "Connection"
+msgstr ""
+
+#: modules/devices/monitors.c:470
+msgid "DRM"
+msgstr ""
+
 #: modules/devices/parisc/processor.c:107
 msgid "PA-RISC Processor"
 msgstr ""
-
-#: modules/devices/parisc/processor.c:157
-msgid "System"
-msgstr "Système"
 
 #: modules/devices/parisc/processor.c:161
 msgid "HVersion"
@@ -2468,31 +3448,23 @@ msgstr ""
 msgid "SVersion"
 msgstr ""
 
-#: modules/devices/parisc/processor.c:163 modules/devices/x86/processor.c:660
-msgid "Cache"
-msgstr ""
-
-#: modules/devices/pci.c:91
+#: modules/devices/pci.c:109
 msgid "Link Width"
 msgstr ""
 
-#: modules/devices/pci.c:93
+#: modules/devices/pci.c:111
 msgid "Link Speed"
 msgstr ""
 
-#: modules/devices/pci.c:119 modules/devices/usb.c:70
-msgid "Connection"
-msgstr ""
-
-#: modules/devices/pci.c:120
+#: modules/devices/pci.c:138
 msgid "Domain"
 msgstr "Domaine"
 
-#: modules/devices/pci.c:123
+#: modules/devices/pci.c:141
 msgid "Function"
 msgstr "Fonction"
 
-#: modules/devices/pci.c:161
+#: modules/devices/pci.c:185
 msgid "No PCI devices found"
 msgstr "Aucun matériel PCI trouvé"
 
@@ -2700,26 +3672,416 @@ msgstr "Fréquence BUS"
 msgid "Module Frequency"
 msgstr "Fréquence Modules"
 
-#: modules/devices/spd-decode.c:1475
+#: modules/devices/spd-decode.c:306
+msgid "Row address bits"
+msgstr ""
+
+#: modules/devices/spd-decode.c:307
+msgid "Column address bits"
+msgstr ""
+
+#: modules/devices/spd-decode.c:308
+msgid "Number of rows"
+msgstr ""
+
+#: modules/devices/spd-decode.c:309
+msgid "Data width"
+msgstr ""
+
+#: modules/devices/spd-decode.c:310
+msgid "Interface signal levels"
+msgstr ""
+
+#: modules/devices/spd-decode.c:311
+msgid "Configuration type"
+msgstr ""
+
+#: modules/devices/spd-decode.c:312
+msgid "Refresh"
+msgstr ""
+
+#: modules/devices/spd-decode.c:313 modules/devices/spd-decode.c:397
+#: modules/devices/spd-decode.c:492 modules/devices/spd-decode.c:617
+msgid "Timings"
+msgstr ""
+
+#: modules/devices/spd-decode.c:593
+msgid "Ranks"
+msgstr ""
+
+#: modules/devices/spd-decode.c:594
+msgid "IO Pins per Chip"
+msgstr ""
+
+#: modules/devices/spd-decode.c:595
+msgid "Die count"
+msgstr ""
+
+#: modules/devices/spd-decode.c:596
+msgid "Thermal Sensor"
+msgstr ""
+
+#: modules/devices/spd-decode.c:596
+msgid "Present"
+msgstr ""
+
+#: modules/devices/spd-decode.c:596
+msgid "Not present"
+msgstr ""
+
+#: modules/devices/spd-decode.c:597
+msgid "Supported Voltages"
+msgstr ""
+
+#: modules/devices/spd-decode.c:601
+msgid "Supported CAS Latencies"
+msgstr ""
+
+#: modules/devices/spd-decode.c:638
+msgid "Invalid"
+msgstr ""
+
+#: modules/devices/spd-decode.c:870
+msgid "XMP Profile"
+msgstr ""
+
+#: modules/devices/spd-decode.c:871 modules/devices/usb.c:173
+msgid "Speed"
+msgstr ""
+
+#: modules/devices/spd-decode.c:872 modules/devices/spd-decode.c:914
+#: modules/devices/x86/processor.c:715
+msgid "Voltage"
+msgstr ""
+
+#: modules/devices/spd-decode.c:873
+msgid "XMP Timings"
+msgstr ""
+
+#: modules/devices/spd-decode.c:915
+msgid "XMP"
+msgstr ""
+
+#: modules/devices/spd-decode.c:916
+msgid "JEDEC Timings"
+msgstr ""
+
+#: modules/devices/storage.c:84
+msgid "Read Error Rate"
+msgstr ""
+
+#: modules/devices/storage.c:85
+msgid "Throughput Performance"
+msgstr ""
+
+#: modules/devices/storage.c:86
+msgid "Spin-Up Time"
+msgstr ""
+
+#: modules/devices/storage.c:87
+msgid "Start/Stop Count"
+msgstr ""
+
+#: modules/devices/storage.c:88
+msgid "Reallocated Sector Count"
+msgstr ""
+
+#: modules/devices/storage.c:89
+msgid "Read Channel Margin"
+msgstr ""
+
+#: modules/devices/storage.c:90
+msgid "Seek Error Rate"
+msgstr ""
+
+#: modules/devices/storage.c:91
+msgid "Seek Timer Performance"
+msgstr ""
+
+#: modules/devices/storage.c:92 modules/devices/storage.c:131
+msgid "Power-On Hours"
+msgstr ""
+
+#: modules/devices/storage.c:93
+msgid "Spin Retry Count"
+msgstr ""
+
+#: modules/devices/storage.c:94
+msgid "Calibration Retry Count"
+msgstr ""
+
+#: modules/devices/storage.c:95
+msgid "Power Cycle Count"
+msgstr ""
+
+#: modules/devices/storage.c:96 modules/devices/storage.c:113
+msgid "Soft Read Error Rate"
+msgstr ""
+
+#: modules/devices/storage.c:97
+msgid "Runtime Bad Block"
+msgstr ""
+
+#: modules/devices/storage.c:98
+msgid "End-to-End error"
+msgstr ""
+
+#: modules/devices/storage.c:99
+msgid "Reported Uncorrectable Errors"
+msgstr ""
+
+#: modules/devices/storage.c:100
+msgid "Command Timeout"
+msgstr ""
+
+#: modules/devices/storage.c:101
+msgid "High Fly Writes"
+msgstr ""
+
+#: modules/devices/storage.c:102
+msgid "Airflow Temperature"
+msgstr ""
+
+#: modules/devices/storage.c:103
+msgid "G-sense Error Rate"
+msgstr ""
+
+#: modules/devices/storage.c:104
+msgid "Power-off Retract Count"
+msgstr ""
+
+#: modules/devices/storage.c:105
+msgid "Load Cycle Count"
+msgstr ""
+
+#: modules/devices/storage.c:106 modules/devices/storage.c:129
+msgid "Temperature"
+msgstr ""
+
+#: modules/devices/storage.c:107
+msgid "Hardware ECC Recovered"
+msgstr ""
+
+#: modules/devices/storage.c:108
+msgid "Reallocation Event Count"
+msgstr ""
+
+#: modules/devices/storage.c:109
+msgid "Current Pending Sector Count"
+msgstr ""
+
+#: modules/devices/storage.c:110
+msgid "Uncorrectable Sector Count"
+msgstr ""
+
+#: modules/devices/storage.c:111
+msgid "UltraDMA CRC Error Count"
+msgstr ""
+
+#: modules/devices/storage.c:112
+msgid "Multi-Zone Error Rate"
+msgstr ""
+
+#: modules/devices/storage.c:114
+msgid "Run Out Cancel"
+msgstr ""
+
+#: modules/devices/storage.c:115
+msgid "Flying Height"
+msgstr ""
+
+#: modules/devices/storage.c:116
+msgid "Spin High Current"
+msgstr ""
+
+#: modules/devices/storage.c:117
+msgid "Spin Buzz"
+msgstr ""
+
+#: modules/devices/storage.c:118
+msgid "Offline Seek Performance"
+msgstr ""
+
+#: modules/devices/storage.c:119
+msgid "Disk Shift"
+msgstr ""
+
+#: modules/devices/storage.c:120
+msgid "G-Sense Error Rate"
+msgstr ""
+
+#: modules/devices/storage.c:121
+msgid "Loaded Hours"
+msgstr ""
+
+#: modules/devices/storage.c:122
+msgid "Load/Unload Retry Count"
+msgstr ""
+
+#: modules/devices/storage.c:123
+msgid "Load Friction"
+msgstr ""
+
+#: modules/devices/storage.c:124
+msgid "Load/Unload Cycle Count"
+msgstr ""
+
+#: modules/devices/storage.c:125
+msgid "Load-in time"
+msgstr ""
+
+#: modules/devices/storage.c:126
+msgid "Torque Amplification Count"
+msgstr ""
+
+#: modules/devices/storage.c:127
+msgid "Power-Off Retract Count"
+msgstr ""
+
+#: modules/devices/storage.c:128
+msgid "GMR Head Amplitude"
+msgstr ""
+
+#: modules/devices/storage.c:130
+msgid "Endurance Remaining"
+msgstr ""
+
+#: modules/devices/storage.c:132
+msgid "Good Block Rate"
+msgstr ""
+
+#: modules/devices/storage.c:133
+msgid "Head Flying Hours"
+msgstr ""
+
+#: modules/devices/storage.c:134
+msgid "Read Error Retry Rate"
+msgstr ""
+
+#: modules/devices/storage.c:135
+msgid "Total LBAs Written"
+msgstr ""
+
+#: modules/devices/storage.c:136
+msgid "Total LBAs Read"
+msgstr ""
+
+#: modules/devices/storage.c:141
 msgid ""
-"[SPD]\n"
-"Please load the eeprom module to obtain information about memory SPD=\n"
-"[$ShellParam$]\n"
-"ReloadInterval=500\n"
-msgstr ""
-"[SPD]\n"
-"Télécharger le module eeprom pour avoir les informations de mémoire SPD=\n"
-"[$ShellParam$]\n"
-
-#: modules/devices/spd-decode.c:1509
-msgid "SPD"
+"\n"
+"[UDisks2]\n"
 msgstr ""
 
-#: modules/devices/spd-decode.c:1510
-msgid "Bank"
+#: modules/devices/storage.c:199
+msgid "Removable"
 msgstr ""
 
-#: modules/devices/storage.c:43
+#: modules/devices/storage.c:199
+msgid "Fixed"
+msgstr ""
+
+#: modules/devices/storage.c:202
+msgid "Ejectable"
+msgstr ""
+
+#: modules/devices/storage.c:205
+msgid "Self-monitoring (S.M.A.R.T.)"
+msgstr ""
+
+#: modules/devices/storage.c:208 modules/devices/x86/processor.c:663
+msgid "Power Management"
+msgstr ""
+
+#: modules/devices/storage.c:211
+msgid "Advanced Power Management"
+msgstr ""
+
+#: modules/devices/storage.c:214
+msgid "Automatic Acoustic Management"
+msgstr ""
+
+#: modules/devices/storage.c:217
+#, c-format
+msgid ""
+"[Drive Information]\n"
+"Model=%s\n"
+msgstr ""
+
+#: modules/devices/storage.c:221 modules/devices/storage.c:449
+#: modules/devices/storage.c:648
+#, c-format
+msgid "Vendor=%s\n"
+msgstr "Vendeur=%s\n"
+
+#: modules/devices/storage.c:226
+#, c-format
+msgid ""
+"Revision=%s\n"
+"Block Device=%s\n"
+"Serial=%s\n"
+"Size=%s\n"
+"Features=%s\n"
+msgstr ""
+
+#: modules/devices/storage.c:240
+#, c-format
+msgid "Rotation Rate=%d RPM\n"
+msgstr ""
+
+#: modules/devices/storage.c:243
+#, c-format
+msgid ""
+"Media=%s\n"
+"Media compatibility=%s\n"
+msgstr ""
+
+#: modules/devices/storage.c:250
+#, c-format
+msgid "Connection bus=%s\n"
+msgstr ""
+
+#: modules/devices/storage.c:253
+#, c-format
+msgid ""
+"[Self-monitoring (S.M.A.R.T.)]\n"
+"Status=%s\n"
+"Bad Sectors=%ld\n"
+"Power on time=%d days %d hours\n"
+"Temperature=%d°C\n"
+msgstr ""
+
+#: modules/devices/storage.c:259
+msgid "Failing"
+msgstr ""
+
+#: modules/devices/storage.c:259
+msgid "OK"
+msgstr ""
+
+#: modules/devices/storage.c:265
+msgid ""
+"[S.M.A.R.T. Attributes]\n"
+"Attribute=Normalized Value / Worst / Threshold\n"
+msgstr ""
+
+#: modules/devices/storage.c:297
+#, c-format
+msgid "(%d) %s=%s\n"
+msgstr ""
+
+#: modules/devices/storage.c:306
+#, c-format
+msgid ""
+"[Partition table]\n"
+"Type=%s\n"
+msgstr ""
+
+#: modules/devices/storage.c:325
+#, c-format
+msgid "Partition %s=%s\n"
+msgstr ""
+
+#: modules/devices/storage.c:375
 msgid ""
 "\n"
 "[SCSI Disks]\n"
@@ -2727,7 +4089,7 @@ msgstr ""
 "\n"
 "[Disques SCSI]\n"
 
-#: modules/devices/storage.c:114 modules/devices/storage.c:320
+#: modules/devices/storage.c:446 modules/devices/storage.c:645
 #, c-format
 msgid ""
 "[Device Information]\n"
@@ -2736,17 +4098,7 @@ msgstr ""
 "[Informations des périphériques]\n"
 "Modele=%s\n"
 
-#: modules/devices/storage.c:119 modules/devices/storage.c:326
-#, c-format
-msgid "Vendor=%s (%s)\n"
-msgstr "Vendeur=%s (%s)\n"
-
-#: modules/devices/storage.c:124 modules/devices/storage.c:328
-#, c-format
-msgid "Vendor=%s\n"
-msgstr "Vendeur=%s\n"
-
-#: modules/devices/storage.c:129
+#: modules/devices/storage.c:453
 #, c-format
 msgid ""
 "Type=%s\n"
@@ -2765,7 +4117,7 @@ msgstr ""
 "ID=%d\n"
 "LUN=%d\n"
 
-#: modules/devices/storage.c:174
+#: modules/devices/storage.c:499
 msgid ""
 "\n"
 "[IDE Disks]\n"
@@ -2773,12 +4125,12 @@ msgstr ""
 "\n"
 "[Disques IDE]\n"
 
-#: modules/devices/storage.c:257
+#: modules/devices/storage.c:582
 #, c-format
 msgid "Driver=%s\n"
 msgstr "Driver=%s\n"
 
-#: modules/devices/storage.c:331
+#: modules/devices/storage.c:650
 #, c-format
 msgid ""
 "Device Name=hd%c\n"
@@ -2789,7 +4141,7 @@ msgstr ""
 "Media=%s\n"
 "Cache=%dkb\n"
 
-#: modules/devices/storage.c:341
+#: modules/devices/storage.c:660
 #, c-format
 msgid ""
 "[Geometry]\n"
@@ -2800,7 +4152,7 @@ msgstr ""
 "Physique=%s\n"
 "Logique=%s\n"
 
-#: modules/devices/storage.c:351
+#: modules/devices/storage.c:670
 #, c-format
 msgid ""
 "[Capabilities]\n"
@@ -2809,7 +4161,7 @@ msgstr ""
 "[Capacités]\n"
 "%s"
 
-#: modules/devices/storage.c:358
+#: modules/devices/storage.c:677
 #, c-format
 msgid ""
 "[Speeds]\n"
@@ -2818,27 +4170,35 @@ msgstr ""
 "[Vitesses]\n"
 "%s"
 
-#: modules/devices/usb.c:65
-msgid "Max Current"
-msgstr ""
-
-#: modules/devices/usb.c:65
-msgid "mA"
-msgstr ""
-
-#: modules/devices/usb.c:66
-msgid "USB Version"
-msgstr ""
-
-#: modules/devices/usb.c:68
+#: modules/devices/usb.c:134 modules/devices/usb.c:175
 msgid "Sub-class"
 msgstr ""
 
-#: modules/devices/usb.c:69
+#: modules/devices/usb.c:135 modules/devices/usb.c:176 modules/network.c:347
+msgid "Protocol"
+msgstr ""
+
+#: modules/devices/usb.c:143 modules/network/net.c:451
+msgid "Mb/s"
+msgstr ""
+
+#: modules/devices/usb.c:171
+msgid "Max Current"
+msgstr ""
+
+#: modules/devices/usb.c:171
+msgid "mA"
+msgstr ""
+
+#: modules/devices/usb.c:172
+msgid "USB Version"
+msgstr ""
+
+#: modules/devices/usb.c:177
 msgid "Device Version"
 msgstr "Version du périphériques"
 
-#: modules/devices/usb.c:103
+#: modules/devices/usb.c:221
 msgid "No USB devices found."
 msgstr "Aucun périphérique USB trouvé"
 
@@ -2878,47 +4238,59 @@ msgstr ""
 msgid "Level %d (%s)#%d=%dx %dKB (%dKB), %d-way set-associative, %d sets\n"
 msgstr ""
 
-#: modules/devices/x86/processor.c:645
+#: modules/devices/x86/processor.c:647
 msgid "Model Name"
 msgstr "Nom du modèle"
 
-#: modules/devices/x86/processor.c:646
+#: modules/devices/x86/processor.c:648
 msgid "Family, model, stepping"
 msgstr "Famille, modèle, stepping"
 
-#: modules/devices/x86/processor.c:652
+#: modules/devices/x86/processor.c:654
 msgid "Microcode Version"
 msgstr ""
 
-#: modules/devices/x86/processor.c:653
+#: modules/devices/x86/processor.c:655
 msgid "Configuration"
 msgstr ""
 
-#: modules/devices/x86/processor.c:654
+#: modules/devices/x86/processor.c:656
 msgid "Cache Size"
 msgstr "Taille du Cache"
 
-#: modules/devices/x86/processor.c:654
+#: modules/devices/x86/processor.c:656
 msgid "kb"
 msgstr ""
 
-#: modules/devices/x86/processor.c:661
-msgid "Power Management"
-msgstr ""
-
-#: modules/devices/x86/processor.c:662
+#: modules/devices/x86/processor.c:664
 msgid "Bug Workarounds"
 msgstr ""
 
-#: modules/devices/x86/processor.c:695 modules/devices/x86/processor.c:715
+#: modules/devices/x86/processor.c:691
+msgid "Socket Information"
+msgstr ""
+
+#: modules/devices/x86/processor.c:712
+msgid "CPU Socket"
+msgstr ""
+
+#: modules/devices/x86/processor.c:716
+msgid "External Clock"
+msgstr ""
+
+#: modules/devices/x86/processor.c:717
+msgid "Max Frequency"
+msgstr ""
+
+#: modules/devices/x86/processor.c:748 modules/devices/x86/processor.c:769
 msgid "Package Information"
 msgstr ""
 
-#: modules/devices/x86/processor.c:742
+#: modules/devices/x86/processor.c:796
 msgid "Socket:Core"
 msgstr ""
 
-#: modules/devices/x86/processor.c:742
+#: modules/devices/x86/processor.c:796
 msgid "Thread"
 msgstr ""
 
@@ -3099,8 +4471,9 @@ msgid ""
 "Intel Itanium Architecture 64-bit (not to be confused with Intel's 64-bit "
 "x86 architecture with flag x86-64 or \"AMD64\" bit indicated by flag lm)"
 msgstr ""
-"Intel Itanium Architecture 64-bit (à ne pas confondre avec le 64-bit d'Intel) "
-"Architecture x86 avec drapeau x86-64 ou \"AMD64\" bit indiqué par drapeau lm)"
+"Intel Itanium Architecture 64-bit (à ne pas confondre avec le 64-bit "
+"d'Intel) Architecture x86 avec drapeau x86-64 ou \"AMD64\" bit indiqué par "
+"drapeau lm)"
 
 #. /flag:pbe
 #: modules/devices/x86/x86_data.c:72
@@ -3459,8 +4832,8 @@ msgid ""
 "Return the Count of Number of Bits Set to 1 instruction (Hamming weight, i."
 "e. bit count)"
 msgstr ""
-"Retourne le nombre de bits réglé à 1 instruction (poids de Hamming, i."
-"e. nombre de bits)"
+"Retourne le nombre de bits réglé à 1 instruction (poids de Hamming, i.e. "
+"nombre de bits)"
 
 #. /flag:tsc_deadline_timer
 #: modules/devices/x86/x86_data.c:137
@@ -3478,7 +4851,8 @@ msgstr "Norme de chriffrement avancée (nouvelles instructions)"
 #: modules/devices/x86/x86_data.c:139
 msgctxt "x86-flag"
 msgid "Save Processor Extended States: also provides XGETBY,XRSTOR,XSETBY"
-msgstr "Save Processor Extended States : fournit également XGETBY,XRSTOR,XSETBY"
+msgstr ""
+"Save Processor Extended States : fournit également XGETBY,XRSTOR,XSETBY"
 
 #. /flag:avx
 #: modules/devices/x86/x86_data.c:140
@@ -3496,7 +4870,9 @@ msgstr ""
 #: modules/devices/x86/x86_data.c:142
 msgctxt "x86-flag"
 msgid "Read Random Number from hardware random number generator instruction"
-msgstr "Lecture d'un nombre aléatoire à partir de l'instruction du générateur de nombres aléatoires matériel"
+msgstr ""
+"Lecture d'un nombre aléatoire à partir de l'instruction du générateur de "
+"nombres aléatoires matériel"
 
 #. /flag:hypervisor
 #: modules/devices/x86/x86_data.c:143
@@ -3615,9 +4991,9 @@ msgid ""
 "legacy SSE instructions operate on unaligned data. Also depends on CR0 and "
 "Alignment Checking bit"
 msgstr ""
-"indique si une exception de protection générale (#GP) est générée"
-"lorsque certaines instructions SSE héritées fonctionnent sur des données non alignées."
-"Dépend aussi de CR0 et contrôle d'alignement des octets"
+"indique si une exception de protection générale (#GP) est généréelorsque "
+"certaines instructions SSE héritées fonctionnent sur des données non "
+"alignées.Dépend aussi de CR0 et contrôle d'alignement des octets"
 
 #. /flag:3dnowprefetch
 #: modules/devices/x86/x86_data.c:164
@@ -4265,181 +5641,175 @@ msgctxt "x86-flag"
 msgid "CPU is affected by speculative store bypass attack"
 msgstr ""
 
+#. /bug:l1tf
+#: modules/devices/x86/x86_data.c:286
+msgctxt "x86-flag"
+msgid "CPU is affected by L1 Terminal Fault"
+msgstr ""
+
 #. /x86/kernel/cpu/powerflags.h
 #. /flag:pm:ts
-#: modules/devices/x86/x86_data.c:288
+#: modules/devices/x86/x86_data.c:289
 msgctxt "x86-flag"
 msgid "temperature sensor"
 msgstr ""
 
 #. /flag:pm:fid
-#: modules/devices/x86/x86_data.c:289
+#: modules/devices/x86/x86_data.c:290
 msgctxt "x86-flag"
 msgid "frequency id control"
 msgstr ""
 
 #. /flag:pm:vid
-#: modules/devices/x86/x86_data.c:290
+#: modules/devices/x86/x86_data.c:291
 msgctxt "x86-flag"
 msgid "voltage id control"
 msgstr ""
 
 #. /flag:pm:ttp
-#: modules/devices/x86/x86_data.c:291
+#: modules/devices/x86/x86_data.c:292
 msgctxt "x86-flag"
 msgid "thermal trip"
 msgstr ""
 
 #. /flag:pm:tm
-#: modules/devices/x86/x86_data.c:292
+#: modules/devices/x86/x86_data.c:293
 msgctxt "x86-flag"
 msgid "hardware thermal control"
 msgstr ""
 
 #. /flag:pm:stc
-#: modules/devices/x86/x86_data.c:293
+#: modules/devices/x86/x86_data.c:294
 msgctxt "x86-flag"
 msgid "software thermal control"
 msgstr ""
 
 #. /flag:pm:100mhzsteps
-#: modules/devices/x86/x86_data.c:294
+#: modules/devices/x86/x86_data.c:295
 msgctxt "x86-flag"
 msgid "100 MHz multiplier control"
 msgstr ""
 
 #. /flag:pm:hwpstate
-#: modules/devices/x86/x86_data.c:295
+#: modules/devices/x86/x86_data.c:296
 msgctxt "x86-flag"
 msgid "hardware P-state control"
 msgstr ""
 
 #. /flag:pm:cpb
-#: modules/devices/x86/x86_data.c:296
+#: modules/devices/x86/x86_data.c:297
 msgctxt "x86-flag"
 msgid "core performance boost"
 msgstr ""
 
 #. /flag:pm:eff_freq_ro
-#: modules/devices/x86/x86_data.c:297
+#: modules/devices/x86/x86_data.c:298
 msgctxt "x86-flag"
 msgid "Readonly aperf/mperf"
 msgstr ""
 
 #. /flag:pm:proc_feedback
-#: modules/devices/x86/x86_data.c:298
+#: modules/devices/x86/x86_data.c:299
 msgctxt "x86-flag"
 msgid "processor feedback interface"
 msgstr ""
 
 #. /flag:pm:acc_power
-#: modules/devices/x86/x86_data.c:299
+#: modules/devices/x86/x86_data.c:300
 msgctxt "x86-flag"
 msgid "accumulated power mechanism"
 msgstr ""
 
-#: modules/network.c:59
+#: modules/network.c:61
 msgid "Interfaces"
 msgstr "Interfaces"
 
-#: modules/network.c:60
+#: modules/network.c:62
 msgid "IP Connections"
 msgstr "Connections IP"
 
-#: modules/network.c:61
+#: modules/network.c:63
 msgid "Routing Table"
 msgstr "Table de Routage"
 
-#: modules/network.c:62 modules/network.c:303
+#: modules/network.c:64 modules/network.c:309
 msgid "ARP Table"
 msgstr "Table ARP"
 
-#: modules/network.c:63
+#: modules/network.c:65
 msgid "DNS Servers"
 msgstr "Serveurs DNS"
 
-#: modules/network.c:64
+#: modules/network.c:66
 msgid "Statistics"
 msgstr "Statistiques"
 
-#: modules/network.c:65
+#: modules/network.c:67
 msgid "Shared Directories"
 msgstr "Dossiers d'interopérabilités"
 
-#: modules/network.c:304 modules/network.c:326 modules/network.c:357
+#: modules/network.c:310 modules/network.c:332 modules/network.c:363
 #: modules/network/net.c:472
 msgid "IP Address"
 msgstr "Addresse IP"
 
-#: modules/network.c:304 modules/network.c:357 modules/network.c:374
-msgid "Interface"
-msgstr ""
-
-#: modules/network.c:304
+#: modules/network.c:310
 msgid "MAC Address"
 msgstr "Adresse MAC"
 
-#: modules/network.c:313
+#: modules/network.c:319
 msgid "SAMBA"
 msgstr ""
 
-#: modules/network.c:314
+#: modules/network.c:320
 msgid "NFS"
 msgstr ""
 
-#: modules/network.c:325
+#: modules/network.c:331
 msgid "Name Servers"
 msgstr "Nom des Serveurs"
 
-#: modules/network.c:340
+#: modules/network.c:346
 msgid "Connections"
 msgstr ""
 
-#: modules/network.c:341
+#: modules/network.c:347
 msgid "Local Address"
 msgstr "Adresse Locale"
 
-#: modules/network.c:341
-msgid "Protocol"
-msgstr ""
-
-#: modules/network.c:341
+#: modules/network.c:347
 msgid "Foreign Address"
 msgstr ""
 
-#: modules/network.c:341
+#: modules/network.c:347
 msgid "State"
 msgstr "Etat"
 
-#: modules/network.c:357
+#: modules/network.c:363
 msgid "Sent"
 msgstr "Envoyé"
 
-#: modules/network.c:357
+#: modules/network.c:363
 msgid "Received"
 msgstr "Reçue"
 
-#: modules/network.c:373
+#: modules/network.c:379
 msgid "IP routing table"
 msgstr ""
 
-#: modules/network.c:374
+#: modules/network.c:380
 msgid "Destination/Gateway"
 msgstr ""
 
-#: modules/network.c:374
-msgid "Flags"
-msgstr ""
-
-#: modules/network.c:374 modules/network/net.c:473
+#: modules/network.c:380 modules/network/net.c:473
 msgid "Mask"
 msgstr ""
 
-#: modules/network.c:402
+#: modules/network.c:408
 msgid "Network"
 msgstr "Réseau"
 
-#: modules/network.c:435
+#: modules/network.c:441
 msgid "Gathers information about this computer's network connection"
 msgstr "Collecte des informations sur les connexions réseau de cet ordinateur"
 
@@ -4609,11 +5979,6 @@ msgstr "Interfaces Réseau"
 msgid "None Found"
 msgstr "Non Trouvé"
 
-#: modules/network/net.c:395 modules/network/net.c:417
-#: modules/network/net.c:418
-msgid "MiB"
-msgstr ""
-
 #: modules/network/net.c:409
 msgid "Network Adapter Properties"
 msgstr ""
@@ -4663,17 +6028,9 @@ msgstr "Nom du Réseau (SSID)"
 msgid "Bit Rate"
 msgstr ""
 
-#: modules/network/net.c:451
-msgid "Mb/s"
-msgstr ""
-
 #: modules/network/net.c:452
 msgid "Transmission Power"
 msgstr ""
-
-#: modules/network/net.c:454
-msgid "Status"
-msgstr "Etats"
 
 #: modules/network/net.c:455
 msgid "Link Quality"
@@ -4696,6 +6053,40 @@ msgstr "(Aucun)"
 msgid "Broadcast Address"
 msgstr "Adresse Broadcast"
 
+#~ msgid "chooses a report format (text, html)"
+#~ msgstr "choisir un format de rapport (texte, html)"
+
+#~ msgid "Couldn't find a Web browser to open URL %s."
+#~ msgstr "Impossible de trouver un navigateur Web pour ouvrir l'URL %s."
+
+#~ msgid "CPU Blowfish"
+#~ msgstr "Test CPU Blowfish"
+
+#~ msgid "CSharp (Mono, old)"
+#~ msgstr "CSharp (Mono, old)"
+
+#~ msgid "CSharp (Mono)"
+#~ msgstr "CSharp (Mono)"
+
+#~ msgid "DMI"
+#~ msgstr "DMI"
+
+#~ msgid "Memory SPD"
+#~ msgstr "Mémoire SPD"
+
+#~ msgid ""
+#~ "[SPD]\n"
+#~ "Please load the eeprom module to obtain information about memory SPD=\n"
+#~ "[$ShellParam$]\n"
+#~ "ReloadInterval=500\n"
+#~ msgstr ""
+#~ "[SPD]\n"
+#~ "Télécharger le module eeprom pour avoir les informations de mémoire SPD=\n"
+#~ "[$ShellParam$]\n"
+
+#~ msgid "Vendor=%s (%s)\n"
+#~ msgstr "Vendeur=%s (%s)\n"
+
 #~ msgid "Unknown benchmark ``%s'' or libbenchmark.so not loaded"
 #~ msgstr "Benchmark inconnu ``%s'' ou libbenchmark.so non chargé"
 
@@ -4710,6 +6101,3 @@ msgstr "Adresse Broadcast"
 
 #~ msgid " (vendor unknown)"
 #~ msgstr " (Fabricant inconnu)"
-
-#~ msgid "Desktop Environment"
-#~ msgstr "Environnement de bureau"

--- a/po/hardinfo.pot
+++ b/po/hardinfo.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-08-15 02:04-0500\n"
+"POT-Creation-Date: 2019-10-24 15:16-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -114,7 +114,7 @@ msgstr ""
 
 #: hardinfo/dmi_util.c:29 modules/computer.c:529 modules/computer.c:1000
 #: modules/devices/alpha/processor.c:87 modules/devices/arm/processor.c:341
-#: modules/devices.c:96 modules/devices/ia64/processor.c:159
+#: modules/devices.c:99 modules/devices/ia64/processor.c:159
 #: modules/devices/m68k/processor.c:83 modules/devices/mips/processor.c:74
 #: modules/devices/parisc/processor.c:154 modules/devices/ppc/processor.c:157
 #: modules/devices/riscv/processor.c:181 modules/devices/s390/processor.c:131
@@ -486,6 +486,7 @@ msgstr ""
 #: modules/computer/modules.c:149 modules/devices/arm/processor.c:469
 #: modules/devices/dmi.c:37 modules/devices/dmi.c:48 modules/devices/gpu.c:233
 #: modules/devices/ia64/processor.c:160 modules/devices/inputdevices.c:111
+#: modules/devices/monitors.c:399 modules/devices/monitors.c:502
 #: modules/devices/sh/processor.c:84 modules/devices/x86/processor.c:749
 #: modules/network.c:332
 msgid "Name"
@@ -495,7 +496,7 @@ msgstr ""
 #: modules/computer.c:574 modules/computer.c:743 modules/computer/modules.c:151
 #: modules/devices/dmi.c:40 modules/devices/dmi.c:46 modules/devices/dmi.c:50
 #: modules/devices/dmi.c:56 modules/devices/firmware.c:105
-#: modules/devices/inputdevices.c:116
+#: modules/devices/inputdevices.c:116 modules/devices/monitors.c:405
 msgid "Version"
 msgstr ""
 
@@ -509,7 +510,8 @@ msgid "Don't know what to do. Exiting."
 msgstr ""
 
 #: hardinfo/usb_util.c:290 modules/devices/devicetree.c:91
-#: modules/devices/devicetree.c:92 modules/devices/storage.c:185
+#: modules/devices/devicetree.c:92 modules/devices/monitors.c:407
+#: modules/devices/storage.c:246
 msgid "(None)"
 msgstr ""
 
@@ -674,15 +676,15 @@ msgstr ""
 msgid "Scanning: %s..."
 msgstr ""
 
-#: hardinfo/util.c:1040 shell/shell.c:310 shell/shell.c:794 shell/shell.c:1961
+#: hardinfo/util.c:1040 shell/shell.c:310 shell/shell.c:795 shell/shell.c:1962
 #: modules/benchmark.c:583 modules/benchmark.c:591
 msgid "Done."
 msgstr ""
 
-#: hardinfo/vendor.c:437 modules/computer.c:573 modules/computer.c:765
+#: hardinfo/vendor.c:440 modules/computer.c:573 modules/computer.c:765
 #: modules/computer/os.c:79 modules/computer/os.c:263 modules/computer/os.c:300
-#: modules/computer/os.c:499 modules/computer/os.c:569 modules/devices.c:350
-#: modules/devices.c:496 modules/devices/printers.c:99
+#: modules/computer/os.c:499 modules/computer/os.c:569 modules/devices.c:359
+#: modules/devices.c:505 modules/devices/printers.c:99
 #: modules/devices/printers.c:106 modules/devices/printers.c:116
 #: modules/devices/printers.c:131 modules/devices/printers.c:140
 #: modules/devices/printers.c:243 modules/devices/spd-decode.c:312
@@ -862,65 +864,65 @@ msgstr ""
 msgid "_Toolbar"
 msgstr ""
 
-#: shell/report.c:722 shell/report.c:730
+#: shell/report.c:769 shell/report.c:777
 msgid "Save File"
 msgstr ""
 
-#: shell/report.c:725 shell/report.c:1196 shell/syncmanager.c:748
+#: shell/report.c:772 shell/report.c:1243 shell/syncmanager.c:748
 msgid "_Cancel"
 msgstr ""
 
-#: shell/report.c:727
+#: shell/report.c:774
 msgid "_Save"
 msgstr ""
 
-#: shell/report.c:896
+#: shell/report.c:943
 msgid "Cannot create ReportContext. Programming bug?"
 msgstr ""
 
-#: shell/report.c:915
+#: shell/report.c:962
 msgid "Open the report with your web browser?"
 msgstr ""
 
-#: shell/report.c:918
+#: shell/report.c:965
 msgid "_No"
 msgstr ""
 
-#: shell/report.c:919
+#: shell/report.c:966
 msgid "_Open"
 msgstr ""
 
-#: shell/report.c:949
+#: shell/report.c:996
 msgid "Generating report..."
 msgstr ""
 
-#: shell/report.c:959
+#: shell/report.c:1006
 msgid "Report saved."
 msgstr ""
 
-#: shell/report.c:961
+#: shell/report.c:1008
 msgid "Error while creating the report."
 msgstr ""
 
-#: shell/report.c:1063
+#: shell/report.c:1110
 msgid "Generate Report"
 msgstr ""
 
-#: shell/report.c:1088
+#: shell/report.c:1135
 msgid ""
 "<big><b>Generate Report</b></big>\n"
 "Please choose the information that you wish to view in your report:"
 msgstr ""
 
-#: shell/report.c:1160
+#: shell/report.c:1207
 msgid "Select _None"
 msgstr ""
 
-#: shell/report.c:1171
+#: shell/report.c:1218
 msgid "Select _All"
 msgstr ""
 
-#: shell/report.c:1206
+#: shell/report.c:1253
 msgid "_Generate"
 msgstr ""
 
@@ -933,16 +935,16 @@ msgstr ""
 msgid "System Information"
 msgstr ""
 
-#: shell/shell.c:781
+#: shell/shell.c:782
 msgid "Loading modules..."
 msgstr ""
 
-#: shell/shell.c:1827
+#: shell/shell.c:1828
 #, c-format
 msgid "<b>%s → Summary</b>"
 msgstr ""
 
-#: shell/shell.c:1935
+#: shell/shell.c:1936
 msgid "Updating..."
 msgstr ""
 
@@ -1065,15 +1067,15 @@ msgid "SysBench CPU (Multi-thread)"
 msgstr ""
 
 #: modules/benchmark/benches.c:104
-msgid "#SysBench CPU (Four threads)"
+msgid "SysBench CPU (Four threads)"
 msgstr ""
 
 #: modules/benchmark/benches.c:106
-msgid "#SysBench Memory (Single-thread)"
+msgid "SysBench Memory (Single-thread)"
 msgstr ""
 
 #: modules/benchmark/benches.c:108
-msgid "#SysBench Memory (Two threads)"
+msgid "SysBench Memory (Two threads)"
 msgstr ""
 
 #: modules/benchmark/benches.c:110
@@ -1124,27 +1126,29 @@ msgstr ""
 #. / Used for an unknown value. Having it in only one place cleans up the .po line references
 #: modules/benchmark/bench_results.c:22 modules/computer.c:41
 #: modules/computer/display.c:41 modules/computer/display.c:58
-#: modules/computer/os.c:286 modules/computer/os.c:346 modules/devices.c:479
+#: modules/computer/os.c:286 modules/computer/os.c:346 modules/devices.c:488
 #: modules/devices/dmi_memory.c:52 modules/devices/dmi_memory.c:53
 #: modules/devices/dmi_memory.c:579 modules/devices/dmi_memory.c:719
 #: modules/devices/dmi_memory.c:855 modules/devices/gpu.c:42
 #: modules/devices/gpu.c:58 modules/devices/gpu.c:112 modules/devices/gpu.c:120
 #: modules/devices/gpu.c:154 modules/devices/gpu.c:155
-#: modules/devices/gpu.c:176 modules/devices/pci.c:25 modules/devices/pci.c:135
-#: modules/devices/pci.c:136 modules/devices/spd-decode.c:306
-#: modules/devices/spd-decode.c:307 modules/devices/spd-decode.c:310
-#: modules/devices/spd-decode.c:311 modules/devices/spd-decode.c:914
-#: modules/devices/spd-decode.c:915 modules/devices/storage.c:186
-#: modules/devices/storage.c:207 modules/devices/usb.c:28
-#: modules/network/net.c:437 includes/cpu_util.h:11
+#: modules/devices/gpu.c:176 modules/devices/monitors.c:27
+#: modules/devices/monitors.c:28 modules/devices/monitors.c:153
+#: modules/devices/monitors.c:162 modules/devices/pci.c:25
+#: modules/devices/pci.c:135 modules/devices/pci.c:136
+#: modules/devices/spd-decode.c:306 modules/devices/spd-decode.c:307
+#: modules/devices/spd-decode.c:310 modules/devices/spd-decode.c:311
+#: modules/devices/spd-decode.c:914 modules/devices/spd-decode.c:915
+#: modules/devices/storage.c:247 modules/devices/storage.c:309
+#: modules/devices/usb.c:28 modules/network/net.c:437 includes/cpu_util.h:11
 msgid "(Unknown)"
 msgstr ""
 
-#: modules/benchmark/bench_results.c:48 modules/benchmark/bench_results.c:326
+#: modules/benchmark/bench_results.c:49 modules/benchmark/bench_results.c:330
 #: modules/devices/alpha/processor.c:90 modules/devices/arm/processor.c:290
 #: modules/devices/arm/processor.c:303 modules/devices/arm/processor.c:345
-#: modules/devices/arm/processor.c:500 modules/devices.c:316
-#: modules/devices.c:324 modules/devices.c:352 modules/devices/gpu.c:115
+#: modules/devices/arm/processor.c:500 modules/devices.c:325
+#: modules/devices.c:333 modules/devices.c:361 modules/devices/gpu.c:115
 #: modules/devices/gpu.c:117 modules/devices/gpu.c:123
 #: modules/devices/gpu.c:125 modules/devices/gpu.c:179
 #: modules/devices/gpu.c:181 modules/devices/ia64/processor.c:167
@@ -1160,123 +1164,121 @@ msgstr ""
 msgid "MHz"
 msgstr ""
 
-#: modules/benchmark/bench_results.c:391 modules/benchmark/bench_results.c:481
+#: modules/benchmark/bench_results.c:396 modules/benchmark/bench_results.c:495
 msgid "kiB"
 msgstr ""
 
-#: modules/benchmark/bench_results.c:413 modules/benchmark/bench_results.c:463
+#: modules/benchmark/bench_results.c:403 modules/benchmark/bench_results.c:453
+#, c-format
+msgid "%d-bit"
+msgstr ""
+
+#: modules/benchmark/bench_results.c:422 modules/benchmark/bench_results.c:477
 msgid "Benchmark Result"
 msgstr ""
 
-#: modules/benchmark/bench_results.c:414 modules/benchmark/bench_results.c:465
+#: modules/benchmark/bench_results.c:423 modules/benchmark/bench_results.c:479
 msgid "Threads"
 msgstr ""
 
-#: modules/benchmark/bench_results.c:415 modules/benchmark/bench_results.c:467
+#: modules/benchmark/bench_results.c:424 modules/benchmark/bench_results.c:481
 msgid "Elapsed Time"
 msgstr ""
 
-#: modules/benchmark/bench_results.c:415 modules/benchmark/bench_results.c:467
+#: modules/benchmark/bench_results.c:424 modules/benchmark/bench_results.c:481
 msgid "seconds"
 msgstr ""
 
-#: modules/benchmark/bench_results.c:416 modules/computer/languages.c:101
+#: modules/benchmark/bench_results.c:425 modules/computer/languages.c:101
 #: modules/devices/arm/processor.c:355 modules/devices/gpu.c:147
 #: modules/devices/ia64/processor.c:166 modules/devices/pci.c:132
 #: modules/devices/ppc/processor.c:159
 msgid "Revision"
 msgstr ""
 
-#: modules/benchmark/bench_results.c:416
-msgid "#Revision"
-msgstr ""
-
-#: modules/benchmark/bench_results.c:417 modules/benchmark/bench_results.c:468
+#: modules/benchmark/bench_results.c:426 modules/benchmark/bench_results.c:482
 msgid "Extra Information"
 msgstr ""
 
-#: modules/benchmark/bench_results.c:417 modules/benchmark/bench_results.c:468
-msgid "#Extra"
-msgstr ""
-
-#: modules/benchmark/bench_results.c:418 modules/benchmark/bench_results.c:469
+#: modules/benchmark/bench_results.c:427 modules/benchmark/bench_results.c:483
 msgid "User Note"
 msgstr ""
 
-#: modules/benchmark/bench_results.c:418 modules/benchmark/bench_results.c:469
-msgid "#User Note"
-msgstr ""
-
-#: modules/benchmark/bench_results.c:420 modules/benchmark/bench_results.c:471
+#: modules/benchmark/bench_results.c:429 modules/benchmark/bench_results.c:485
 msgid "Note"
 msgstr ""
 
-#: modules/benchmark/bench_results.c:421 modules/benchmark/bench_results.c:472
+#: modules/benchmark/bench_results.c:430 modules/benchmark/bench_results.c:486
 msgid ""
 "This result is from an old version of HardInfo. Results might not be "
 "comparable to current version. Some details are missing."
 msgstr ""
 
-#: modules/benchmark/bench_results.c:422 modules/benchmark/bench_results.c:473
+#: modules/benchmark/bench_results.c:431 modules/benchmark/bench_results.c:487
 #: modules/devices/devicetree/pmac_data.c:81 modules/devices/sh/processor.c:85
 msgid "Machine"
 msgstr ""
 
-#: modules/benchmark/bench_results.c:423 modules/benchmark/bench_results.c:474
+#: modules/benchmark/bench_results.c:432 modules/benchmark/bench_results.c:488
 #: modules/devices/devicetree.c:208 modules/devices/dmi.c:47
 msgid "Board"
 msgstr ""
 
-#: modules/benchmark/bench_results.c:424 modules/benchmark/bench_results.c:475
+#: modules/benchmark/bench_results.c:433 modules/benchmark/bench_results.c:489
 msgid "CPU Name"
 msgstr ""
 
-#: modules/benchmark/bench_results.c:425 modules/benchmark/bench_results.c:476
+#: modules/benchmark/bench_results.c:434 modules/benchmark/bench_results.c:490
 msgid "CPU Description"
 msgstr ""
 
-#: modules/benchmark/bench_results.c:426 modules/benchmark/bench_results.c:477
+#: modules/benchmark/bench_results.c:435 modules/benchmark/bench_results.c:491
 #: modules/benchmark.c:442
 msgid "CPU Config"
 msgstr ""
 
-#: modules/benchmark/bench_results.c:427 modules/benchmark/bench_results.c:478
+#: modules/benchmark/bench_results.c:436 modules/benchmark/bench_results.c:492
 msgid "Threads Available"
 msgstr ""
 
-#: modules/benchmark/bench_results.c:428 modules/benchmark/bench_results.c:479
+#: modules/benchmark/bench_results.c:437 modules/benchmark/bench_results.c:493
 msgid "GPU"
 msgstr ""
 
-#: modules/benchmark/bench_results.c:429 modules/benchmark/bench_results.c:480
+#: modules/benchmark/bench_results.c:438 modules/benchmark/bench_results.c:494
 #: modules/computer.c:542
 msgid "OpenGL Renderer"
 msgstr ""
 
-#: modules/benchmark/bench_results.c:430 modules/benchmark/bench_results.c:481
+#: modules/benchmark/bench_results.c:439 modules/benchmark/bench_results.c:495
 #: modules/computer.c:123 modules/computer.c:531 modules/computer.c:1000
 #: modules/devices/gpu.c:150
 msgid "Memory"
 msgstr ""
 
-#: modules/benchmark/bench_results.c:464
+#: modules/benchmark/bench_results.c:440 modules/benchmark/bench_results.c:496
+msgid "Pointer Size"
+msgstr ""
+
+#: modules/benchmark/bench_results.c:478
 msgid "Benchmark"
 msgstr ""
 
-#: modules/benchmark/bench_results.c:466 modules/devices/dmi_memory.c:879
-#: modules/devices/firmware.c:244 modules/devices/x86/processor.c:691
+#: modules/benchmark/bench_results.c:480 modules/devices/dmi_memory.c:879
+#: modules/devices/firmware.c:246 modules/devices/monitors.c:492
+#: modules/devices/x86/processor.c:691
 msgid "Result"
 msgstr ""
 
-#: modules/benchmark/bench_results.c:483
+#: modules/benchmark/bench_results.c:498
 msgid "Handles"
 msgstr ""
 
-#: modules/benchmark/bench_results.c:484
+#: modules/benchmark/bench_results.c:499
 msgid "mid"
 msgstr ""
 
-#: modules/benchmark/bench_results.c:485
+#: modules/benchmark/bench_results.c:500
 msgid "cfg_val"
 msgstr ""
 
@@ -1564,7 +1566,7 @@ msgstr ""
 msgid "Description"
 msgstr ""
 
-#: modules/computer.c:365 modules/devices.c:703
+#: modules/computer.c:365 modules/devices.c:726
 msgid "Value"
 msgstr ""
 
@@ -1629,7 +1631,7 @@ msgstr ""
 msgid "Session Display Server"
 msgstr ""
 
-#: modules/computer.c:548 modules/devices.c:104
+#: modules/computer.c:548 modules/devices.c:108
 msgid "Input Devices"
 msgstr ""
 
@@ -1772,7 +1774,7 @@ msgstr ""
 msgid "Session"
 msgstr ""
 
-#: modules/computer.c:732 modules/devices.c:703 modules/devices/dmi.c:55
+#: modules/computer.c:732 modules/devices.c:726 modules/devices/dmi.c:55
 #: modules/devices/dmi_memory.c:603 modules/devices/dmi_memory.c:749
 #: modules/devices/inputdevices.c:112 modules/devices/x86/processor.c:714
 msgid "Type"
@@ -1793,11 +1795,12 @@ msgstr ""
 #: modules/computer.c:742 modules/computer.c:782 modules/devices/dmi.c:39
 #: modules/devices/dmi.c:45 modules/devices/dmi.c:49 modules/devices/dmi.c:54
 #: modules/devices/dmi_memory.c:750 modules/devices/dmi_memory.c:895
-#: modules/devices/firmware.c:105 modules/devices/firmware.c:167
-#: modules/devices/firmware.c:189 modules/devices/firmware.c:226
+#: modules/devices/firmware.c:105 modules/devices/firmware.c:168
+#: modules/devices/firmware.c:190 modules/devices/firmware.c:228
 #: modules/devices/gpu.c:74 modules/devices/gpu.c:82 modules/devices/gpu.c:224
 #: modules/devices/ia64/processor.c:161 modules/devices/inputdevices.c:114
-#: modules/devices/pci.c:87 modules/devices/pci.c:95 modules/devices/usb.c:168
+#: modules/devices/monitors.c:398 modules/devices/pci.c:87
+#: modules/devices/pci.c:95 modules/devices/usb.c:168
 #: modules/devices/x86/processor.c:653
 msgid "Vendor"
 msgstr ""
@@ -1911,11 +1914,11 @@ msgstr ""
 msgid "Graphics"
 msgstr ""
 
-#: modules/computer.c:1001 modules/devices.c:105
+#: modules/computer.c:1001 modules/devices.c:109
 msgid "Storage"
 msgstr ""
 
-#: modules/computer.c:1001 modules/devices.c:101
+#: modules/computer.c:1001 modules/devices.c:105
 msgid "Printers"
 msgstr ""
 
@@ -2030,7 +2033,7 @@ msgstr ""
 #: modules/computer/modules.c:119 modules/computer/modules.c:120
 #: modules/computer/modules.c:121 modules/computer/modules.c:122
 #: modules/devices/dmi.c:111 modules/devices/dmi_memory.c:881
-#: modules/devices/firmware.c:244 modules/devices/x86/processor.c:693
+#: modules/devices/firmware.c:246 modules/devices/x86/processor.c:693
 msgid "(Not available)"
 msgstr ""
 
@@ -2189,8 +2192,9 @@ msgstr ""
 #: modules/devices/devicetree.c:209 modules/devices/devicetree/pmac_data.c:80
 #: modules/devices/gpu.c:106 modules/devices/ia64/processor.c:165
 #: modules/devices/m68k/processor.c:84 modules/devices/mips/processor.c:75
-#: modules/devices/parisc/processor.c:155 modules/devices/ppc/processor.c:158
-#: modules/devices/riscv/processor.c:182 modules/devices/s390/processor.c:132
+#: modules/devices/monitors.c:400 modules/devices/parisc/processor.c:155
+#: modules/devices/ppc/processor.c:158 modules/devices/riscv/processor.c:182
+#: modules/devices/s390/processor.c:132
 msgid "Model"
 msgstr ""
 
@@ -2518,61 +2522,66 @@ msgid ""
 "No batteries found on this system=\n"
 msgstr ""
 
-#: modules/devices.c:97
+#: modules/devices.c:100
 msgid "Graphics Processors"
 msgstr ""
 
-#: modules/devices.c:98 modules/devices/pci.c:163
+#: modules/devices.c:101 modules/devices/monitors.c:445
+#: modules/devices/monitors.c:492
+msgid "Monitors"
+msgstr ""
+
+#: modules/devices.c:102 modules/devices/pci.c:163
 msgid "PCI Devices"
 msgstr ""
 
-#: modules/devices.c:99 modules/devices/usb.c:210
+#: modules/devices.c:103 modules/devices/usb.c:210
 msgid "USB Devices"
 msgstr ""
 
-#: modules/devices.c:100
+#: modules/devices.c:104
 msgid "Firmware"
 msgstr ""
 
-#: modules/devices.c:102
+#: modules/devices.c:106
 msgid "Battery"
 msgstr ""
 
-#: modules/devices.c:103
+#: modules/devices.c:107
 msgid "Sensors"
 msgstr ""
 
-#: modules/devices.c:106
+#: modules/devices.c:110
 msgid "System DMI"
 msgstr ""
 
-#: modules/devices.c:107
+#: modules/devices.c:111
 msgid "Memory Devices"
 msgstr ""
 
-#: modules/devices.c:111
+#: modules/devices.c:113 modules/devices.c:115
 msgid "Device Tree"
 msgstr ""
 
-#: modules/devices.c:113
+#: modules/devices.c:117
 msgid "Resources"
 msgstr ""
 
-#: modules/devices.c:168
+#: modules/devices.c:177
 #, c-format
 msgid "%d physical processor"
 msgid_plural "%d physical processors"
 msgstr[0] ""
 msgstr[1] ""
 
-#: modules/devices.c:169
+#: modules/devices.c:178
 #, c-format
 msgid "%d core"
 msgid_plural "%d cores"
 msgstr[0] ""
 msgstr[1] ""
 
-#: modules/devices.c:170
+#: modules/devices.c:179
 #, c-format
 msgid "%d thread"
 msgid_plural "%d threads"
@@ -2580,36 +2589,36 @@ msgstr[0] ""
 msgstr[1] ""
 
 #. /NP procs; NC cores; NT threads
-#: modules/devices.c:171
+#: modules/devices.c:180
 #, c-format
 msgid "%s; %s; %s"
 msgstr ""
 
-#: modules/devices.c:703
+#: modules/devices.c:726
 msgid "Sensor"
 msgstr ""
 
-#: modules/devices.c:750 modules/devices/dmi_memory.c:826
+#: modules/devices.c:773 modules/devices/dmi_memory.c:826
 msgid "Devices"
 msgstr ""
 
-#: modules/devices.c:762
+#: modules/devices.c:785
 msgid "Update PCI ID listing"
 msgstr ""
 
-#: modules/devices.c:774
+#: modules/devices.c:797
 msgid "Update CPU feature database"
 msgstr ""
 
-#: modules/devices.c:802
+#: modules/devices.c:825
 msgid "Gathers information about hardware devices"
 msgstr ""
 
-#: modules/devices.c:821
+#: modules/devices.c:844
 msgid "Resource information requires superuser privileges"
 msgstr ""
 
-#: modules/devices.c:827
+#: modules/devices.c:850
 msgid ""
 "Any NVMe storage devices present are not listed.\n"
 "<b><i>udisksd</i></b> is required for NVMe devices."
@@ -2887,6 +2896,7 @@ msgid "Configured Voltage"
 msgstr ""
 
 #: modules/devices/dmi_memory.c:786 modules/devices/dmi_memory.c:793
+#: modules/devices/monitors.c:492
 msgid "(Empty)"
 msgstr ""
 
@@ -3049,11 +3059,11 @@ msgstr ""
 msgid "Created"
 msgstr ""
 
-#: modules/devices/firmware.c:243
+#: modules/devices/firmware.c:245
 msgid "Firmware List"
 msgstr ""
 
-#: modules/devices/firmware.c:256
+#: modules/devices/firmware.c:258
 msgid "Requires the <i><b>fwupdmgr</b></i> utility."
 msgstr ""
 
@@ -3136,7 +3146,8 @@ msgstr ""
 msgid "Device Tree Node"
 msgstr ""
 
-#: modules/devices/gpu.c:232 modules/network/net.c:454
+#: modules/devices/gpu.c:232 modules/devices/monitors.c:471
+#: modules/network/net.c:454
 msgid "Status"
 msgstr ""
 
@@ -3193,6 +3204,154 @@ msgstr ""
 msgid "System Type"
 msgstr ""
 
+#: modules/devices/monitors.c:29 modules/devices/monitors.c:253
+#: modules/devices/monitors.c:346 modules/devices/spd-decode.c:595
+msgid "(Unspecified)"
+msgstr ""
+
+#: modules/devices/monitors.c:228
+#, c-format
+msgid "Week %d of %d"
+msgstr ""
+
+#: modules/devices/monitors.c:238
+msgid "Ok"
+msgstr ""
+
+#: modules/devices/monitors.c:238
+msgid "Fail"
+msgstr ""
+
+#: modules/devices/monitors.c:266 modules/devices/monitors.c:274
+#: modules/devices/monitors.c:282 modules/devices/monitors.c:293
+#: modules/devices/monitors.c:301 modules/devices/monitors.c:308
+#: modules/devices/monitors.c:316 modules/devices/monitors.c:324
+#: modules/devices/monitors.c:332 modules/devices/monitors.c:338
+msgid "(Empty List)"
+msgstr ""
+
+#: modules/devices/monitors.c:390
+msgid "Signal Type"
+msgstr ""
+
+#: modules/devices/monitors.c:390
+msgid "Digital"
+msgstr ""
+
+#: modules/devices/monitors.c:390
+msgid "Analog"
+msgstr ""
+
+#: modules/devices/monitors.c:391 modules/devices/usb.c:132
+#: modules/network.c:310 modules/network.c:363 modules/network.c:380
+msgid "Interface"
+msgstr ""
+
+#: modules/devices/monitors.c:392
+msgid "Bits per Color Channel"
+msgstr ""
+
+#: modules/devices/monitors.c:393
+msgid "Speaker Allocation"
+msgstr ""
+
+#: modules/devices/monitors.c:394
+msgid "Output (Max)"
+msgstr ""
+
+#: modules/devices/monitors.c:397
+msgid "EDID Device"
+msgstr ""
+
+#: modules/devices/monitors.c:401
+msgid "Serial"
+msgstr ""
+
+#: modules/devices/monitors.c:402
+msgid "Manufacture Date"
+msgstr ""
+
+#: modules/devices/monitors.c:403
+msgid "EDID Meta"
+msgstr ""
+
+#: modules/devices/monitors.c:404
+msgid "Data Size"
+msgstr ""
+
+#: modules/devices/monitors.c:404
+msgid "bytes"
+msgstr ""
+
+#: modules/devices/monitors.c:406
+msgid "Extension Blocks"
+msgstr ""
+
+#: modules/devices/monitors.c:407
+msgid "Extended to"
+msgstr ""
+
+#: modules/devices/monitors.c:408
+msgid "Checksum"
+msgstr ""
+
+#: modules/devices/monitors.c:409
+msgid "EDID Descriptors"
+msgstr ""
+
+#: modules/devices/monitors.c:410
+msgid "Detailed Timing Descriptors (DTD)"
+msgstr ""
+
+#: modules/devices/monitors.c:411
+msgid "Established Timings Bitmap (ETB)"
+msgstr ""
+
+#: modules/devices/monitors.c:412
+msgid "Standard Timings (STD)"
+msgstr ""
+
+#: modules/devices/monitors.c:413
+msgid "E-EDID Extension Blocks"
+msgstr ""
+
+#: modules/devices/monitors.c:414
+msgid "EIA/CEA-861 Data Blocks"
+msgstr ""
+
+#: modules/devices/monitors.c:415
+msgid "EIA/CEA-861 Short Audio Descriptors"
+msgstr ""
+
+#: modules/devices/monitors.c:416
+msgid "EIA/CEA-861 Short Video Descriptors"
+msgstr ""
+
+#: modules/devices/monitors.c:417
+msgid "DisplayID Timings"
+msgstr ""
+
+#: modules/devices/monitors.c:418
+msgid "DisplayID Strings"
+msgstr ""
+
+#: modules/devices/monitors.c:419
+msgid "Hex Dump"
+msgstr ""
+
+#: modules/devices/monitors.c:419
+msgid "Data"
+msgstr ""
+
+#: modules/devices/monitors.c:469 modules/devices/monitors.c:501
+#: modules/devices/pci.c:137 modules/devices/usb.c:179
+msgid "Connection"
+msgstr ""
+
+#: modules/devices/monitors.c:470
+msgid "DRM"
+msgstr ""
+
 #: modules/devices/parisc/processor.c:107
 msgid "PA-RISC Processor"
 msgstr ""
@@ -3211,10 +3370,6 @@ msgstr ""
 
 #: modules/devices/pci.c:111
 msgid "Link Speed"
-msgstr ""
-
-#: modules/devices/pci.c:137 modules/devices/usb.c:179
-msgid "Connection"
 msgstr ""
 
 #: modules/devices/pci.c:138
@@ -3474,10 +3629,6 @@ msgstr ""
 msgid "Die count"
 msgstr ""
 
-#: modules/devices/spd-decode.c:595
-msgid "(Unspecified)"
-msgstr ""
-
 #: modules/devices/spd-decode.c:596
 msgid "Thermal Sensor"
 msgstr ""
@@ -3527,54 +3678,254 @@ msgstr ""
 msgid "JEDEC Timings"
 msgstr ""
 
-#: modules/devices/storage.c:80
+#: modules/devices/storage.c:84
+msgid "Read Error Rate"
+msgstr ""
+
+#: modules/devices/storage.c:85
+msgid "Throughput Performance"
+msgstr ""
+
+#: modules/devices/storage.c:86
+msgid "Spin-Up Time"
+msgstr ""
+
+#: modules/devices/storage.c:87
+msgid "Start/Stop Count"
+msgstr ""
+
+#: modules/devices/storage.c:88
+msgid "Reallocated Sector Count"
+msgstr ""
+
+#: modules/devices/storage.c:89
+msgid "Read Channel Margin"
+msgstr ""
+
+#: modules/devices/storage.c:90
+msgid "Seek Error Rate"
+msgstr ""
+
+#: modules/devices/storage.c:91
+msgid "Seek Timer Performance"
+msgstr ""
+
+#: modules/devices/storage.c:92 modules/devices/storage.c:131
+msgid "Power-On Hours"
+msgstr ""
+
+#: modules/devices/storage.c:93
+msgid "Spin Retry Count"
+msgstr ""
+
+#: modules/devices/storage.c:94
+msgid "Calibration Retry Count"
+msgstr ""
+
+#: modules/devices/storage.c:95
+msgid "Power Cycle Count"
+msgstr ""
+
+#: modules/devices/storage.c:96 modules/devices/storage.c:113
+msgid "Soft Read Error Rate"
+msgstr ""
+
+#: modules/devices/storage.c:97
+msgid "Runtime Bad Block"
+msgstr ""
+
+#: modules/devices/storage.c:98
+msgid "End-to-End error"
+msgstr ""
+
+#: modules/devices/storage.c:99
+msgid "Reported Uncorrectable Errors"
+msgstr ""
+
+#: modules/devices/storage.c:100
+msgid "Command Timeout"
+msgstr ""
+
+#: modules/devices/storage.c:101
+msgid "High Fly Writes"
+msgstr ""
+
+#: modules/devices/storage.c:102
+msgid "Airflow Temperature"
+msgstr ""
+
+#: modules/devices/storage.c:103
+msgid "G-sense Error Rate"
+msgstr ""
+
+#: modules/devices/storage.c:104
+msgid "Power-off Retract Count"
+msgstr ""
+
+#: modules/devices/storage.c:105
+msgid "Load Cycle Count"
+msgstr ""
+
+#: modules/devices/storage.c:106 modules/devices/storage.c:129
+msgid "Temperature"
+msgstr ""
+
+#: modules/devices/storage.c:107
+msgid "Hardware ECC Recovered"
+msgstr ""
+
+#: modules/devices/storage.c:108
+msgid "Reallocation Event Count"
+msgstr ""
+
+#: modules/devices/storage.c:109
+msgid "Current Pending Sector Count"
+msgstr ""
+
+#: modules/devices/storage.c:110
+msgid "Uncorrectable Sector Count"
+msgstr ""
+
+#: modules/devices/storage.c:111
+msgid "UltraDMA CRC Error Count"
+msgstr ""
+
+#: modules/devices/storage.c:112
+msgid "Multi-Zone Error Rate"
+msgstr ""
+
+#: modules/devices/storage.c:114
+msgid "Run Out Cancel"
+msgstr ""
+
+#: modules/devices/storage.c:115
+msgid "Flying Height"
+msgstr ""
+
+#: modules/devices/storage.c:116
+msgid "Spin High Current"
+msgstr ""
+
+#: modules/devices/storage.c:117
+msgid "Spin Buzz"
+msgstr ""
+
+#: modules/devices/storage.c:118
+msgid "Offline Seek Performance"
+msgstr ""
+
+#: modules/devices/storage.c:119
+msgid "Disk Shift"
+msgstr ""
+
+#: modules/devices/storage.c:120
+msgid "G-Sense Error Rate"
+msgstr ""
+
+#: modules/devices/storage.c:121
+msgid "Loaded Hours"
+msgstr ""
+
+#: modules/devices/storage.c:122
+msgid "Load/Unload Retry Count"
+msgstr ""
+
+#: modules/devices/storage.c:123
+msgid "Load Friction"
+msgstr ""
+
+#: modules/devices/storage.c:124
+msgid "Load/Unload Cycle Count"
+msgstr ""
+
+#: modules/devices/storage.c:125
+msgid "Load-in time"
+msgstr ""
+
+#: modules/devices/storage.c:126
+msgid "Torque Amplification Count"
+msgstr ""
+
+#: modules/devices/storage.c:127
+msgid "Power-Off Retract Count"
+msgstr ""
+
+#: modules/devices/storage.c:128
+msgid "GMR Head Amplitude"
+msgstr ""
+
+#: modules/devices/storage.c:130
+msgid "Endurance Remaining"
+msgstr ""
+
+#: modules/devices/storage.c:132
+msgid "Good Block Rate"
+msgstr ""
+
+#: modules/devices/storage.c:133
+msgid "Head Flying Hours"
+msgstr ""
+
+#: modules/devices/storage.c:134
+msgid "Read Error Retry Rate"
+msgstr ""
+
+#: modules/devices/storage.c:135
+msgid "Total LBAs Written"
+msgstr ""
+
+#: modules/devices/storage.c:136
+msgid "Total LBAs Read"
+msgstr ""
+
+#: modules/devices/storage.c:141
 msgid ""
 "\n"
 "[UDisks2]\n"
 msgstr ""
 
-#: modules/devices/storage.c:138
+#: modules/devices/storage.c:199
 msgid "Removable"
 msgstr ""
 
-#: modules/devices/storage.c:138
+#: modules/devices/storage.c:199
 msgid "Fixed"
 msgstr ""
 
-#: modules/devices/storage.c:141
+#: modules/devices/storage.c:202
 msgid "Ejectable"
 msgstr ""
 
-#: modules/devices/storage.c:144
+#: modules/devices/storage.c:205
 msgid "Self-monitoring (S.M.A.R.T.)"
 msgstr ""
 
-#: modules/devices/storage.c:147 modules/devices/x86/processor.c:663
+#: modules/devices/storage.c:208 modules/devices/x86/processor.c:663
 msgid "Power Management"
 msgstr ""
 
-#: modules/devices/storage.c:150
+#: modules/devices/storage.c:211
 msgid "Advanced Power Management"
 msgstr ""
 
-#: modules/devices/storage.c:153
+#: modules/devices/storage.c:214
 msgid "Automatic Acoustic Management"
 msgstr ""
 
-#: modules/devices/storage.c:156
+#: modules/devices/storage.c:217
 #, c-format
 msgid ""
 "[Drive Information]\n"
 "Model=%s\n"
 msgstr ""
 
-#: modules/devices/storage.c:160 modules/devices/storage.c:347
-#: modules/devices/storage.c:546
+#: modules/devices/storage.c:221 modules/devices/storage.c:449
+#: modules/devices/storage.c:648
 #, c-format
 msgid "Vendor=%s\n"
 msgstr ""
 
-#: modules/devices/storage.c:165
+#: modules/devices/storage.c:226
 #, c-format
 msgid ""
 "Revision=%s\n"
@@ -3584,24 +3935,24 @@ msgid ""
 "Features=%s\n"
 msgstr ""
 
-#: modules/devices/storage.c:179
+#: modules/devices/storage.c:240
 #, c-format
 msgid "Rotation Rate=%d RPM\n"
 msgstr ""
 
-#: modules/devices/storage.c:182
+#: modules/devices/storage.c:243
 #, c-format
 msgid ""
 "Media=%s\n"
 "Media compatibility=%s\n"
 msgstr ""
 
-#: modules/devices/storage.c:189
+#: modules/devices/storage.c:250
 #, c-format
 msgid "Connection bus=%s\n"
 msgstr ""
 
-#: modules/devices/storage.c:192
+#: modules/devices/storage.c:253
 #, c-format
 msgid ""
 "[Self-monitoring (S.M.A.R.T.)]\n"
@@ -3611,40 +3962,51 @@ msgid ""
 "Temperature=%d°C\n"
 msgstr ""
 
-#: modules/devices/storage.c:198
+#: modules/devices/storage.c:259
 msgid "Failing"
 msgstr ""
 
-#: modules/devices/storage.c:198
+#: modules/devices/storage.c:259
 msgid "OK"
 msgstr ""
 
-#: modules/devices/storage.c:204
+#: modules/devices/storage.c:265
+msgid ""
+"[S.M.A.R.T. Attributes]\n"
+"Attribute=Normalized Value / Worst / Threshold\n"
+msgstr ""
+
+#: modules/devices/storage.c:297
+#, c-format
+msgid "(%d) %s=%s\n"
+msgstr ""
+
+#: modules/devices/storage.c:306
 #, c-format
 msgid ""
 "[Partition table]\n"
 "Type=%s\n"
 msgstr ""
 
-#: modules/devices/storage.c:223
+#: modules/devices/storage.c:325
 #, c-format
 msgid "Partition %s=%s\n"
 msgstr ""
 
-#: modules/devices/storage.c:273
+#: modules/devices/storage.c:375
 msgid ""
 "\n"
 "[SCSI Disks]\n"
 msgstr ""
 
-#: modules/devices/storage.c:344 modules/devices/storage.c:543
+#: modules/devices/storage.c:446 modules/devices/storage.c:645
 #, c-format
 msgid ""
 "[Device Information]\n"
 "Model=%s\n"
 msgstr ""
 
-#: modules/devices/storage.c:351
+#: modules/devices/storage.c:453
 #, c-format
 msgid ""
 "Type=%s\n"
@@ -3656,18 +4018,18 @@ msgid ""
 "LUN=%d\n"
 msgstr ""
 
-#: modules/devices/storage.c:397
+#: modules/devices/storage.c:499
 msgid ""
 "\n"
 "[IDE Disks]\n"
 msgstr ""
 
-#: modules/devices/storage.c:480
+#: modules/devices/storage.c:582
 #, c-format
 msgid "Driver=%s\n"
 msgstr ""
 
-#: modules/devices/storage.c:548
+#: modules/devices/storage.c:650
 #, c-format
 msgid ""
 "Device Name=hd%c\n"
@@ -3675,7 +4037,7 @@ msgid ""
 "Cache=%dkb\n"
 msgstr ""
 
-#: modules/devices/storage.c:558
+#: modules/devices/storage.c:660
 #, c-format
 msgid ""
 "[Geometry]\n"
@@ -3683,23 +4045,18 @@ msgid ""
 "Logical=%s\n"
 msgstr ""
 
-#: modules/devices/storage.c:568
+#: modules/devices/storage.c:670
 #, c-format
 msgid ""
 "[Capabilities]\n"
 "%s"
 msgstr ""
 
-#: modules/devices/storage.c:575
+#: modules/devices/storage.c:677
 #, c-format
 msgid ""
 "[Speeds]\n"
 "%s"
-msgstr ""
-
-#: modules/devices/usb.c:132 modules/network.c:310 modules/network.c:363
-#: modules/network.c:380
-msgid "Interface"
 msgstr ""
 
 #: modules/devices/usb.c:134 modules/devices/usb.c:175

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -2,26 +2,28 @@
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
+#
 # Translators:
 # eltonfabricio10 <eltonfabricio10@gmail.com>, 2019
 # Ezilei Correia dos Santos <ezilei@yahoo.com.br>, 2019
 # lucas batista silva <darckangelsama@gmail.com>, 2019
 # LordDan Alkaiser <einlanzer@gmx.net>, 2019
 # Paulo Giovanni Pereira <paulusiohannes@gmail.com>, 2019
-# 
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-08-15 02:04-0500\n"
+"POT-Creation-Date: 2019-10-24 15:16-0500\n"
 "PO-Revision-Date: 2019-08-08 04:36+0000\n"
 "Last-Translator: Paulo Giovanni Pereira <paulusiohannes@gmail.com>, 2019\n"
-"Language-Team: Portuguese (Brazil) (https://www.transifex.com/biglinux-1/teams/102270/pt_BR/)\n"
+"Language-Team: Portuguese (Brazil) (https://www.transifex.com/biglinux-1/"
+"teams/102270/pt_BR/)\n"
+"Language: pt_BR\n"
+"X-Poedit-Basepath: ../\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: pt_BR\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 "X-Generator: Poedit 2.2.3\n"
 
@@ -121,7 +123,7 @@ msgstr "Chassis"
 
 #: hardinfo/dmi_util.c:29 modules/computer.c:529 modules/computer.c:1000
 #: modules/devices/alpha/processor.c:87 modules/devices/arm/processor.c:341
-#: modules/devices.c:96 modules/devices/ia64/processor.c:159
+#: modules/devices.c:99 modules/devices/ia64/processor.c:159
 #: modules/devices/m68k/processor.c:83 modules/devices/mips/processor.c:74
 #: modules/devices/parisc/processor.c:154 modules/devices/ppc/processor.c:157
 #: modules/devices/riscv/processor.c:181 modules/devices/s390/processor.c:131
@@ -470,9 +472,9 @@ msgstr ""
 msgid "Yes"
 msgstr "Sim"
 
-#: hardinfo/hardinfo.c:59 modules/computer.c:785
-#: modules/computer/modules.c:131 modules/computer/modules.c:132
-#: modules/devices/printers.c:138 modules/devices/spd-decode.c:900
+#: hardinfo/hardinfo.c:59 modules/computer.c:785 modules/computer/modules.c:131
+#: modules/computer/modules.c:132 modules/devices/printers.c:138
+#: modules/devices/spd-decode.c:900
 msgid "No"
 msgstr "Não"
 
@@ -506,16 +508,17 @@ msgstr "Nome do arquivo"
 #: modules/computer/modules.c:149 modules/devices/arm/processor.c:469
 #: modules/devices/dmi.c:37 modules/devices/dmi.c:48 modules/devices/gpu.c:233
 #: modules/devices/ia64/processor.c:160 modules/devices/inputdevices.c:111
+#: modules/devices/monitors.c:399 modules/devices/monitors.c:502
 #: modules/devices/sh/processor.c:84 modules/devices/x86/processor.c:749
 #: modules/network.c:332
 msgid "Name"
 msgstr "Nome"
 
 #: hardinfo/hardinfo.c:78 modules/computer.c:347 modules/computer.c:572
-#: modules/computer.c:574 modules/computer.c:743
-#: modules/computer/modules.c:151 modules/devices/dmi.c:40
-#: modules/devices/dmi.c:46 modules/devices/dmi.c:50 modules/devices/dmi.c:56
-#: modules/devices/firmware.c:105 modules/devices/inputdevices.c:116
+#: modules/computer.c:574 modules/computer.c:743 modules/computer/modules.c:151
+#: modules/devices/dmi.c:40 modules/devices/dmi.c:46 modules/devices/dmi.c:50
+#: modules/devices/dmi.c:56 modules/devices/firmware.c:105
+#: modules/devices/inputdevices.c:116 modules/devices/monitors.c:405
 msgid "Version"
 msgstr "Versão"
 
@@ -529,7 +532,8 @@ msgid "Don't know what to do. Exiting."
 msgstr "Não sabe o que fazer. Sair."
 
 #: hardinfo/usb_util.c:290 modules/devices/devicetree.c:91
-#: modules/devices/devicetree.c:92 modules/devices/storage.c:185
+#: modules/devices/devicetree.c:92 modules/devices/monitors.c:407
+#: modules/devices/storage.c:246
 msgid "(None)"
 msgstr "(Nenhum)"
 
@@ -703,19 +707,19 @@ msgstr ""
 msgid "Scanning: %s..."
 msgstr "Escaneando: %s..."
 
-#: hardinfo/util.c:1040 shell/shell.c:310 shell/shell.c:794 shell/shell.c:1961
+#: hardinfo/util.c:1040 shell/shell.c:310 shell/shell.c:795 shell/shell.c:1962
 #: modules/benchmark.c:583 modules/benchmark.c:591
 msgid "Done."
 msgstr "Feito."
 
-#: hardinfo/vendor.c:437 modules/computer.c:573 modules/computer.c:765
-#: modules/computer/os.c:79 modules/computer/os.c:263
-#: modules/computer/os.c:300 modules/computer/os.c:499
-#: modules/computer/os.c:569 modules/devices.c:350 modules/devices.c:496
-#: modules/devices/printers.c:99 modules/devices/printers.c:106
-#: modules/devices/printers.c:116 modules/devices/printers.c:131
-#: modules/devices/printers.c:140 modules/devices/printers.c:243
-#: modules/devices/spd-decode.c:312 modules/devices/usb.c:146
+#: hardinfo/vendor.c:440 modules/computer.c:573 modules/computer.c:765
+#: modules/computer/os.c:79 modules/computer/os.c:263 modules/computer/os.c:300
+#: modules/computer/os.c:499 modules/computer/os.c:569 modules/devices.c:359
+#: modules/devices.c:505 modules/devices/printers.c:99
+#: modules/devices/printers.c:106 modules/devices/printers.c:116
+#: modules/devices/printers.c:131 modules/devices/printers.c:140
+#: modules/devices/printers.c:243 modules/devices/spd-decode.c:312
+#: modules/devices/usb.c:146
 msgid "Unknown"
 msgstr "Desconhecido"
 
@@ -755,8 +759,7 @@ msgstr "Implementação de SHA1 por Steve Reid (veja sha1.c para detalhes)"
 
 #: shell/callbacks.c:170
 msgid "Blowfish implementation by Paul Kocher (see blowfich.c for details)"
-msgstr ""
-"Implementação Blowfish por Paul Kocher (veja blowfich.c para detalhes)"
+msgstr "Implementação Blowfish por Paul Kocher (veja blowfich.c para detalhes)"
 
 #: shell/callbacks.c:171
 msgid "Raytracing benchmark by John Walker (see fbench.c for details)"
@@ -801,17 +804,30 @@ msgstr "Informações do sistema e ferramenta de benchmark"
 
 #: shell/callbacks.c:206
 msgid ""
-"HardInfo is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.\n"
+"HardInfo is free software; you can redistribute it and/or modify it under "
+"the terms of the GNU General Public License as published by the Free "
+"Software Foundation, version 2.\n"
 "\n"
-"This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.\n"
+"This program is distributed in the hope that it will be useful, but WITHOUT "
+"ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or "
+"FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for "
+"more details.\n"
 "\n"
-"You should have received a copy of the GNU General Public License along with this program; if not, write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA"
+"You should have received a copy of the GNU General Public License along with "
+"this program; if not, write to the Free Software Foundation, Inc., 51 "
+"Franklin St, Fifth Floor, Boston, MA  02110-1301 USA"
 msgstr ""
-"HardInfo é software livre; você pode redistribuí-lo e / ou modificá-lo sob os termos da Licença Pública Geral GNU como publicada pela Free Software Foundation, versão 2.\n"
+"HardInfo é software livre; você pode redistribuí-lo e / ou modificá-lo sob "
+"os termos da Licença Pública Geral GNU como publicada pela Free Software "
+"Foundation, versão 2.\n"
 "\n"
-"Este programa é distribuído na esperança de que seja útil, mas SEM QUALQUER GARANTIA; sem mesmo a garantia implícita de COMERCIALIZAÇÃO ou ADEQUAÇÃO A UM DETERMINADO FIM. Veja a Licença Pública Geral GNU para mais detalhes.\n"
+"Este programa é distribuído na esperança de que seja útil, mas SEM QUALQUER "
+"GARANTIA; sem mesmo a garantia implícita de COMERCIALIZAÇÃO ou ADEQUAÇÃO A "
+"UM DETERMINADO FIM. Veja a Licença Pública Geral GNU para mais detalhes.\n"
 "\n"
-"Você deve ter recebido uma cópia da Licença Pública Geral GNU junto com este programa; se não, escreva para a Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 EUA"
+"Você deve ter recebido uma cópia da Licença Pública Geral GNU junto com este "
+"programa; se não, escreva para a Free Software Foundation, Inc., 51 Franklin "
+"Street, Fifth Floor, Boston, MA 02110-1301 EUA"
 
 #: shell/callbacks.c:221
 msgid "translator-credits"
@@ -893,67 +909,68 @@ msgstr "Alterna a visibilidade do painel lateral"
 msgid "_Toolbar"
 msgstr "_Barra de ferramentas"
 
-#: shell/report.c:722 shell/report.c:730
+#: shell/report.c:769 shell/report.c:777
 msgid "Save File"
 msgstr "Salvar arquivo"
 
-#: shell/report.c:725 shell/report.c:1196 shell/syncmanager.c:748
+#: shell/report.c:772 shell/report.c:1243 shell/syncmanager.c:748
 msgid "_Cancel"
 msgstr "_Cancelar"
 
-#: shell/report.c:727
+#: shell/report.c:774
 msgid "_Save"
 msgstr "_Salvar"
 
-#: shell/report.c:896
+#: shell/report.c:943
 msgid "Cannot create ReportContext. Programming bug?"
 msgstr "Não é possível criar ReportContext. Erro de programação?"
 
-#: shell/report.c:915
+#: shell/report.c:962
 msgid "Open the report with your web browser?"
 msgstr "Abrir o relatório com o seu navegador da web?"
 
-#: shell/report.c:918
+#: shell/report.c:965
 msgid "_No"
 msgstr "_Não"
 
-#: shell/report.c:919
+#: shell/report.c:966
 msgid "_Open"
 msgstr "_Abrir"
 
-#: shell/report.c:949
+#: shell/report.c:996
 msgid "Generating report..."
 msgstr "Gerando relatório ..."
 
-#: shell/report.c:959
+#: shell/report.c:1006
 msgid "Report saved."
 msgstr "Relatório salvo."
 
-#: shell/report.c:961
+#: shell/report.c:1008
 msgid "Error while creating the report."
 msgstr "Erro ao criar o relatório."
 
-#: shell/report.c:1063
+#: shell/report.c:1110
 msgid "Generate Report"
 msgstr "Gerar relatório"
 
-#: shell/report.c:1088
+#: shell/report.c:1135
 msgid ""
 "<big><b>Generate Report</b></big>\n"
 "Please choose the information that you wish to view in your report:"
 msgstr ""
 "<big><b>Gerar relatório</big>\n"
-"Por favor, escolha as informações que você deseja visualizar em seu relatório:"
+"Por favor, escolha as informações que você deseja visualizar em seu "
+"relatório:"
 
-#: shell/report.c:1160
+#: shell/report.c:1207
 msgid "Select _None"
 msgstr "Selecionar_nenhum"
 
-#: shell/report.c:1171
+#: shell/report.c:1218
 msgid "Select _All"
 msgstr "Selecionar_todos"
 
-#: shell/report.c:1206
+#: shell/report.c:1253
 msgid "_Generate"
 msgstr "_Gerar"
 
@@ -966,26 +983,28 @@ msgstr "%s - Informações do sistema "
 msgid "System Information"
 msgstr "Informações do sistema"
 
-#: shell/shell.c:781
+#: shell/shell.c:782
 msgid "Loading modules..."
 msgstr "Carregando módulos ..."
 
-#: shell/shell.c:1827
+#: shell/shell.c:1828
 #, c-format
 msgid "<b>%s → Summary</b>"
 msgstr "<b>%s → Resumo</b>"
 
-#: shell/shell.c:1935
+#: shell/shell.c:1936
 msgid "Updating..."
 msgstr "Atualizando..."
 
 #: shell/syncmanager.c:69
 msgid ""
 "<big><b>Synchronize with Central Database</b></big>\n"
-"The following information may be synchronized with the HardInfo central database."
+"The following information may be synchronized with the HardInfo central "
+"database."
 msgstr ""
 "<big><b>sincronizar com o banco de dados</big>\n"
-"As informações a seguir podem ser sincronizadas com o banco de dados central do HardInfo."
+"As informações a seguir podem ser sincronizadas com o banco de dados central "
+"do HardInfo."
 
 #: shell/syncmanager.c:72
 msgid ""
@@ -997,11 +1016,10 @@ msgstr ""
 
 #: shell/syncmanager.c:132
 msgid ""
-"HardInfo was compiled without libsoup support. (Network Updater requires "
-"it.)"
+"HardInfo was compiled without libsoup support. (Network Updater requires it.)"
 msgstr ""
-"O HardInfo foi compilado sem suporte ao libsoup. (Atualizador de rede requer"
-" isso.)"
+"O HardInfo foi compilado sem suporte ao libsoup. (Atualizador de rede requer "
+"isso.)"
 
 #: shell/syncmanager.c:161 shell/syncmanager.c:189
 #, c-format
@@ -1040,11 +1058,13 @@ msgstr "(falhou)"
 #: shell/syncmanager.c:521
 #, c-format
 msgid ""
-"Failed while performing \"%s\". Please file a bug report if this problem persists. (Use the Help→Report bug option.)\n"
+"Failed while performing \"%s\". Please file a bug report if this problem "
+"persists. (Use the Help→Report bug option.)\n"
 "\n"
 "Details: %s"
 msgstr ""
-"Falha ao executar \"%s\". Por favor arquive um relatório de bug se este problema persistir. (Use a opção Ajuda → Reportar erro.)\n"
+"Falha ao executar \"%s\". Por favor arquive um relatório de bug se este "
+"problema persistir. (Use a opção Ajuda → Reportar erro.)\n"
 "\n"
 "Detalhes: %s"
 
@@ -1110,16 +1130,16 @@ msgid "SysBench CPU (Multi-thread)"
 msgstr "SysBench (Processamento múltiplo)"
 
 #: modules/benchmark/benches.c:104
-msgid "#SysBench CPU (Four threads)"
-msgstr "#SysBench CPU (4 processamentos)"
+msgid "SysBench CPU (Four threads)"
+msgstr ""
 
 #: modules/benchmark/benches.c:106
-msgid "#SysBench Memory (Single-thread)"
-msgstr "#SysBench Memória (Processamento unitário)"
+msgid "SysBench Memory (Single-thread)"
+msgstr ""
 
 #: modules/benchmark/benches.c:108
-msgid "#SysBench Memory (Two threads)"
-msgstr "#SysBench Memória (2 Processamentos)"
+msgid "SysBench Memory (Two threads)"
+msgstr ""
 
 #: modules/benchmark/benches.c:110
 msgid "SysBench Memory"
@@ -1168,34 +1188,34 @@ msgstr "Resultados em segundos. Menor é melhor."
 #. *
 #. *    You should have received a copy of the GNU General Public License
 #. *    along with this program; if not, write to the Free Software
-#. *    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301
-#. USA
-#. / Used for an unknown value. Having it in only one place cleans up the .po
-#. line references
+#. *    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+#.
+#. / Used for an unknown value. Having it in only one place cleans up the .po line references
 #: modules/benchmark/bench_results.c:22 modules/computer.c:41
 #: modules/computer/display.c:41 modules/computer/display.c:58
-#: modules/computer/os.c:286 modules/computer/os.c:346 modules/devices.c:479
+#: modules/computer/os.c:286 modules/computer/os.c:346 modules/devices.c:488
 #: modules/devices/dmi_memory.c:52 modules/devices/dmi_memory.c:53
 #: modules/devices/dmi_memory.c:579 modules/devices/dmi_memory.c:719
 #: modules/devices/dmi_memory.c:855 modules/devices/gpu.c:42
-#: modules/devices/gpu.c:58 modules/devices/gpu.c:112
-#: modules/devices/gpu.c:120 modules/devices/gpu.c:154
-#: modules/devices/gpu.c:155 modules/devices/gpu.c:176
-#: modules/devices/pci.c:25 modules/devices/pci.c:135
-#: modules/devices/pci.c:136 modules/devices/spd-decode.c:306
-#: modules/devices/spd-decode.c:307 modules/devices/spd-decode.c:310
-#: modules/devices/spd-decode.c:311 modules/devices/spd-decode.c:914
-#: modules/devices/spd-decode.c:915 modules/devices/storage.c:186
-#: modules/devices/storage.c:207 modules/devices/usb.c:28
-#: modules/network/net.c:437 includes/cpu_util.h:11
+#: modules/devices/gpu.c:58 modules/devices/gpu.c:112 modules/devices/gpu.c:120
+#: modules/devices/gpu.c:154 modules/devices/gpu.c:155
+#: modules/devices/gpu.c:176 modules/devices/monitors.c:27
+#: modules/devices/monitors.c:28 modules/devices/monitors.c:153
+#: modules/devices/monitors.c:162 modules/devices/pci.c:25
+#: modules/devices/pci.c:135 modules/devices/pci.c:136
+#: modules/devices/spd-decode.c:306 modules/devices/spd-decode.c:307
+#: modules/devices/spd-decode.c:310 modules/devices/spd-decode.c:311
+#: modules/devices/spd-decode.c:914 modules/devices/spd-decode.c:915
+#: modules/devices/storage.c:247 modules/devices/storage.c:309
+#: modules/devices/usb.c:28 modules/network/net.c:437 includes/cpu_util.h:11
 msgid "(Unknown)"
 msgstr "(Desconhecido)"
 
-#: modules/benchmark/bench_results.c:48 modules/benchmark/bench_results.c:326
+#: modules/benchmark/bench_results.c:49 modules/benchmark/bench_results.c:330
 #: modules/devices/alpha/processor.c:90 modules/devices/arm/processor.c:290
 #: modules/devices/arm/processor.c:303 modules/devices/arm/processor.c:345
-#: modules/devices/arm/processor.c:500 modules/devices.c:316
-#: modules/devices.c:324 modules/devices.c:352 modules/devices/gpu.c:115
+#: modules/devices/arm/processor.c:500 modules/devices.c:325
+#: modules/devices.c:333 modules/devices.c:361 modules/devices/gpu.c:115
 #: modules/devices/gpu.c:117 modules/devices/gpu.c:123
 #: modules/devices/gpu.c:125 modules/devices/gpu.c:179
 #: modules/devices/gpu.c:181 modules/devices/ia64/processor.c:167
@@ -1211,58 +1231,51 @@ msgstr "(Desconhecido)"
 msgid "MHz"
 msgstr "MHz"
 
-#: modules/benchmark/bench_results.c:391 modules/benchmark/bench_results.c:481
+#: modules/benchmark/bench_results.c:396 modules/benchmark/bench_results.c:495
 msgid "kiB"
 msgstr "kIB"
 
-#: modules/benchmark/bench_results.c:413 modules/benchmark/bench_results.c:463
+#: modules/benchmark/bench_results.c:403 modules/benchmark/bench_results.c:453
+#, c-format
+msgid "%d-bit"
+msgstr ""
+
+#: modules/benchmark/bench_results.c:422 modules/benchmark/bench_results.c:477
 msgid "Benchmark Result"
 msgstr "Resultado de referência"
 
-#: modules/benchmark/bench_results.c:414 modules/benchmark/bench_results.c:465
+#: modules/benchmark/bench_results.c:423 modules/benchmark/bench_results.c:479
 msgid "Threads"
 msgstr "Tópicos"
 
-#: modules/benchmark/bench_results.c:415 modules/benchmark/bench_results.c:467
+#: modules/benchmark/bench_results.c:424 modules/benchmark/bench_results.c:481
 msgid "Elapsed Time"
 msgstr "Tempo gasto"
 
-#: modules/benchmark/bench_results.c:415 modules/benchmark/bench_results.c:467
+#: modules/benchmark/bench_results.c:424 modules/benchmark/bench_results.c:481
 msgid "seconds"
 msgstr "segundos"
 
-#: modules/benchmark/bench_results.c:416 modules/computer/languages.c:101
+#: modules/benchmark/bench_results.c:425 modules/computer/languages.c:101
 #: modules/devices/arm/processor.c:355 modules/devices/gpu.c:147
 #: modules/devices/ia64/processor.c:166 modules/devices/pci.c:132
 #: modules/devices/ppc/processor.c:159
 msgid "Revision"
 msgstr "Revisão"
 
-#: modules/benchmark/bench_results.c:416
-msgid "#Revision"
-msgstr "#Revisão"
-
-#: modules/benchmark/bench_results.c:417 modules/benchmark/bench_results.c:468
+#: modules/benchmark/bench_results.c:426 modules/benchmark/bench_results.c:482
 msgid "Extra Information"
 msgstr "Informação extra"
 
-#: modules/benchmark/bench_results.c:417 modules/benchmark/bench_results.c:468
-msgid "#Extra"
-msgstr "#Extra"
-
-#: modules/benchmark/bench_results.c:418 modules/benchmark/bench_results.c:469
+#: modules/benchmark/bench_results.c:427 modules/benchmark/bench_results.c:483
 msgid "User Note"
 msgstr "Nota de usuário"
 
-#: modules/benchmark/bench_results.c:418 modules/benchmark/bench_results.c:469
-msgid "#User Note"
-msgstr "#Nota de usuário"
-
-#: modules/benchmark/bench_results.c:420 modules/benchmark/bench_results.c:471
+#: modules/benchmark/bench_results.c:429 modules/benchmark/bench_results.c:485
 msgid "Note"
 msgstr "Nota"
 
-#: modules/benchmark/bench_results.c:421 modules/benchmark/bench_results.c:472
+#: modules/benchmark/bench_results.c:430 modules/benchmark/bench_results.c:486
 msgid ""
 "This result is from an old version of HardInfo. Results might not be "
 "comparable to current version. Some details are missing."
@@ -1270,66 +1283,71 @@ msgstr ""
 "Este resultado é de uma versão antiga do HardInfo. Os resultados não devem "
 "ser comparados com os da versão atual. Alguns detalhes estão faltando."
 
-#: modules/benchmark/bench_results.c:422 modules/benchmark/bench_results.c:473
+#: modules/benchmark/bench_results.c:431 modules/benchmark/bench_results.c:487
 #: modules/devices/devicetree/pmac_data.c:81 modules/devices/sh/processor.c:85
 msgid "Machine"
 msgstr "Máquina "
 
-#: modules/benchmark/bench_results.c:423 modules/benchmark/bench_results.c:474
+#: modules/benchmark/bench_results.c:432 modules/benchmark/bench_results.c:488
 #: modules/devices/devicetree.c:208 modules/devices/dmi.c:47
 msgid "Board"
 msgstr "Placa"
 
-#: modules/benchmark/bench_results.c:424 modules/benchmark/bench_results.c:475
+#: modules/benchmark/bench_results.c:433 modules/benchmark/bench_results.c:489
 msgid "CPU Name"
 msgstr "Nome da CPU"
 
-#: modules/benchmark/bench_results.c:425 modules/benchmark/bench_results.c:476
+#: modules/benchmark/bench_results.c:434 modules/benchmark/bench_results.c:490
 msgid "CPU Description"
 msgstr "Descrição da CPU"
 
-#: modules/benchmark/bench_results.c:426 modules/benchmark/bench_results.c:477
+#: modules/benchmark/bench_results.c:435 modules/benchmark/bench_results.c:491
 #: modules/benchmark.c:442
 msgid "CPU Config"
 msgstr "Configurações da CPU"
 
-#: modules/benchmark/bench_results.c:427 modules/benchmark/bench_results.c:478
+#: modules/benchmark/bench_results.c:436 modules/benchmark/bench_results.c:492
 msgid "Threads Available"
 msgstr "Tópicos disponíveis"
 
-#: modules/benchmark/bench_results.c:428 modules/benchmark/bench_results.c:479
+#: modules/benchmark/bench_results.c:437 modules/benchmark/bench_results.c:493
 msgid "GPU"
 msgstr "GPU"
 
-#: modules/benchmark/bench_results.c:429 modules/benchmark/bench_results.c:480
+#: modules/benchmark/bench_results.c:438 modules/benchmark/bench_results.c:494
 #: modules/computer.c:542
 msgid "OpenGL Renderer"
 msgstr "Renderizador OpenGL"
 
-#: modules/benchmark/bench_results.c:430 modules/benchmark/bench_results.c:481
+#: modules/benchmark/bench_results.c:439 modules/benchmark/bench_results.c:495
 #: modules/computer.c:123 modules/computer.c:531 modules/computer.c:1000
 #: modules/devices/gpu.c:150
 msgid "Memory"
 msgstr "Memória"
 
-#: modules/benchmark/bench_results.c:464
+#: modules/benchmark/bench_results.c:440 modules/benchmark/bench_results.c:496
+msgid "Pointer Size"
+msgstr ""
+
+#: modules/benchmark/bench_results.c:478
 msgid "Benchmark"
 msgstr "Referência"
 
-#: modules/benchmark/bench_results.c:466 modules/devices/dmi_memory.c:879
-#: modules/devices/firmware.c:244 modules/devices/x86/processor.c:691
+#: modules/benchmark/bench_results.c:480 modules/devices/dmi_memory.c:879
+#: modules/devices/firmware.c:246 modules/devices/monitors.c:492
+#: modules/devices/x86/processor.c:691
 msgid "Result"
 msgstr "Resultado "
 
-#: modules/benchmark/bench_results.c:483
+#: modules/benchmark/bench_results.c:498
 msgid "Handles"
 msgstr "Alças"
 
-#: modules/benchmark/bench_results.c:484
+#: modules/benchmark/bench_results.c:499
 msgid "mid"
 msgstr "Mid"
 
-#: modules/benchmark/bench_results.c:485
+#: modules/benchmark/bench_results.c:500
 msgid "cfg_val"
 msgstr "cfg_val"
 
@@ -1614,13 +1632,12 @@ msgstr "Programa"
 msgid "Field"
 msgstr "Campo "
 
-#: modules/computer.c:365 modules/computer.c:667
-#: modules/computer/modules.c:149 modules/computer/modules.c:150
-#: modules/devices/arm/processor.c:470
+#: modules/computer.c:365 modules/computer.c:667 modules/computer/modules.c:149
+#: modules/computer/modules.c:150 modules/devices/arm/processor.c:470
 msgid "Description"
 msgstr "Descrição"
 
-#: modules/computer.c:365 modules/devices.c:703
+#: modules/computer.c:365 modules/devices.c:726
 msgid "Value"
 msgstr "Valor"
 
@@ -1685,7 +1702,7 @@ msgstr "%dx%d pixels"
 msgid "Session Display Server"
 msgstr "Servidor de exibição de sessão"
 
-#: modules/computer.c:548 modules/devices.c:104
+#: modules/computer.c:548 modules/devices.c:108
 msgid "Input Devices"
 msgstr "Dispositivos de entrada"
 
@@ -1828,7 +1845,7 @@ msgstr "Dispositivo"
 msgid "Session"
 msgstr "Sessão"
 
-#: modules/computer.c:732 modules/devices.c:703 modules/devices/dmi.c:55
+#: modules/computer.c:732 modules/devices.c:726 modules/devices/dmi.c:55
 #: modules/devices/dmi_memory.c:603 modules/devices/dmi_memory.c:749
 #: modules/devices/inputdevices.c:112 modules/devices/x86/processor.c:714
 msgid "Type"
@@ -1849,11 +1866,12 @@ msgstr "Servidor X"
 #: modules/computer.c:742 modules/computer.c:782 modules/devices/dmi.c:39
 #: modules/devices/dmi.c:45 modules/devices/dmi.c:49 modules/devices/dmi.c:54
 #: modules/devices/dmi_memory.c:750 modules/devices/dmi_memory.c:895
-#: modules/devices/firmware.c:105 modules/devices/firmware.c:167
-#: modules/devices/firmware.c:189 modules/devices/firmware.c:226
+#: modules/devices/firmware.c:105 modules/devices/firmware.c:168
+#: modules/devices/firmware.c:190 modules/devices/firmware.c:228
 #: modules/devices/gpu.c:74 modules/devices/gpu.c:82 modules/devices/gpu.c:224
 #: modules/devices/ia64/processor.c:161 modules/devices/inputdevices.c:114
-#: modules/devices/pci.c:87 modules/devices/pci.c:95 modules/devices/usb.c:168
+#: modules/devices/monitors.c:398 modules/devices/pci.c:87
+#: modules/devices/pci.c:95 modules/devices/usb.c:168
 #: modules/devices/x86/processor.c:653
 msgid "Vendor"
 msgstr "Fornecedor"
@@ -1967,11 +1985,11 @@ msgstr "Placa mãe"
 msgid "Graphics"
 msgstr "Gráficos"
 
-#: modules/computer.c:1001 modules/devices.c:105
+#: modules/computer.c:1001 modules/devices.c:109
 msgid "Storage"
 msgstr "Armazenamento"
 
-#: modules/computer.c:1001 modules/devices.c:101
+#: modules/computer.c:1001 modules/devices.c:105
 msgid "Printers"
 msgstr "Impressoras Printers"
 
@@ -2086,7 +2104,7 @@ msgstr "Memória virtual livre"
 #: modules/computer/modules.c:119 modules/computer/modules.c:120
 #: modules/computer/modules.c:121 modules/computer/modules.c:122
 #: modules/devices/dmi.c:111 modules/devices/dmi_memory.c:881
-#: modules/devices/firmware.c:244 modules/devices/x86/processor.c:693
+#: modules/devices/firmware.c:246 modules/devices/x86/processor.c:693
 msgid "(Not available)"
 msgstr "(Indisponível)"
 
@@ -2245,8 +2263,9 @@ msgstr "Shell Padrão "
 #: modules/devices/devicetree.c:209 modules/devices/devicetree/pmac_data.c:80
 #: modules/devices/gpu.c:106 modules/devices/ia64/processor.c:165
 #: modules/devices/m68k/processor.c:84 modules/devices/mips/processor.c:75
-#: modules/devices/parisc/processor.c:155 modules/devices/ppc/processor.c:158
-#: modules/devices/riscv/processor.c:182 modules/devices/s390/processor.c:132
+#: modules/devices/monitors.c:400 modules/devices/parisc/processor.c:155
+#: modules/devices/ppc/processor.c:158 modules/devices/riscv/processor.c:182
+#: modules/devices/s390/processor.c:132
 msgid "Model"
 msgstr "Modelo "
 
@@ -2327,8 +2346,7 @@ msgstr "VFP (instruções iniciais de ponto flutuante de vetor SIMD)"
 #. /flag:edsp
 #: modules/devices/arm/arm_data.c:49
 msgctxt "arm-flag"
-msgid ""
-"DSP extensions (the 'e' variant of the ARM9 CPUs, and all others above)"
+msgid "DSP extensions (the 'e' variant of the ARM9 CPUs, and all others above)"
 msgstr "Extensões DSP (a variante 'e' das CPUs ARM9 e todas as outras acima)"
 
 #. /flag:java
@@ -2497,8 +2515,7 @@ msgid "Part"
 msgstr "Parte"
 
 #: modules/devices/arm/processor.c:353 modules/devices/ia64/processor.c:162
-#: modules/devices/parisc/processor.c:156
-#: modules/devices/riscv/processor.c:183
+#: modules/devices/parisc/processor.c:156 modules/devices/riscv/processor.c:183
 msgid "Architecture"
 msgstr "Arquitetura"
 
@@ -2609,61 +2626,66 @@ msgstr ""
 "[Sem baterias]\n"
 "Nenhuma bateria encontrada neste sistema=\n"
 
-#: modules/devices.c:97
+#: modules/devices.c:100
 msgid "Graphics Processors"
 msgstr "Processadores Gráficos"
 
-#: modules/devices.c:98 modules/devices/pci.c:163
+#: modules/devices.c:101 modules/devices/monitors.c:445
+#: modules/devices/monitors.c:492
+msgid "Monitors"
+msgstr ""
+
+#: modules/devices.c:102 modules/devices/pci.c:163
 msgid "PCI Devices"
 msgstr "Dispositivos PCI"
 
-#: modules/devices.c:99 modules/devices/usb.c:210
+#: modules/devices.c:103 modules/devices/usb.c:210
 msgid "USB Devices"
 msgstr "Dispositivos USB "
 
-#: modules/devices.c:100
+#: modules/devices.c:104
 msgid "Firmware"
 msgstr "Firmware"
 
-#: modules/devices.c:102
+#: modules/devices.c:106
 msgid "Battery"
 msgstr "Bateria"
 
-#: modules/devices.c:103
+#: modules/devices.c:107
 msgid "Sensors"
 msgstr "Sensores"
 
-#: modules/devices.c:106
+#: modules/devices.c:110
 msgid "System DMI"
 msgstr "Sistema DMI"
 
-#: modules/devices.c:107
+#: modules/devices.c:111
 msgid "Memory Devices"
 msgstr "Dispositivos de memória"
 
-#: modules/devices.c:111
+#: modules/devices.c:113 modules/devices.c:115
 msgid "Device Tree"
 msgstr "Árvore de Dispositivos"
 
-#: modules/devices.c:113
+#: modules/devices.c:117
 msgid "Resources"
 msgstr "Recursos"
 
-#: modules/devices.c:168
+#: modules/devices.c:177
 #, c-format
 msgid "%d physical processor"
 msgid_plural "%d physical processors"
 msgstr[0] "1%d processador físico"
 msgstr[1] "%d processadores físicos"
 
-#: modules/devices.c:169
+#: modules/devices.c:178
 #, c-format
 msgid "%d core"
 msgid_plural "%d cores"
 msgstr[0] "1%d núcleo"
 msgstr[1] " %d núcleos"
 
-#: modules/devices.c:170
+#: modules/devices.c:179
 #, c-format
 msgid "%d thread"
 msgid_plural "%d threads"
@@ -2671,36 +2693,36 @@ msgstr[0] "%d thread"
 msgstr[1] "%d threads"
 
 #. /NP procs; NC cores; NT threads
-#: modules/devices.c:171
+#: modules/devices.c:180
 #, c-format
 msgid "%s; %s; %s"
 msgstr "%s; %s; %s"
 
-#: modules/devices.c:703
+#: modules/devices.c:726
 msgid "Sensor"
 msgstr "Sensor"
 
-#: modules/devices.c:750 modules/devices/dmi_memory.c:826
+#: modules/devices.c:773 modules/devices/dmi_memory.c:826
 msgid "Devices"
 msgstr "Dispositivos "
 
-#: modules/devices.c:762
+#: modules/devices.c:785
 msgid "Update PCI ID listing"
 msgstr "Atualizar lista de IDs de PCI"
 
-#: modules/devices.c:774
+#: modules/devices.c:797
 msgid "Update CPU feature database"
 msgstr "Atualizar banco de dados de recursos da CPU"
 
-#: modules/devices.c:802
+#: modules/devices.c:825
 msgid "Gathers information about hardware devices"
 msgstr "Reúne informações sobre dispositivos de hardware"
 
-#: modules/devices.c:821
+#: modules/devices.c:844
 msgid "Resource information requires superuser privileges"
 msgstr "Reúne informações sobre dispositivos de hardware"
 
-#: modules/devices.c:827
+#: modules/devices.c:850
 msgid ""
 "Any NVMe storage devices present are not listed.\n"
 "<b><i>udisksd</i></b> is required for NVMe devices."
@@ -2763,8 +2785,7 @@ msgstr "RCode"
 #: modules/devices/devicetree.c:165
 msgid "No revision code available; unable to lookup model details."
 msgstr ""
-"Nenhum código de revisão disponível; incapaz de pesquisar detalhes do "
-"modelo."
+"Nenhum código de revisão disponível; incapaz de pesquisar detalhes do modelo."
 
 #: modules/devices/devicetree.c:190
 msgid "More"
@@ -2982,6 +3003,7 @@ msgid "Configured Voltage"
 msgstr "Voltagem configurada"
 
 #: modules/devices/dmi_memory.c:786 modules/devices/dmi_memory.c:793
+#: modules/devices/monitors.c:492
 msgid "(Empty)"
 msgstr "(Vazio)"
 
@@ -3013,7 +3035,8 @@ msgstr "As informações de memória precisam  <b>um ou ambos </b> do seguinte:"
 
 #: modules/devices/dmi_memory.c:982
 msgid ""
-"\"More often than not, information contained in the DMI tables is inaccurate,\n"
+"\"More often than not, information contained in the DMI tables is "
+"inaccurate,\n"
 "incomplete or simply wrong.\" -<i><b>dmidecode</b></i> manual page"
 msgstr ""
 
@@ -3144,11 +3167,11 @@ msgstr "Duração da instalação"
 msgid "Created"
 msgstr "Criado"
 
-#: modules/devices/firmware.c:243
+#: modules/devices/firmware.c:245
 msgid "Firmware List"
 msgstr "Lista de firmware"
 
-#: modules/devices/firmware.c:256
+#: modules/devices/firmware.c:258
 msgid "Requires the <i><b>fwupdmgr</b></i> utility."
 msgstr "Requer o <i><b> utilitário </b></i>fwupdmgr."
 
@@ -3172,8 +3195,7 @@ msgstr "Largura máxima do link"
 msgid "Maximum Link Speed"
 msgstr "Velocidade Máxima de Link"
 
-#: modules/devices/gpu.c:95 modules/devices/pci.c:111
-#: modules/devices/pci.c:112
+#: modules/devices/gpu.c:95 modules/devices/pci.c:111 modules/devices/pci.c:112
 msgid "GT/s"
 msgstr "GT/s"
 
@@ -3232,7 +3254,8 @@ msgstr ""
 msgid "Device Tree Node"
 msgstr ""
 
-#: modules/devices/gpu.c:232 modules/network/net.c:454
+#: modules/devices/gpu.c:232 modules/devices/monitors.c:471
+#: modules/network/net.c:454
 msgid "Status"
 msgstr "Estado"
 
@@ -3289,6 +3312,154 @@ msgstr "Calibração"
 msgid "System Type"
 msgstr "Tipo de sistema"
 
+#: modules/devices/monitors.c:29 modules/devices/monitors.c:253
+#: modules/devices/monitors.c:346 modules/devices/spd-decode.c:595
+msgid "(Unspecified)"
+msgstr "(Não especificado)"
+
+#: modules/devices/monitors.c:228
+#, c-format
+msgid "Week %d of %d"
+msgstr ""
+
+#: modules/devices/monitors.c:238
+msgid "Ok"
+msgstr ""
+
+#: modules/devices/monitors.c:238
+msgid "Fail"
+msgstr ""
+
+#: modules/devices/monitors.c:266 modules/devices/monitors.c:274
+#: modules/devices/monitors.c:282 modules/devices/monitors.c:293
+#: modules/devices/monitors.c:301 modules/devices/monitors.c:308
+#: modules/devices/monitors.c:316 modules/devices/monitors.c:324
+#: modules/devices/monitors.c:332 modules/devices/monitors.c:338
+msgid "(Empty List)"
+msgstr ""
+
+#: modules/devices/monitors.c:390
+msgid "Signal Type"
+msgstr ""
+
+#: modules/devices/monitors.c:390
+msgid "Digital"
+msgstr ""
+
+#: modules/devices/monitors.c:390
+msgid "Analog"
+msgstr ""
+
+#: modules/devices/monitors.c:391 modules/devices/usb.c:132
+#: modules/network.c:310 modules/network.c:363 modules/network.c:380
+msgid "Interface"
+msgstr "Interface"
+
+#: modules/devices/monitors.c:392
+msgid "Bits per Color Channel"
+msgstr ""
+
+#: modules/devices/monitors.c:393
+msgid "Speaker Allocation"
+msgstr ""
+
+#: modules/devices/monitors.c:394
+msgid "Output (Max)"
+msgstr ""
+
+#: modules/devices/monitors.c:397
+msgid "EDID Device"
+msgstr ""
+
+#: modules/devices/monitors.c:401
+msgid "Serial"
+msgstr ""
+
+#: modules/devices/monitors.c:402
+msgid "Manufacture Date"
+msgstr ""
+
+#: modules/devices/monitors.c:403
+msgid "EDID Meta"
+msgstr ""
+
+#: modules/devices/monitors.c:404
+msgid "Data Size"
+msgstr ""
+
+#: modules/devices/monitors.c:404
+msgid "bytes"
+msgstr ""
+
+#: modules/devices/monitors.c:406
+msgid "Extension Blocks"
+msgstr ""
+
+#: modules/devices/monitors.c:407
+msgid "Extended to"
+msgstr ""
+
+#: modules/devices/monitors.c:408
+msgid "Checksum"
+msgstr ""
+
+#: modules/devices/monitors.c:409
+msgid "EDID Descriptors"
+msgstr ""
+
+#: modules/devices/monitors.c:410
+msgid "Detailed Timing Descriptors (DTD)"
+msgstr ""
+
+#: modules/devices/monitors.c:411
+msgid "Established Timings Bitmap (ETB)"
+msgstr ""
+
+#: modules/devices/monitors.c:412
+msgid "Standard Timings (STD)"
+msgstr ""
+
+#: modules/devices/monitors.c:413
+msgid "E-EDID Extension Blocks"
+msgstr ""
+
+#: modules/devices/monitors.c:414
+msgid "EIA/CEA-861 Data Blocks"
+msgstr ""
+
+#: modules/devices/monitors.c:415
+msgid "EIA/CEA-861 Short Audio Descriptors"
+msgstr ""
+
+#: modules/devices/monitors.c:416
+msgid "EIA/CEA-861 Short Video Descriptors"
+msgstr ""
+
+#: modules/devices/monitors.c:417
+msgid "DisplayID Timings"
+msgstr ""
+
+#: modules/devices/monitors.c:418
+msgid "DisplayID Strings"
+msgstr ""
+
+#: modules/devices/monitors.c:419
+msgid "Hex Dump"
+msgstr ""
+
+#: modules/devices/monitors.c:419
+msgid "Data"
+msgstr ""
+
+#: modules/devices/monitors.c:469 modules/devices/monitors.c:501
+#: modules/devices/pci.c:137 modules/devices/usb.c:179
+msgid "Connection"
+msgstr "Conexão"
+
+#: modules/devices/monitors.c:470
+msgid "DRM"
+msgstr ""
+
 #: modules/devices/parisc/processor.c:107
 msgid "PA-RISC Processor"
 msgstr "Processador PA-RISC"
@@ -3308,10 +3479,6 @@ msgstr "Largura do Link"
 #: modules/devices/pci.c:111
 msgid "Link Speed"
 msgstr "Velocidade de Link"
-
-#: modules/devices/pci.c:137 modules/devices/usb.c:179
-msgid "Connection"
-msgstr "Conexão"
 
 #: modules/devices/pci.c:138
 msgid "Domain"
@@ -3574,10 +3741,6 @@ msgstr ""
 msgid "Die count"
 msgstr ""
 
-#: modules/devices/spd-decode.c:595
-msgid "(Unspecified)"
-msgstr "(Não especificado)"
-
 #: modules/devices/spd-decode.c:596
 msgid "Thermal Sensor"
 msgstr "Sensor termal"
@@ -3627,7 +3790,207 @@ msgstr "XMP"
 msgid "JEDEC Timings"
 msgstr ""
 
-#: modules/devices/storage.c:80
+#: modules/devices/storage.c:84
+msgid "Read Error Rate"
+msgstr ""
+
+#: modules/devices/storage.c:85
+msgid "Throughput Performance"
+msgstr ""
+
+#: modules/devices/storage.c:86
+msgid "Spin-Up Time"
+msgstr ""
+
+#: modules/devices/storage.c:87
+msgid "Start/Stop Count"
+msgstr ""
+
+#: modules/devices/storage.c:88
+msgid "Reallocated Sector Count"
+msgstr ""
+
+#: modules/devices/storage.c:89
+msgid "Read Channel Margin"
+msgstr ""
+
+#: modules/devices/storage.c:90
+msgid "Seek Error Rate"
+msgstr ""
+
+#: modules/devices/storage.c:91
+msgid "Seek Timer Performance"
+msgstr ""
+
+#: modules/devices/storage.c:92 modules/devices/storage.c:131
+msgid "Power-On Hours"
+msgstr ""
+
+#: modules/devices/storage.c:93
+msgid "Spin Retry Count"
+msgstr ""
+
+#: modules/devices/storage.c:94
+msgid "Calibration Retry Count"
+msgstr ""
+
+#: modules/devices/storage.c:95
+msgid "Power Cycle Count"
+msgstr ""
+
+#: modules/devices/storage.c:96 modules/devices/storage.c:113
+msgid "Soft Read Error Rate"
+msgstr ""
+
+#: modules/devices/storage.c:97
+msgid "Runtime Bad Block"
+msgstr ""
+
+#: modules/devices/storage.c:98
+msgid "End-to-End error"
+msgstr ""
+
+#: modules/devices/storage.c:99
+msgid "Reported Uncorrectable Errors"
+msgstr ""
+
+#: modules/devices/storage.c:100
+msgid "Command Timeout"
+msgstr ""
+
+#: modules/devices/storage.c:101
+msgid "High Fly Writes"
+msgstr ""
+
+#: modules/devices/storage.c:102
+msgid "Airflow Temperature"
+msgstr ""
+
+#: modules/devices/storage.c:103
+msgid "G-sense Error Rate"
+msgstr ""
+
+#: modules/devices/storage.c:104
+msgid "Power-off Retract Count"
+msgstr ""
+
+#: modules/devices/storage.c:105
+msgid "Load Cycle Count"
+msgstr ""
+
+#: modules/devices/storage.c:106 modules/devices/storage.c:129
+msgid "Temperature"
+msgstr ""
+
+#: modules/devices/storage.c:107
+msgid "Hardware ECC Recovered"
+msgstr ""
+
+#: modules/devices/storage.c:108
+msgid "Reallocation Event Count"
+msgstr ""
+
+#: modules/devices/storage.c:109
+msgid "Current Pending Sector Count"
+msgstr ""
+
+#: modules/devices/storage.c:110
+msgid "Uncorrectable Sector Count"
+msgstr ""
+
+#: modules/devices/storage.c:111
+msgid "UltraDMA CRC Error Count"
+msgstr ""
+
+#: modules/devices/storage.c:112
+msgid "Multi-Zone Error Rate"
+msgstr ""
+
+#: modules/devices/storage.c:114
+msgid "Run Out Cancel"
+msgstr ""
+
+#: modules/devices/storage.c:115
+msgid "Flying Height"
+msgstr ""
+
+#: modules/devices/storage.c:116
+msgid "Spin High Current"
+msgstr ""
+
+#: modules/devices/storage.c:117
+msgid "Spin Buzz"
+msgstr ""
+
+#: modules/devices/storage.c:118
+msgid "Offline Seek Performance"
+msgstr ""
+
+#: modules/devices/storage.c:119
+msgid "Disk Shift"
+msgstr ""
+
+#: modules/devices/storage.c:120
+msgid "G-Sense Error Rate"
+msgstr ""
+
+#: modules/devices/storage.c:121
+msgid "Loaded Hours"
+msgstr ""
+
+#: modules/devices/storage.c:122
+msgid "Load/Unload Retry Count"
+msgstr ""
+
+#: modules/devices/storage.c:123
+msgid "Load Friction"
+msgstr ""
+
+#: modules/devices/storage.c:124
+msgid "Load/Unload Cycle Count"
+msgstr ""
+
+#: modules/devices/storage.c:125
+msgid "Load-in time"
+msgstr ""
+
+#: modules/devices/storage.c:126
+msgid "Torque Amplification Count"
+msgstr ""
+
+#: modules/devices/storage.c:127
+msgid "Power-Off Retract Count"
+msgstr ""
+
+#: modules/devices/storage.c:128
+msgid "GMR Head Amplitude"
+msgstr ""
+
+#: modules/devices/storage.c:130
+msgid "Endurance Remaining"
+msgstr ""
+
+#: modules/devices/storage.c:132
+msgid "Good Block Rate"
+msgstr ""
+
+#: modules/devices/storage.c:133
+msgid "Head Flying Hours"
+msgstr ""
+
+#: modules/devices/storage.c:134
+msgid "Read Error Retry Rate"
+msgstr ""
+
+#: modules/devices/storage.c:135
+msgid "Total LBAs Written"
+msgstr ""
+
+#: modules/devices/storage.c:136
+msgid "Total LBAs Read"
+msgstr ""
+
+#: modules/devices/storage.c:141
 msgid ""
 "\n"
 "[UDisks2]\n"
@@ -3635,35 +3998,35 @@ msgstr ""
 "\n"
 "[UDisks2]\n"
 
-#: modules/devices/storage.c:138
+#: modules/devices/storage.c:199
 msgid "Removable"
 msgstr "Removível"
 
-#: modules/devices/storage.c:138
+#: modules/devices/storage.c:199
 msgid "Fixed"
 msgstr "Fixo"
 
-#: modules/devices/storage.c:141
+#: modules/devices/storage.c:202
 msgid "Ejectable"
 msgstr "Ejetável"
 
-#: modules/devices/storage.c:144
+#: modules/devices/storage.c:205
 msgid "Self-monitoring (S.M.A.R.T.)"
 msgstr "Monitoramento automático (S.M.A.R.T.)"
 
-#: modules/devices/storage.c:147 modules/devices/x86/processor.c:663
+#: modules/devices/storage.c:208 modules/devices/x86/processor.c:663
 msgid "Power Management"
 msgstr "Gerenciamento de energia"
 
-#: modules/devices/storage.c:150
+#: modules/devices/storage.c:211
 msgid "Advanced Power Management"
 msgstr "Gerenciamento avançando de energia"
 
-#: modules/devices/storage.c:153
+#: modules/devices/storage.c:214
 msgid "Automatic Acoustic Management"
 msgstr "Gerenciamento acústico automático"
 
-#: modules/devices/storage.c:156
+#: modules/devices/storage.c:217
 #, c-format
 msgid ""
 "[Drive Information]\n"
@@ -3672,13 +4035,13 @@ msgstr ""
 "[Informação do dispositivo]\n"
 "Modelo=%s\n"
 
-#: modules/devices/storage.c:160 modules/devices/storage.c:347
-#: modules/devices/storage.c:546
+#: modules/devices/storage.c:221 modules/devices/storage.c:449
+#: modules/devices/storage.c:648
 #, c-format
 msgid "Vendor=%s\n"
 msgstr "Fornecedor=%s\n"
 
-#: modules/devices/storage.c:165
+#: modules/devices/storage.c:226
 #, c-format
 msgid ""
 "Revision=%s\n"
@@ -3688,12 +4051,12 @@ msgid ""
 "Features=%s\n"
 msgstr ""
 
-#: modules/devices/storage.c:179
+#: modules/devices/storage.c:240
 #, c-format
 msgid "Rotation Rate=%d RPM\n"
 msgstr ""
 
-#: modules/devices/storage.c:182
+#: modules/devices/storage.c:243
 #, c-format
 msgid ""
 "Media=%s\n"
@@ -3702,12 +4065,12 @@ msgstr ""
 "Mídia=%s\n"
 "Compatibilidade da mídia=%s\n"
 
-#: modules/devices/storage.c:189
+#: modules/devices/storage.c:250
 #, c-format
 msgid "Connection bus=%s\n"
 msgstr ""
 
-#: modules/devices/storage.c:192
+#: modules/devices/storage.c:253
 #, c-format
 msgid ""
 "[Self-monitoring (S.M.A.R.T.)]\n"
@@ -3717,15 +4080,26 @@ msgid ""
 "Temperature=%d°C\n"
 msgstr ""
 
-#: modules/devices/storage.c:198
+#: modules/devices/storage.c:259
 msgid "Failing"
 msgstr ""
 
-#: modules/devices/storage.c:198
+#: modules/devices/storage.c:259
 msgid "OK"
 msgstr "OK"
 
-#: modules/devices/storage.c:204
+#: modules/devices/storage.c:265
+msgid ""
+"[S.M.A.R.T. Attributes]\n"
+"Attribute=Normalized Value / Worst / Threshold\n"
+msgstr ""
+
+#: modules/devices/storage.c:297
+#, c-format
+msgid "(%d) %s=%s\n"
+msgstr ""
+
+#: modules/devices/storage.c:306
 #, c-format
 msgid ""
 "[Partition table]\n"
@@ -3734,12 +4108,12 @@ msgstr ""
 "[Tabela de partição]\n"
 "Tipo=%s\n"
 
-#: modules/devices/storage.c:223
+#: modules/devices/storage.c:325
 #, c-format
 msgid "Partition %s=%s\n"
 msgstr "Partição %s=%s\n"
 
-#: modules/devices/storage.c:273
+#: modules/devices/storage.c:375
 msgid ""
 "\n"
 "[SCSI Disks]\n"
@@ -3747,7 +4121,7 @@ msgstr ""
 "\n"
 "[SCSI Discos]\n"
 
-#: modules/devices/storage.c:344 modules/devices/storage.c:543
+#: modules/devices/storage.c:446 modules/devices/storage.c:645
 #, c-format
 msgid ""
 "[Device Information]\n"
@@ -3756,7 +4130,7 @@ msgstr ""
 "[Informação de dispositivo]\n"
 "Modelo=%s\n"
 
-#: modules/devices/storage.c:351
+#: modules/devices/storage.c:453
 #, c-format
 msgid ""
 "Type=%s\n"
@@ -3775,7 +4149,7 @@ msgstr ""
 "ID=%d\n"
 "LUN=%d\n"
 
-#: modules/devices/storage.c:397
+#: modules/devices/storage.c:499
 msgid ""
 "\n"
 "[IDE Disks]\n"
@@ -3783,12 +4157,12 @@ msgstr ""
 "\n"
 "[IDE Discos]\n"
 
-#: modules/devices/storage.c:480
+#: modules/devices/storage.c:582
 #, c-format
 msgid "Driver=%s\n"
 msgstr "Driver=%s\n"
 
-#: modules/devices/storage.c:548
+#: modules/devices/storage.c:650
 #, c-format
 msgid ""
 "Device Name=hd%c\n"
@@ -3799,7 +4173,7 @@ msgstr ""
 "mídia=%s\n"
 "Cache=%dkb\n"
 
-#: modules/devices/storage.c:558
+#: modules/devices/storage.c:660
 #, c-format
 msgid ""
 "[Geometry]\n"
@@ -3810,7 +4184,7 @@ msgstr ""
 "Físico=%s\n"
 "Lógico=%s\n"
 
-#: modules/devices/storage.c:568
+#: modules/devices/storage.c:670
 #, c-format
 msgid ""
 "[Capabilities]\n"
@@ -3819,7 +4193,7 @@ msgstr ""
 "[Capacidades]\n"
 "%s"
 
-#: modules/devices/storage.c:575
+#: modules/devices/storage.c:677
 #, c-format
 msgid ""
 "[Speeds]\n"
@@ -3827,11 +4201,6 @@ msgid ""
 msgstr ""
 "[Velocidades]\n"
 "%s"
-
-#: modules/devices/usb.c:132 modules/network.c:310 modules/network.c:363
-#: modules/network.c:380
-msgid "Interface"
-msgstr "Interface"
 
 #: modules/devices/usb.c:134 modules/devices/usb.c:175
 msgid "Sub-class"
@@ -4081,8 +4450,8 @@ msgid ""
 "Debug Store (buffer for debugging and profiling instructions), or "
 "alternately: digital thermal sensor"
 msgstr ""
-"Armazenamento de Depuração (buffer para instruções de depuração e criação de"
-" perfil) ou alternativamente: sensor térmico digital"
+"Armazenamento de Depuração (buffer para instruções de depuração e criação de "
+"perfil) ou alternativamente: sensor térmico digital"
 
 #. /flag:acpi
 #: modules/devices/x86/x86_data.c:63
@@ -4378,8 +4747,8 @@ msgid ""
 "Perform a Carry-Less Multiplication of Quadword instruction - accelerator "
 "for GCM)"
 msgstr ""
-"Executar uma multiplicação sem carga do acelerador de instruções do Quadword"
-" para o GCM)"
+"Executar uma multiplicação sem carga do acelerador de instruções do Quadword "
+"para o GCM)"
 
 #. /flag:dtes64
 #: modules/devices/x86/x86_data.c:116
@@ -4505,8 +4874,8 @@ msgstr "Mover dados após a instrução troca de Bytes"
 #: modules/devices/x86/x86_data.c:136
 msgctxt "x86-flag"
 msgid ""
-"Return the Count of Number of Bits Set to 1 instruction (Hamming weight, "
-"i.e. bit count)"
+"Return the Count of Number of Bits Set to 1 instruction (Hamming weight, i."
+"e. bit count)"
 msgstr ""
 "Retorna a Contagem do Número de Bits Definido como 1 instrução (peso "
 "Hamming, ou seja, contagem de bits)"
@@ -5738,3 +6107,21 @@ msgstr "(Não configurado)"
 #: modules/network/net.c:474
 msgid "Broadcast Address"
 msgstr "Endereço de transmissão"
+
+#~ msgid "#SysBench CPU (Four threads)"
+#~ msgstr "#SysBench CPU (4 processamentos)"
+
+#~ msgid "#SysBench Memory (Single-thread)"
+#~ msgstr "#SysBench Memória (Processamento unitário)"
+
+#~ msgid "#SysBench Memory (Two threads)"
+#~ msgstr "#SysBench Memória (2 Processamentos)"
+
+#~ msgid "#Revision"
+#~ msgstr "#Revisão"
+
+#~ msgid "#Extra"
+#~ msgstr "#Extra"
+
+#~ msgid "#User Note"
+#~ msgstr "#Nota de usuário"

--- a/po/ru.po
+++ b/po/ru.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: hardinfo\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-08-28 18:26+0300\n"
+"POT-Creation-Date: 2019-10-24 15:16-0500\n"
 "PO-Revision-Date: \n"
 "Last-Translator: Sergey Rodin <rodin.s@rambler.ru>\n"
 "Language-Team: \n"
@@ -525,7 +525,7 @@ msgstr "Неизвестно, что делать. Выход."
 
 #: hardinfo/usb_util.c:290 modules/devices/devicetree.c:91
 #: modules/devices/devicetree.c:92 modules/devices/monitors.c:407
-#: modules/devices/storage.c:185
+#: modules/devices/storage.c:246
 msgid "(None)"
 msgstr "(Нет)"
 
@@ -902,51 +902,51 @@ msgstr "Управляет боковой панелью"
 msgid "_Toolbar"
 msgstr "_Панель инструментов"
 
-#: shell/report.c:724 shell/report.c:732
+#: shell/report.c:769 shell/report.c:777
 msgid "Save File"
 msgstr "Сохранить файл"
 
-#: shell/report.c:727 shell/report.c:1198 shell/syncmanager.c:748
+#: shell/report.c:772 shell/report.c:1243 shell/syncmanager.c:748
 msgid "_Cancel"
 msgstr "_Отмена"
 
-#: shell/report.c:729
+#: shell/report.c:774
 msgid "_Save"
 msgstr "_Сохранить"
 
-#: shell/report.c:898
+#: shell/report.c:943
 msgid "Cannot create ReportContext. Programming bug?"
 msgstr "Не могу создать ReportContext. Ошибка программирования?"
 
-#: shell/report.c:917
+#: shell/report.c:962
 msgid "Open the report with your web browser?"
 msgstr "Открыть отчёт в веб-браузере?"
 
-#: shell/report.c:920
+#: shell/report.c:965
 msgid "_No"
 msgstr "_Нет"
 
-#: shell/report.c:921
+#: shell/report.c:966
 msgid "_Open"
 msgstr "_Открыть"
 
-#: shell/report.c:951
+#: shell/report.c:996
 msgid "Generating report..."
 msgstr "Создаётся отчёт..."
 
-#: shell/report.c:961
+#: shell/report.c:1006
 msgid "Report saved."
 msgstr "Отчёт сохранён."
 
-#: shell/report.c:963
+#: shell/report.c:1008
 msgid "Error while creating the report."
 msgstr "Ошибка во время создания отчёта."
 
-#: shell/report.c:1065
+#: shell/report.c:1110
 msgid "Generate Report"
 msgstr "Создать отчёт"
 
-#: shell/report.c:1090
+#: shell/report.c:1135
 msgid ""
 "<big><b>Generate Report</b></big>\n"
 "Please choose the information that you wish to view in your report:"
@@ -954,15 +954,15 @@ msgstr ""
 "<big><b>Создать отчёт</b></big>\n"
 "Пожалуйста, выберите информацию для отображения в отчёте:"
 
-#: shell/report.c:1162
+#: shell/report.c:1207
 msgid "Select _None"
 msgstr "Выбор: нет"
 
-#: shell/report.c:1173
+#: shell/report.c:1218
 msgid "Select _All"
 msgstr "Выбор: все"
 
-#: shell/report.c:1208
+#: shell/report.c:1253
 msgid "_Generate"
 msgstr "_Сгенерировать"
 
@@ -1122,15 +1122,15 @@ msgid "SysBench CPU (Multi-thread)"
 msgstr "SysBench CPU (многопоточный)"
 
 #: modules/benchmark/benches.c:104
-msgid "#SysBench CPU (Four threads)"
+msgid "SysBench CPU (Four threads)"
 msgstr ""
 
 #: modules/benchmark/benches.c:106
-msgid "#SysBench Memory (Single-thread)"
+msgid "SysBench Memory (Single-thread)"
 msgstr ""
 
 #: modules/benchmark/benches.c:108
-msgid "#SysBench Memory (Two threads)"
+msgid "SysBench Memory (Two threads)"
 msgstr ""
 
 #: modules/benchmark/benches.c:110
@@ -1198,12 +1198,12 @@ msgstr "Результат в секундах. Чем ниже, тем лучш
 #: modules/devices/spd-decode.c:306 modules/devices/spd-decode.c:307
 #: modules/devices/spd-decode.c:310 modules/devices/spd-decode.c:311
 #: modules/devices/spd-decode.c:914 modules/devices/spd-decode.c:915
-#: modules/devices/storage.c:186 modules/devices/storage.c:207
+#: modules/devices/storage.c:247 modules/devices/storage.c:309
 #: modules/devices/usb.c:28 modules/network/net.c:437 includes/cpu_util.h:11
 msgid "(Unknown)"
 msgstr "(Неизвестно)"
 
-#: modules/benchmark/bench_results.c:48 modules/benchmark/bench_results.c:326
+#: modules/benchmark/bench_results.c:49 modules/benchmark/bench_results.c:330
 #: modules/devices/alpha/processor.c:90 modules/devices/arm/processor.c:290
 #: modules/devices/arm/processor.c:303 modules/devices/arm/processor.c:345
 #: modules/devices/arm/processor.c:500 modules/devices.c:325
@@ -1223,58 +1223,51 @@ msgstr "(Неизвестно)"
 msgid "MHz"
 msgstr "МГц"
 
-#: modules/benchmark/bench_results.c:391 modules/benchmark/bench_results.c:481
+#: modules/benchmark/bench_results.c:396 modules/benchmark/bench_results.c:495
 msgid "kiB"
 msgstr "КиБ"
 
-#: modules/benchmark/bench_results.c:413 modules/benchmark/bench_results.c:463
+#: modules/benchmark/bench_results.c:403 modules/benchmark/bench_results.c:453
+#, c-format
+msgid "%d-bit"
+msgstr ""
+
+#: modules/benchmark/bench_results.c:422 modules/benchmark/bench_results.c:477
 msgid "Benchmark Result"
 msgstr "Результат теста"
 
-#: modules/benchmark/bench_results.c:414 modules/benchmark/bench_results.c:465
+#: modules/benchmark/bench_results.c:423 modules/benchmark/bench_results.c:479
 msgid "Threads"
 msgstr "Потоки"
 
-#: modules/benchmark/bench_results.c:415 modules/benchmark/bench_results.c:467
+#: modules/benchmark/bench_results.c:424 modules/benchmark/bench_results.c:481
 msgid "Elapsed Time"
 msgstr "Затраченное время"
 
-#: modules/benchmark/bench_results.c:415 modules/benchmark/bench_results.c:467
+#: modules/benchmark/bench_results.c:424 modules/benchmark/bench_results.c:481
 msgid "seconds"
 msgstr "секунд"
 
-#: modules/benchmark/bench_results.c:416 modules/computer/languages.c:101
+#: modules/benchmark/bench_results.c:425 modules/computer/languages.c:101
 #: modules/devices/arm/processor.c:355 modules/devices/gpu.c:147
 #: modules/devices/ia64/processor.c:166 modules/devices/pci.c:132
 #: modules/devices/ppc/processor.c:159
 msgid "Revision"
 msgstr "Ревизия"
 
-#: modules/benchmark/bench_results.c:416
-msgid "#Revision"
-msgstr ""
-
-#: modules/benchmark/bench_results.c:417 modules/benchmark/bench_results.c:468
+#: modules/benchmark/bench_results.c:426 modules/benchmark/bench_results.c:482
 msgid "Extra Information"
 msgstr "Дополнительная информация"
 
-#: modules/benchmark/bench_results.c:417 modules/benchmark/bench_results.c:468
-msgid "#Extra"
-msgstr ""
-
-#: modules/benchmark/bench_results.c:418 modules/benchmark/bench_results.c:469
+#: modules/benchmark/bench_results.c:427 modules/benchmark/bench_results.c:483
 msgid "User Note"
 msgstr ""
 
-#: modules/benchmark/bench_results.c:418 modules/benchmark/bench_results.c:469
-msgid "#User Note"
-msgstr ""
-
-#: modules/benchmark/bench_results.c:420 modules/benchmark/bench_results.c:471
+#: modules/benchmark/bench_results.c:429 modules/benchmark/bench_results.c:485
 msgid "Note"
 msgstr "Примечание"
 
-#: modules/benchmark/bench_results.c:421 modules/benchmark/bench_results.c:472
+#: modules/benchmark/bench_results.c:430 modules/benchmark/bench_results.c:486
 msgid ""
 "This result is from an old version of HardInfo. Results might not be "
 "comparable to current version. Some details are missing."
@@ -1283,67 +1276,71 @@ msgstr ""
 "быть несопоставим с результатом текущей версии, поскольку отсутствуют "
 "некоторые подробности."
 
-#: modules/benchmark/bench_results.c:422 modules/benchmark/bench_results.c:473
+#: modules/benchmark/bench_results.c:431 modules/benchmark/bench_results.c:487
 #: modules/devices/devicetree/pmac_data.c:81 modules/devices/sh/processor.c:85
 msgid "Machine"
 msgstr "Машина"
 
-#: modules/benchmark/bench_results.c:423 modules/benchmark/bench_results.c:474
+#: modules/benchmark/bench_results.c:432 modules/benchmark/bench_results.c:488
 #: modules/devices/devicetree.c:208 modules/devices/dmi.c:47
 msgid "Board"
 msgstr "Плата"
 
-#: modules/benchmark/bench_results.c:424 modules/benchmark/bench_results.c:475
+#: modules/benchmark/bench_results.c:433 modules/benchmark/bench_results.c:489
 msgid "CPU Name"
 msgstr "Название процессора"
 
-#: modules/benchmark/bench_results.c:425 modules/benchmark/bench_results.c:476
+#: modules/benchmark/bench_results.c:434 modules/benchmark/bench_results.c:490
 msgid "CPU Description"
 msgstr "Описание процессора"
 
-#: modules/benchmark/bench_results.c:426 modules/benchmark/bench_results.c:477
+#: modules/benchmark/bench_results.c:435 modules/benchmark/bench_results.c:491
 #: modules/benchmark.c:442
 msgid "CPU Config"
 msgstr "Конфигурация процессора"
 
-#: modules/benchmark/bench_results.c:427 modules/benchmark/bench_results.c:478
+#: modules/benchmark/bench_results.c:436 modules/benchmark/bench_results.c:492
 msgid "Threads Available"
 msgstr "Доступно потоков"
 
-#: modules/benchmark/bench_results.c:428 modules/benchmark/bench_results.c:479
+#: modules/benchmark/bench_results.c:437 modules/benchmark/bench_results.c:493
 msgid "GPU"
 msgstr "Графический процессор"
 
-#: modules/benchmark/bench_results.c:429 modules/benchmark/bench_results.c:480
+#: modules/benchmark/bench_results.c:438 modules/benchmark/bench_results.c:494
 #: modules/computer.c:542
 msgid "OpenGL Renderer"
 msgstr "Рендер OpenGL"
 
-#: modules/benchmark/bench_results.c:430 modules/benchmark/bench_results.c:481
+#: modules/benchmark/bench_results.c:439 modules/benchmark/bench_results.c:495
 #: modules/computer.c:123 modules/computer.c:531 modules/computer.c:1000
 #: modules/devices/gpu.c:150
 msgid "Memory"
 msgstr "Память"
 
-#: modules/benchmark/bench_results.c:464
+#: modules/benchmark/bench_results.c:440 modules/benchmark/bench_results.c:496
+msgid "Pointer Size"
+msgstr ""
+
+#: modules/benchmark/bench_results.c:478
 msgid "Benchmark"
 msgstr ""
 
-#: modules/benchmark/bench_results.c:466 modules/devices/dmi_memory.c:879
+#: modules/benchmark/bench_results.c:480 modules/devices/dmi_memory.c:879
 #: modules/devices/firmware.c:246 modules/devices/monitors.c:492
 #: modules/devices/x86/processor.c:691
 msgid "Result"
 msgstr "Результат"
 
-#: modules/benchmark/bench_results.c:483
+#: modules/benchmark/bench_results.c:498
 msgid "Handles"
 msgstr ""
 
-#: modules/benchmark/bench_results.c:484
+#: modules/benchmark/bench_results.c:499
 msgid "mid"
 msgstr ""
 
-#: modules/benchmark/bench_results.c:485
+#: modules/benchmark/bench_results.c:500
 msgid "cfg_val"
 msgstr ""
 
@@ -3787,41 +3784,241 @@ msgstr ""
 msgid "JEDEC Timings"
 msgstr ""
 
-#: modules/devices/storage.c:80
+#: modules/devices/storage.c:84
+msgid "Read Error Rate"
+msgstr ""
+
+#: modules/devices/storage.c:85
+msgid "Throughput Performance"
+msgstr ""
+
+#: modules/devices/storage.c:86
+msgid "Spin-Up Time"
+msgstr ""
+
+#: modules/devices/storage.c:87
+msgid "Start/Stop Count"
+msgstr ""
+
+#: modules/devices/storage.c:88
+msgid "Reallocated Sector Count"
+msgstr ""
+
+#: modules/devices/storage.c:89
+msgid "Read Channel Margin"
+msgstr ""
+
+#: modules/devices/storage.c:90
+msgid "Seek Error Rate"
+msgstr ""
+
+#: modules/devices/storage.c:91
+msgid "Seek Timer Performance"
+msgstr ""
+
+#: modules/devices/storage.c:92 modules/devices/storage.c:131
+msgid "Power-On Hours"
+msgstr ""
+
+#: modules/devices/storage.c:93
+msgid "Spin Retry Count"
+msgstr ""
+
+#: modules/devices/storage.c:94
+msgid "Calibration Retry Count"
+msgstr ""
+
+#: modules/devices/storage.c:95
+msgid "Power Cycle Count"
+msgstr ""
+
+#: modules/devices/storage.c:96 modules/devices/storage.c:113
+msgid "Soft Read Error Rate"
+msgstr ""
+
+#: modules/devices/storage.c:97
+msgid "Runtime Bad Block"
+msgstr ""
+
+#: modules/devices/storage.c:98
+msgid "End-to-End error"
+msgstr ""
+
+#: modules/devices/storage.c:99
+msgid "Reported Uncorrectable Errors"
+msgstr ""
+
+#: modules/devices/storage.c:100
+msgid "Command Timeout"
+msgstr ""
+
+#: modules/devices/storage.c:101
+msgid "High Fly Writes"
+msgstr ""
+
+#: modules/devices/storage.c:102
+msgid "Airflow Temperature"
+msgstr ""
+
+#: modules/devices/storage.c:103
+msgid "G-sense Error Rate"
+msgstr ""
+
+#: modules/devices/storage.c:104
+msgid "Power-off Retract Count"
+msgstr ""
+
+#: modules/devices/storage.c:105
+msgid "Load Cycle Count"
+msgstr ""
+
+#: modules/devices/storage.c:106 modules/devices/storage.c:129
+msgid "Temperature"
+msgstr ""
+
+#: modules/devices/storage.c:107
+msgid "Hardware ECC Recovered"
+msgstr ""
+
+#: modules/devices/storage.c:108
+msgid "Reallocation Event Count"
+msgstr ""
+
+#: modules/devices/storage.c:109
+msgid "Current Pending Sector Count"
+msgstr ""
+
+#: modules/devices/storage.c:110
+msgid "Uncorrectable Sector Count"
+msgstr ""
+
+#: modules/devices/storage.c:111
+msgid "UltraDMA CRC Error Count"
+msgstr ""
+
+#: modules/devices/storage.c:112
+msgid "Multi-Zone Error Rate"
+msgstr ""
+
+#: modules/devices/storage.c:114
+msgid "Run Out Cancel"
+msgstr ""
+
+#: modules/devices/storage.c:115
+msgid "Flying Height"
+msgstr ""
+
+#: modules/devices/storage.c:116
+msgid "Spin High Current"
+msgstr ""
+
+#: modules/devices/storage.c:117
+msgid "Spin Buzz"
+msgstr ""
+
+#: modules/devices/storage.c:118
+msgid "Offline Seek Performance"
+msgstr ""
+
+#: modules/devices/storage.c:119
+msgid "Disk Shift"
+msgstr ""
+
+#: modules/devices/storage.c:120
+msgid "G-Sense Error Rate"
+msgstr ""
+
+#: modules/devices/storage.c:121
+msgid "Loaded Hours"
+msgstr ""
+
+#: modules/devices/storage.c:122
+msgid "Load/Unload Retry Count"
+msgstr ""
+
+#: modules/devices/storage.c:123
+msgid "Load Friction"
+msgstr ""
+
+#: modules/devices/storage.c:124
+msgid "Load/Unload Cycle Count"
+msgstr ""
+
+#: modules/devices/storage.c:125
+msgid "Load-in time"
+msgstr ""
+
+#: modules/devices/storage.c:126
+msgid "Torque Amplification Count"
+msgstr ""
+
+#: modules/devices/storage.c:127
+msgid "Power-Off Retract Count"
+msgstr ""
+
+#: modules/devices/storage.c:128
+msgid "GMR Head Amplitude"
+msgstr ""
+
+#: modules/devices/storage.c:130
+msgid "Endurance Remaining"
+msgstr ""
+
+#: modules/devices/storage.c:132
+msgid "Good Block Rate"
+msgstr ""
+
+#: modules/devices/storage.c:133
+msgid "Head Flying Hours"
+msgstr ""
+
+#: modules/devices/storage.c:134
+msgid "Read Error Retry Rate"
+msgstr ""
+
+#: modules/devices/storage.c:135
+msgid "Total LBAs Written"
+msgstr ""
+
+#: modules/devices/storage.c:136
+msgid "Total LBAs Read"
+msgstr ""
+
+#: modules/devices/storage.c:141
 msgid ""
 "\n"
 "[UDisks2]\n"
 msgstr ""
 
-#: modules/devices/storage.c:138
+#: modules/devices/storage.c:199
 msgid "Removable"
 msgstr "Съемное"
 
-#: modules/devices/storage.c:138
+#: modules/devices/storage.c:199
 msgid "Fixed"
 msgstr "Фиксированное"
 
-#: modules/devices/storage.c:141
+#: modules/devices/storage.c:202
 msgid "Ejectable"
 msgstr "Сменное"
 
-#: modules/devices/storage.c:144
+#: modules/devices/storage.c:205
 msgid "Self-monitoring (S.M.A.R.T.)"
 msgstr "Мониторинг (S.M.A.R.T.)"
 
-#: modules/devices/storage.c:147 modules/devices/x86/processor.c:663
+#: modules/devices/storage.c:208 modules/devices/x86/processor.c:663
 msgid "Power Management"
 msgstr "Управление питанием"
 
-#: modules/devices/storage.c:150
+#: modules/devices/storage.c:211
 msgid "Advanced Power Management"
 msgstr "Расширенное управление питанием"
 
-#: modules/devices/storage.c:153
+#: modules/devices/storage.c:214
 msgid "Automatic Acoustic Management"
 msgstr "Автоматическое управление шумом"
 
-#: modules/devices/storage.c:156
+#: modules/devices/storage.c:217
 #, c-format
 msgid ""
 "[Drive Information]\n"
@@ -3830,13 +4027,13 @@ msgstr ""
 "[Информация о диске]\n"
 "Модель=%s\n"
 
-#: modules/devices/storage.c:160 modules/devices/storage.c:347
-#: modules/devices/storage.c:546
+#: modules/devices/storage.c:221 modules/devices/storage.c:449
+#: modules/devices/storage.c:648
 #, c-format
 msgid "Vendor=%s\n"
 msgstr "Поставщик=%s\n"
 
-#: modules/devices/storage.c:165
+#: modules/devices/storage.c:226
 #, c-format
 msgid ""
 "Revision=%s\n"
@@ -3851,12 +4048,12 @@ msgstr ""
 "Размер=%s\n"
 "Возможности=%s\n"
 
-#: modules/devices/storage.c:179
+#: modules/devices/storage.c:240
 #, c-format
 msgid "Rotation Rate=%d RPM\n"
 msgstr "Скорость вращения=%d об/мин\n"
 
-#: modules/devices/storage.c:182
+#: modules/devices/storage.c:243
 #, c-format
 msgid ""
 "Media=%s\n"
@@ -3865,12 +4062,12 @@ msgstr ""
 "Медиа=%s\n"
 "Совместимость с медиа=%s\n"
 
-#: modules/devices/storage.c:189
+#: modules/devices/storage.c:250
 #, c-format
 msgid "Connection bus=%s\n"
 msgstr ""
 
-#: modules/devices/storage.c:192
+#: modules/devices/storage.c:253
 #, c-format
 msgid ""
 "[Self-monitoring (S.M.A.R.T.)]\n"
@@ -3880,15 +4077,26 @@ msgid ""
 "Temperature=%d°C\n"
 msgstr ""
 
-#: modules/devices/storage.c:198
+#: modules/devices/storage.c:259
 msgid "Failing"
 msgstr ""
 
-#: modules/devices/storage.c:198
+#: modules/devices/storage.c:259
 msgid "OK"
 msgstr ""
 
-#: modules/devices/storage.c:204
+#: modules/devices/storage.c:265
+msgid ""
+"[S.M.A.R.T. Attributes]\n"
+"Attribute=Normalized Value / Worst / Threshold\n"
+msgstr ""
+
+#: modules/devices/storage.c:297
+#, c-format
+msgid "(%d) %s=%s\n"
+msgstr ""
+
+#: modules/devices/storage.c:306
 #, c-format
 msgid ""
 "[Partition table]\n"
@@ -3897,12 +4105,12 @@ msgstr ""
 "[Таблица разделов]\n"
 "Тип=%s\n"
 
-#: modules/devices/storage.c:223
+#: modules/devices/storage.c:325
 #, c-format
 msgid "Partition %s=%s\n"
 msgstr "Раздел %s=%s\n"
 
-#: modules/devices/storage.c:273
+#: modules/devices/storage.c:375
 msgid ""
 "\n"
 "[SCSI Disks]\n"
@@ -3910,7 +4118,7 @@ msgstr ""
 "\n"
 "[SCSI диски]\n"
 
-#: modules/devices/storage.c:344 modules/devices/storage.c:543
+#: modules/devices/storage.c:446 modules/devices/storage.c:645
 #, c-format
 msgid ""
 "[Device Information]\n"
@@ -3919,7 +4127,7 @@ msgstr ""
 "[Информация об устройстве]\n"
 "Модель=%s\n"
 
-#: modules/devices/storage.c:351
+#: modules/devices/storage.c:453
 #, c-format
 msgid ""
 "Type=%s\n"
@@ -3931,7 +4139,7 @@ msgid ""
 "LUN=%d\n"
 msgstr ""
 
-#: modules/devices/storage.c:397
+#: modules/devices/storage.c:499
 msgid ""
 "\n"
 "[IDE Disks]\n"
@@ -3939,12 +4147,12 @@ msgstr ""
 "\n"
 "[IDE диски]\n"
 
-#: modules/devices/storage.c:480
+#: modules/devices/storage.c:582
 #, c-format
 msgid "Driver=%s\n"
 msgstr "Драйвер=%s\n"
 
-#: modules/devices/storage.c:548
+#: modules/devices/storage.c:650
 #, c-format
 msgid ""
 "Device Name=hd%c\n"
@@ -3955,7 +4163,7 @@ msgstr ""
 "Медиа=%s\n"
 "Кэш=%d кБ\n"
 
-#: modules/devices/storage.c:558
+#: modules/devices/storage.c:660
 #, c-format
 msgid ""
 "[Geometry]\n"
@@ -3966,7 +4174,7 @@ msgstr ""
 "Физическая=%s\n"
 "Логическая=%s\n"
 
-#: modules/devices/storage.c:568
+#: modules/devices/storage.c:670
 #, c-format
 msgid ""
 "[Capabilities]\n"
@@ -3975,7 +4183,7 @@ msgstr ""
 "[Возможности]\n"
 "%s"
 
-#: modules/devices/storage.c:575
+#: modules/devices/storage.c:677
 #, c-format
 msgid ""
 "[Speeds]\n"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: hardinfo\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-06-22 16:35+0800\n"
+"POT-Creation-Date: 2019-10-24 15:16-0500\n"
 "PO-Revision-Date: 2018-06-22 16:23+0800\n"
 "Last-Translator: yetist <yetist@gmail.com>\n"
 "Language-Team: Chinese\n"
@@ -28,19 +28,20 @@ msgstr "小端序"
 msgid "Big Endian"
 msgstr "大端序"
 
-#: hardinfo/cpu_util.c:184 hardinfo/cpu_util.c:195
+#: hardinfo/cpu_util.c:184 hardinfo/cpu_util.c:195 modules/devices/gpu.c:200
 msgid "Frequency Scaling"
 msgstr ""
 
-#: hardinfo/cpu_util.c:185
+#: hardinfo/cpu_util.c:185 modules/devices/gpu.c:201
 msgid "Minimum"
 msgstr "最小值"
 
 #: hardinfo/cpu_util.c:185 hardinfo/cpu_util.c:186 hardinfo/cpu_util.c:187
+#: hardinfo/dt_util.c:589 modules/devices/gpu.c:201 modules/devices/gpu.c:202
 msgid "kHz"
 msgstr "kHz"
 
-#: hardinfo/cpu_util.c:186
+#: hardinfo/cpu_util.c:186 modules/devices/gpu.c:202
 msgid "Maximum"
 msgstr "最大值"
 
@@ -48,11 +49,11 @@ msgstr "最大值"
 msgid "Current"
 msgstr "当前设置"
 
-#: hardinfo/cpu_util.c:188
+#: hardinfo/cpu_util.c:188 modules/devices/gpu.c:203
 msgid "Transition Latency"
 msgstr ""
 
-#: hardinfo/cpu_util.c:188
+#: hardinfo/cpu_util.c:188 modules/devices/gpu.c:203
 msgid "ns"
 msgstr "ns"
 
@@ -60,13 +61,13 @@ msgstr "ns"
 msgid "Governor"
 msgstr ""
 
-#: hardinfo/cpu_util.c:190 hardinfo/cpu_util.c:196 modules/devices/gpu.c:149
-#: modules/devices/pci.c:116
+#: hardinfo/cpu_util.c:190 hardinfo/cpu_util.c:196 modules/devices/gpu.c:153
+#: modules/devices/pci.c:134 modules/devices/usb.c:136
 msgid "Driver"
 msgstr "驱动"
 
-#: hardinfo/cpu_util.c:202 modules/computer.c:596
-#: modules/devices/arm/processor.c:242 modules/devices/x86/processor.c:284
+#: hardinfo/cpu_util.c:202 modules/computer.c:737
+#: modules/devices/arm/processor.c:256 modules/devices/x86/processor.c:284
 #: modules/devices/x86/processor.c:388 modules/devices/x86/processor.c:524
 msgid "(Not Available)"
 msgstr ""
@@ -75,7 +76,8 @@ msgstr ""
 msgid "Socket"
 msgstr "套接字"
 
-#: hardinfo/cpu_util.c:215 hardinfo/cpu_util.c:217
+#: hardinfo/cpu_util.c:215 hardinfo/cpu_util.c:217 modules/devices/gpu.c:149
+#: modules/devices/gpu.c:227
 msgid "Core"
 msgstr "核心"
 
@@ -87,8 +89,8 @@ msgstr ""
 msgid "Drawer"
 msgstr ""
 
-#: hardinfo/cpu_util.c:228 modules/devices/arm/processor.c:449
-#: modules/devices/x86/processor.c:697
+#: hardinfo/cpu_util.c:228 modules/devices/arm/processor.c:471
+#: modules/devices/x86/processor.c:750
 msgid "Topology"
 msgstr ""
 
@@ -96,112 +98,336 @@ msgstr ""
 msgid "ID"
 msgstr "ID"
 
-#: hardinfo/dmi_util.c:130
+#: hardinfo/dmi_util.c:25
+msgid "BIOS Information"
+msgstr ""
+
+#: hardinfo/dmi_util.c:26 modules/devices/parisc/processor.c:157
+msgid "System"
+msgstr "系统"
+
+#: hardinfo/dmi_util.c:27
+msgid "Base Board"
+msgstr ""
+
+#: hardinfo/dmi_util.c:28 modules/devices/dmi.c:53
+msgid "Chassis"
+msgstr ""
+
+#: hardinfo/dmi_util.c:29 modules/computer.c:529 modules/computer.c:1000
+#: modules/devices/alpha/processor.c:87 modules/devices/arm/processor.c:341
+#: modules/devices.c:99 modules/devices/ia64/processor.c:159
+#: modules/devices/m68k/processor.c:83 modules/devices/mips/processor.c:74
+#: modules/devices/parisc/processor.c:154 modules/devices/ppc/processor.c:157
+#: modules/devices/riscv/processor.c:181 modules/devices/s390/processor.c:131
+#: modules/devices/sh/processor.c:83 modules/devices/sparc/processor.c:74
+#: modules/devices/x86/processor.c:646
+msgid "Processor"
+msgstr "处理器"
+
+#: hardinfo/dmi_util.c:30
+msgid "Memory Controller"
+msgstr ""
+
+#: hardinfo/dmi_util.c:31
+msgid "Memory Module"
+msgstr ""
+
+#: hardinfo/dmi_util.c:32 modules/devices/parisc/processor.c:163
+#: modules/devices/x86/processor.c:662
+msgid "Cache"
+msgstr "缓存"
+
+#: hardinfo/dmi_util.c:33
+msgid "Port Connector"
+msgstr ""
+
+#: hardinfo/dmi_util.c:34
+msgid "System Slots"
+msgstr ""
+
+#: hardinfo/dmi_util.c:35
+msgid "On Board Devices"
+msgstr ""
+
+#: hardinfo/dmi_util.c:36
+msgid "OEM Strings"
+msgstr ""
+
+#: hardinfo/dmi_util.c:37
+msgid "System Configuration Options"
+msgstr ""
+
+#: hardinfo/dmi_util.c:38
+msgid "BIOS Language"
+msgstr ""
+
+#: hardinfo/dmi_util.c:39
+msgid "Group Associations"
+msgstr ""
+
+#: hardinfo/dmi_util.c:40
+msgid "System Event Log"
+msgstr ""
+
+#: hardinfo/dmi_util.c:41
+msgid "Physical Memory Array"
+msgstr ""
+
+#: hardinfo/dmi_util.c:42
+msgid "Memory Device"
+msgstr ""
+
+#: hardinfo/dmi_util.c:43
+msgid "32-bit Memory Error"
+msgstr ""
+
+#: hardinfo/dmi_util.c:44
+msgid "Memory Array Mapped Address"
+msgstr ""
+
+#: hardinfo/dmi_util.c:45
+msgid "Memory Device Mapped Address"
+msgstr ""
+
+#: hardinfo/dmi_util.c:46
+msgid "Built-in Pointing Device"
+msgstr ""
+
+#: hardinfo/dmi_util.c:47
+msgid "Portable Battery"
+msgstr ""
+
+#: hardinfo/dmi_util.c:48
+msgid "System Reset"
+msgstr ""
+
+#: hardinfo/dmi_util.c:49
+msgid "Hardware Security"
+msgstr ""
+
+#: hardinfo/dmi_util.c:50
+msgid "System Power Controls"
+msgstr ""
+
+#: hardinfo/dmi_util.c:51
+msgid "Voltage Probe"
+msgstr ""
+
+#: hardinfo/dmi_util.c:52
+msgid "Cooling Device"
+msgstr ""
+
+#: hardinfo/dmi_util.c:53
+msgid "Temperature Probe"
+msgstr ""
+
+#: hardinfo/dmi_util.c:54
+msgid "Electrical Current Probe"
+msgstr ""
+
+#: hardinfo/dmi_util.c:55
+msgid "Out-of-band Remote Access"
+msgstr ""
+
+#: hardinfo/dmi_util.c:56
+msgid "Boot Integrity Services"
+msgstr ""
+
+#: hardinfo/dmi_util.c:57
+msgid "System Boot"
+msgstr ""
+
+#: hardinfo/dmi_util.c:58
+msgid "64-bit Memory Error"
+msgstr ""
+
+#: hardinfo/dmi_util.c:59
+msgid "Management Device"
+msgstr ""
+
+#: hardinfo/dmi_util.c:60
+msgid "Management Device Component"
+msgstr ""
+
+#: hardinfo/dmi_util.c:61
+msgid "Management Device Threshold Data"
+msgstr ""
+
+#: hardinfo/dmi_util.c:62
+msgid "Memory Channel"
+msgstr ""
+
+#: hardinfo/dmi_util.c:63
+msgid "IPMI Device"
+msgstr ""
+
+#: hardinfo/dmi_util.c:64
+msgid "Power Supply"
+msgstr ""
+
+#: hardinfo/dmi_util.c:65
+msgid "Additional Information"
+msgstr ""
+
+#: hardinfo/dmi_util.c:66
+msgid "Onboard Device"
+msgstr ""
+
+#: hardinfo/dmi_util.c:226
 msgid "Invalid chassis type (0)"
 msgstr ""
 
-#: hardinfo/dmi_util.c:131 hardinfo/dmi_util.c:132
+#: hardinfo/dmi_util.c:227 hardinfo/dmi_util.c:228
 msgid "Unknown chassis type"
 msgstr ""
 
-#: hardinfo/dmi_util.c:133
+#: hardinfo/dmi_util.c:229
 msgid "Desktop"
 msgstr "桌面"
 
-#: hardinfo/dmi_util.c:134
+#: hardinfo/dmi_util.c:230
 msgid "Low-profile Desktop"
 msgstr ""
 
-#: hardinfo/dmi_util.c:135
+#: hardinfo/dmi_util.c:231
 msgid "Pizza Box"
 msgstr ""
 
-#: hardinfo/dmi_util.c:136
+#: hardinfo/dmi_util.c:232
 msgid "Mini Tower"
 msgstr ""
 
-#: hardinfo/dmi_util.c:137
+#: hardinfo/dmi_util.c:233
 msgid "Tower"
 msgstr ""
 
-#: hardinfo/dmi_util.c:138
+#: hardinfo/dmi_util.c:234
 msgid "Portable"
 msgstr "便携式"
 
-#: hardinfo/dmi_util.c:139 modules/computer.c:330 modules/computer.c:339
-#: modules/computer.c:361
+#: hardinfo/dmi_util.c:235 modules/computer.c:391 modules/computer.c:400
+#: modules/computer.c:422
 msgid "Laptop"
 msgstr "笔记本电脑"
 
-#: hardinfo/dmi_util.c:140
+#: hardinfo/dmi_util.c:236
 msgid "Notebook"
 msgstr "笔记本"
 
-#: hardinfo/dmi_util.c:141
+#: hardinfo/dmi_util.c:237
 msgid "Handheld"
 msgstr "手持设备"
 
-#: hardinfo/dmi_util.c:142
+#: hardinfo/dmi_util.c:238
 msgid "Docking Station"
 msgstr "扩展坞"
 
-#: hardinfo/dmi_util.c:143
+#: hardinfo/dmi_util.c:239
 msgid "All-in-one"
 msgstr ""
 
-#: hardinfo/dmi_util.c:144
+#: hardinfo/dmi_util.c:240
 msgid "Subnotebook"
 msgstr ""
 
-#: hardinfo/dmi_util.c:145
+#: hardinfo/dmi_util.c:241
 msgid "Space-saving"
 msgstr ""
 
-#: hardinfo/dmi_util.c:146
+#: hardinfo/dmi_util.c:242
 msgid "Lunch Box"
 msgstr ""
 
-#: hardinfo/dmi_util.c:147
+#: hardinfo/dmi_util.c:243
 msgid "Main Server Chassis"
 msgstr ""
 
-#: hardinfo/dmi_util.c:148
+#: hardinfo/dmi_util.c:244
 msgid "Expansion Chassis"
 msgstr ""
 
-#: hardinfo/dmi_util.c:149
+#: hardinfo/dmi_util.c:245
 msgid "Sub Chassis"
 msgstr ""
 
-#: hardinfo/dmi_util.c:150
+#: hardinfo/dmi_util.c:246
 msgid "Bus Expansion Chassis"
 msgstr ""
 
-#: hardinfo/dmi_util.c:151
+#: hardinfo/dmi_util.c:247
 msgid "Peripheral Chassis"
 msgstr ""
 
-#: hardinfo/dmi_util.c:152
+#: hardinfo/dmi_util.c:248
 msgid "RAID Chassis"
 msgstr ""
 
-#: hardinfo/dmi_util.c:153
+#: hardinfo/dmi_util.c:249
 msgid "Rack Mount Chassis"
 msgstr ""
 
-#: hardinfo/dmi_util.c:154
+#: hardinfo/dmi_util.c:250
 msgid "Sealed-case PC"
 msgstr ""
 
-#: hardinfo/dt_util.c:1011
+#: hardinfo/dmi_util.c:251
+msgid "Multi-system"
+msgstr ""
+
+#: hardinfo/dmi_util.c:252
+msgid "CompactPCI"
+msgstr ""
+
+#: hardinfo/dmi_util.c:253
+msgid "AdvancedTCA"
+msgstr ""
+
+#: hardinfo/dmi_util.c:254
+msgid "Blade"
+msgstr ""
+
+#: hardinfo/dmi_util.c:255
+msgid "Blade Enclosing"
+msgstr ""
+
+#: hardinfo/dmi_util.c:256
+msgid "Tablet"
+msgstr ""
+
+#: hardinfo/dmi_util.c:257
+msgid "Convertible"
+msgstr ""
+
+#: hardinfo/dmi_util.c:258
+msgid "Detachable"
+msgstr ""
+
+#: hardinfo/dmi_util.c:259
+msgid "IoT Gateway"
+msgstr ""
+
+#: hardinfo/dmi_util.c:260
+msgid "Embedded PC"
+msgstr ""
+
+#: hardinfo/dmi_util.c:261
+msgid "Mini PC"
+msgstr ""
+
+#: hardinfo/dmi_util.c:262
+msgid "Stick PC"
+msgstr ""
+
+#: hardinfo/dt_util.c:1179
 msgid "phandle Map"
 msgstr ""
 
-#: hardinfo/dt_util.c:1012
+#: hardinfo/dt_util.c:1180
 msgid "Alias Map"
 msgstr ""
 
-#: hardinfo/dt_util.c:1013
+#: hardinfo/dt_util.c:1181
 msgid "Symbol Map"
 msgstr ""
 
@@ -224,12 +450,16 @@ msgid ""
 "  Compiled for:      %s\n"
 msgstr ""
 
-#: hardinfo/hardinfo.c:58 hardinfo/hardinfo.c:59 modules/computer.c:644
-#: modules/devices/inputdevices.c:128 modules/devices/printers.c:138
+#: hardinfo/hardinfo.c:58 hardinfo/hardinfo.c:59 modules/computer.c:785
+#: modules/computer/modules.c:131 modules/computer/modules.c:132
+#: modules/devices/inputdevices.c:123 modules/devices/printers.c:138
+#: modules/devices/spd-decode.c:903
 msgid "Yes"
 msgstr "是"
 
-#: hardinfo/hardinfo.c:59 modules/computer.c:644 modules/devices/printers.c:138
+#: hardinfo/hardinfo.c:59 modules/computer.c:785 modules/computer/modules.c:131
+#: modules/computer/modules.c:132 modules/devices/printers.c:138
+#: modules/devices/spd-decode.c:900
 msgid "No"
 msgstr "否"
 
@@ -255,31 +485,39 @@ msgstr ""
 msgid "File Name"
 msgstr "文件名"
 
-#: hardinfo/hardinfo.c:78 modules/computer.c:528 modules/computer.c:556
-#: modules/computer.c:674 modules/computer/languages.c:95
-#: modules/computer/modules.c:146 modules/devices/arm/processor.c:447
-#: modules/devices/dmi.c:37 modules/devices/dmi.c:46
-#: modules/devices/ia64/processor.c:160 modules/devices/inputdevices.c:116
-#: modules/devices/sh/processor.c:84 modules/devices/x86/processor.c:696
-#: modules/network.c:326
+#: hardinfo/hardinfo.c:78 modules/computer.c:666 modules/computer.c:694
+#: modules/computer.c:815 modules/computer/languages.c:95
+#: modules/computer/modules.c:149 modules/devices/arm/processor.c:469
+#: modules/devices/dmi.c:37 modules/devices/dmi.c:48 modules/devices/gpu.c:233
+#: modules/devices/ia64/processor.c:160 modules/devices/inputdevices.c:111
+#: modules/devices/monitors.c:399 modules/devices/monitors.c:502
+#: modules/devices/sh/processor.c:84 modules/devices/x86/processor.c:749
+#: modules/network.c:332
 msgid "Name"
 msgstr "名称"
 
-#: hardinfo/hardinfo.c:78 modules/computer.c:304 modules/computer.c:499
-#: modules/computer.c:501 modules/computer.c:602 modules/devices/dmi.c:40
-#: modules/devices/dmi.c:44 modules/devices/dmi.c:48 modules/devices/dmi.c:54
-#: modules/devices/inputdevices.c:121
+#: hardinfo/hardinfo.c:78 modules/computer.c:347 modules/computer.c:572
+#: modules/computer.c:574 modules/computer.c:743 modules/computer/modules.c:151
+#: modules/devices/dmi.c:40 modules/devices/dmi.c:46 modules/devices/dmi.c:50
+#: modules/devices/dmi.c:56 modules/devices/firmware.c:105
+#: modules/devices/inputdevices.c:116 modules/devices/monitors.c:405
 msgid "Version"
 msgstr "版本"
 
-#: hardinfo/hardinfo.c:125
+#: hardinfo/hardinfo.c:129
 #, c-format
 msgid "Unknown benchmark ``%s'' or benchmark.so not loaded"
 msgstr ""
 
-#: hardinfo/hardinfo.c:155
+#: hardinfo/hardinfo.c:159
 msgid "Don't know what to do. Exiting."
 msgstr ""
+
+#: hardinfo/usb_util.c:290 modules/devices/devicetree.c:91
+#: modules/devices/devicetree.c:92 modules/devices/monitors.c:407
+#: modules/devices/storage.c:246
+msgid "(None)"
+msgstr "（无）"
 
 #: hardinfo/util.c:104 modules/computer/uptime.c:54
 #, c-format
@@ -347,92 +585,112 @@ msgstr "警告"
 msgid "Fatal Error"
 msgstr "严重错误"
 
-#: hardinfo/util.c:403
+#: hardinfo/util.c:406
 msgid "creates a report and prints to standard output"
 msgstr ""
 
-#: hardinfo/util.c:409
-msgid "chooses a report format (text, html)"
+#: hardinfo/util.c:412
+msgid "chooses a report format ([text], html)"
 msgstr ""
 
-#: hardinfo/util.c:415
+#: hardinfo/util.c:418
 msgid "run benchmark; requires benchmark.so to be loaded"
 msgstr ""
 
-#: hardinfo/util.c:421
+#: hardinfo/util.c:424
+msgid "note attached to benchmark results"
+msgstr ""
+
+#: hardinfo/util.c:430
 msgid "benchmark result format ([short], conf, shell)"
 msgstr ""
 
-#: hardinfo/util.c:427
+#: hardinfo/util.c:436
+msgid ""
+"maximum number of benchmark results to include (-1 for no limit, default is "
+"10)"
+msgstr ""
+
+#: hardinfo/util.c:442
 msgid "lists modules"
 msgstr "模块列表"
 
-#: hardinfo/util.c:433
+#: hardinfo/util.c:448
 msgid "specify module to load"
 msgstr ""
 
-#: hardinfo/util.c:439
+#: hardinfo/util.c:454
 msgid "automatically load module dependencies"
 msgstr ""
 
-#: hardinfo/util.c:446
+#: hardinfo/util.c:461
 msgid "run in XML-RPC server mode"
 msgstr ""
 
-#: hardinfo/util.c:453
+#: hardinfo/util.c:468
 msgid "shows program version and quit"
 msgstr "显示程序版本并退出"
 
-#: hardinfo/util.c:459
+#: hardinfo/util.c:474
 msgid "do not run benchmarks"
 msgstr ""
 
-#: hardinfo/util.c:464
+#: hardinfo/util.c:480
+msgid "show all details"
+msgstr ""
+
+#: hardinfo/util.c:485
 msgid "- System Profiler and Benchmark tool"
 msgstr ""
 
-#: hardinfo/util.c:474
+#: hardinfo/util.c:495
 #, c-format
 msgid ""
 "Unrecognized arguments.\n"
 "Try ``%s --help'' for more information.\n"
 msgstr ""
 
-#: hardinfo/util.c:542
-#, c-format
-msgid "Couldn't find a Web browser to open URL %s."
-msgstr ""
-
-#: hardinfo/util.c:891
+#: hardinfo/util.c:903
 #, c-format
 msgid "Module \"%s\" depends on module \"%s\", load it?"
 msgstr ""
 
-#: hardinfo/util.c:914
+#: hardinfo/util.c:926
 #, c-format
 msgid "Module \"%s\" depends on module \"%s\"."
 msgstr ""
 
-#: hardinfo/util.c:959
+#: hardinfo/util.c:971
 #, c-format
 msgid "No module could be loaded. Check permissions on \"%s\" and try again."
 msgstr ""
 
-#: hardinfo/util.c:963
+#: hardinfo/util.c:975
 msgid ""
 "No module could be loaded. Please use hardinfo -l to list all available "
 "modules and try again with a valid module list."
 msgstr ""
 
-#: hardinfo/util.c:1040
+#: hardinfo/util.c:1030
 #, c-format
 msgid "Scanning: %s..."
 msgstr "正在扫描：%s..."
 
-#: hardinfo/util.c:1050 shell/shell.c:301 shell/shell.c:772 shell/shell.c:1850
-#: modules/benchmark.c:549 modules/benchmark.c:557
+#: hardinfo/util.c:1040 shell/shell.c:310 shell/shell.c:795 shell/shell.c:1962
+#: modules/benchmark.c:583 modules/benchmark.c:591
 msgid "Done."
 msgstr "完成。"
+
+#: hardinfo/vendor.c:440 modules/computer.c:573 modules/computer.c:765
+#: modules/computer/os.c:79 modules/computer/os.c:263 modules/computer/os.c:300
+#: modules/computer/os.c:499 modules/computer/os.c:569 modules/devices.c:359
+#: modules/devices.c:505 modules/devices/printers.c:99
+#: modules/devices/printers.c:106 modules/devices/printers.c:116
+#: modules/devices/printers.c:131 modules/devices/printers.c:140
+#: modules/devices/printers.c:243 modules/devices/spd-decode.c:312
+#: modules/devices/usb.c:146
+msgid "Unknown"
+msgstr "未知"
 
 #: shell/callbacks.c:128
 #, c-format
@@ -454,63 +712,63 @@ msgstr "作者："
 msgid "Contributors:"
 msgstr "贡献者："
 
-#: shell/callbacks.c:166
+#: shell/callbacks.c:167
 msgid "Based on work by:"
 msgstr ""
 
-#: shell/callbacks.c:167
+#: shell/callbacks.c:168
 msgid "MD5 implementation by Colin Plumb (see md5.c for details)"
 msgstr ""
 
-#: shell/callbacks.c:168
+#: shell/callbacks.c:169
 msgid "SHA1 implementation by Steve Reid (see sha1.c for details)"
 msgstr ""
 
-#: shell/callbacks.c:169
+#: shell/callbacks.c:170
 msgid "Blowfish implementation by Paul Kocher (see blowfich.c for details)"
 msgstr ""
 
-#: shell/callbacks.c:170
+#: shell/callbacks.c:171
 msgid "Raytracing benchmark by John Walker (see fbench.c for details)"
 msgstr ""
 
-#: shell/callbacks.c:171
+#: shell/callbacks.c:172
 msgid "FFT benchmark by Scott Robert Ladd (see fftbench.c for details)"
 msgstr ""
 
-#: shell/callbacks.c:172
+#: shell/callbacks.c:173
 msgid "Some code partly based on x86cpucaps by Osamu Kayasono"
 msgstr ""
 
-#: shell/callbacks.c:173
+#: shell/callbacks.c:174
 msgid "Vendor list based on GtkSysInfo by Pissens Sebastien"
 msgstr ""
 
-#: shell/callbacks.c:174
+#: shell/callbacks.c:175
 msgid "DMI support based on code by Stewart Adam"
 msgstr ""
 
-#: shell/callbacks.c:175
+#: shell/callbacks.c:176
 msgid "SCSI support based on code by Pascal F. Martin"
 msgstr ""
 
-#: shell/callbacks.c:180
+#: shell/callbacks.c:181
 msgid "Tango Project"
 msgstr "Tango 项目"
 
-#: shell/callbacks.c:181
+#: shell/callbacks.c:182
 msgid "The GNOME Project"
 msgstr "GNOME 项目"
 
-#: shell/callbacks.c:182
+#: shell/callbacks.c:183
 msgid "VMWare, Inc. (USB icon from VMWare Workstation 6)"
 msgstr ""
 
-#: shell/callbacks.c:200
+#: shell/callbacks.c:201
 msgid "System information and benchmark tool"
 msgstr ""
 
-#: shell/callbacks.c:205
+#: shell/callbacks.c:206
 msgid ""
 "HardInfo is free software; you can redistribute it and/or modify it under "
 "the terms of the GNU General Public License as published by the Free "
@@ -526,167 +784,167 @@ msgid ""
 "Franklin St, Fifth Floor, Boston, MA  02110-1301 USA"
 msgstr ""
 
-#: shell/callbacks.c:220
+#: shell/callbacks.c:221
 msgid "translator-credits"
 msgstr ""
 
-#: shell/menu.c:35
+#: shell/menu.c:43
 msgid "_Information"
 msgstr "信息(_I)"
 
-#: shell/menu.c:36
+#: shell/menu.c:44
 msgid "_Remote"
 msgstr "远程(_R)"
 
-#: shell/menu.c:37
+#: shell/menu.c:45
 msgid "_View"
 msgstr "查看(_V)"
 
-#: shell/menu.c:38
+#: shell/menu.c:46
 msgid "_Help"
 msgstr "帮助(_H)"
 
-#: shell/menu.c:39
+#: shell/menu.c:47
 msgid "About _Modules"
 msgstr "关于模块(_M)"
 
-#: shell/menu.c:43
+#: shell/menu.c:51
 msgid "Generate _Report"
 msgstr "生成报表(_R)"
 
-#: shell/menu.c:48
+#: shell/menu.c:56
 msgid "_Network Updater..."
 msgstr ""
 
-#: shell/menu.c:53
+#: shell/menu.c:61
 msgid "_Open..."
 msgstr "打开...(_O)"
 
-#: shell/menu.c:58
+#: shell/menu.c:66
 msgid "_Copy to Clipboard"
 msgstr "复制到剪贴板(_C)"
 
-#: shell/menu.c:59
+#: shell/menu.c:67
 msgid "Copy to clipboard"
 msgstr "复制到剪贴板"
 
-#: shell/menu.c:63
+#: shell/menu.c:71
 msgid "_Refresh"
 msgstr "刷新(_R)"
 
-#: shell/menu.c:68
+#: shell/menu.c:76
 msgid "_Open HardInfo Web Site"
 msgstr "打开 HardInfo 网站(_O)"
 
-#: shell/menu.c:73
+#: shell/menu.c:81
 msgid "_Report bug"
 msgstr "报告错误(_B)"
 
-#: shell/menu.c:78
+#: shell/menu.c:86
 msgid "_About HardInfo"
 msgstr "关于 HardInfo(_A)"
 
-#: shell/menu.c:79
+#: shell/menu.c:87
 msgid "Displays program version information"
 msgstr "显示程序版本信息"
 
-#: shell/menu.c:83
+#: shell/menu.c:91
 msgid "_Quit"
 msgstr "退出(_Q)"
 
-#: shell/menu.c:90
+#: shell/menu.c:98
 msgid "_Side Pane"
 msgstr "侧边栏(_S)"
 
-#: shell/menu.c:91
+#: shell/menu.c:99
 msgid "Toggles side pane visibility"
 msgstr "更改侧边栏的可见性"
 
-#: shell/menu.c:94
+#: shell/menu.c:102
 msgid "_Toolbar"
 msgstr "工具栏(_T)"
 
-#: shell/report.c:500 shell/report.c:508
+#: shell/report.c:769 shell/report.c:777
 msgid "Save File"
 msgstr "保存文件"
 
-#: shell/report.c:503 shell/report.c:935 shell/syncmanager.c:748
+#: shell/report.c:772 shell/report.c:1243 shell/syncmanager.c:748
 msgid "_Cancel"
 msgstr "取消(_C)"
 
-#: shell/report.c:505
+#: shell/report.c:774
 msgid "_Save"
 msgstr "保存(_S)"
 
-#: shell/report.c:635
+#: shell/report.c:943
 msgid "Cannot create ReportContext. Programming bug?"
 msgstr ""
 
-#: shell/report.c:654
+#: shell/report.c:962
 msgid "Open the report with your web browser?"
 msgstr "在默认浏览器中打开报告？"
 
-#: shell/report.c:657
+#: shell/report.c:965
 msgid "_No"
 msgstr "否(_N)"
 
-#: shell/report.c:658
+#: shell/report.c:966
 msgid "_Open"
 msgstr "打开(_O)"
 
-#: shell/report.c:688
+#: shell/report.c:996
 msgid "Generating report..."
 msgstr "生成报告..."
 
-#: shell/report.c:698
+#: shell/report.c:1006
 msgid "Report saved."
 msgstr "报告已保存。"
 
-#: shell/report.c:700
+#: shell/report.c:1008
 msgid "Error while creating the report."
 msgstr "在创建报表时出错。"
 
-#: shell/report.c:802
+#: shell/report.c:1110
 msgid "Generate Report"
 msgstr "生成报表"
 
-#: shell/report.c:827
+#: shell/report.c:1135
 msgid ""
 "<big><b>Generate Report</b></big>\n"
 "Please choose the information that you wish to view in your report:"
 msgstr ""
 
-#: shell/report.c:899
+#: shell/report.c:1207
 msgid "Select _None"
 msgstr "不选择(_N)"
 
-#: shell/report.c:910
+#: shell/report.c:1218
 msgid "Select _All"
 msgstr "选中全部(_A)"
 
-#: shell/report.c:945
+#: shell/report.c:1253
 msgid "_Generate"
 msgstr "生成(_G)"
 
-#: shell/shell.c:402
+#: shell/shell.c:407
 #, c-format
 msgid "%s - System Information"
 msgstr "%s - 系统信息"
 
-#: shell/shell.c:407
+#: shell/shell.c:412
 msgid "System Information"
 msgstr "系统信息"
 
-#: shell/shell.c:759
+#: shell/shell.c:782
 msgid "Loading modules..."
 msgstr "正在加载模块..."
 
-#: shell/shell.c:1715
+#: shell/shell.c:1828
 #, c-format
 msgid "<b>%s → Summary</b>"
 msgstr "<b>%s → 概要</b>"
 
-#: shell/shell.c:1824
+#: shell/shell.c:1936
 msgid "Updating..."
 msgstr "正在更新..."
 
@@ -764,47 +1022,91 @@ msgstr ""
 msgid "_Synchronize"
 msgstr "同步(_S)"
 
-#: modules/benchmark/benches.c:74
-msgid "CPU Blowfish"
+#: modules/benchmark/benches.c:82
+msgid "CPU Blowfish (Single-thread)"
 msgstr ""
 
-#: modules/benchmark/benches.c:75
-msgid "CPU CryptoHash"
+#: modules/benchmark/benches.c:84
+msgid "CPU Blowfish (Multi-thread)"
 msgstr ""
 
-#: modules/benchmark/benches.c:76
-msgid "CPU Fibonacci"
+#: modules/benchmark/benches.c:86
+msgid "CPU Blowfish (Multi-core)"
 msgstr ""
 
-#: modules/benchmark/benches.c:77
-msgid "CPU N-Queens"
-msgstr ""
-
-#: modules/benchmark/benches.c:78
+#: modules/benchmark/benches.c:88
 msgid "CPU Zlib"
 msgstr ""
 
-#: modules/benchmark/benches.c:79
+#: modules/benchmark/benches.c:90
+msgid "CPU CryptoHash"
+msgstr ""
+
+#: modules/benchmark/benches.c:92
+msgid "CPU Fibonacci"
+msgstr ""
+
+#: modules/benchmark/benches.c:94
+msgid "CPU N-Queens"
+msgstr ""
+
+#: modules/benchmark/benches.c:96
 msgid "FPU FFT"
 msgstr ""
 
-#: modules/benchmark/benches.c:80
+#: modules/benchmark/benches.c:98
 msgid "FPU Raytracing"
 msgstr ""
 
-#: modules/benchmark/benches.c:82
-msgid "GPU Drawing"
-msgstr ""
-
-#: modules/benchmark/benches.c:91
-msgid "Results in MiB/second. Higher is better."
-msgstr "结果以 MiB/秒为单位，越大越好。"
-
-#: modules/benchmark/benches.c:95
-msgid "Results in HIMarks. Higher is better."
+#: modules/benchmark/benches.c:100
+msgid "SysBench CPU (Single-thread)"
 msgstr ""
 
 #: modules/benchmark/benches.c:102
+msgid "SysBench CPU (Multi-thread)"
+msgstr ""
+
+#: modules/benchmark/benches.c:104
+msgid "SysBench CPU (Four threads)"
+msgstr ""
+
+#: modules/benchmark/benches.c:106
+msgid "SysBench Memory (Single-thread)"
+msgstr ""
+
+#: modules/benchmark/benches.c:108
+msgid "SysBench Memory (Two threads)"
+msgstr ""
+
+#: modules/benchmark/benches.c:110
+msgid "SysBench Memory"
+msgstr ""
+
+#: modules/benchmark/benches.c:113
+msgid "GPU Drawing"
+msgstr ""
+
+#: modules/benchmark/benches.c:126
+msgid ""
+"Alexey Kopytov's <i><b>sysbench</b></i> is required.\n"
+"Results in events/second. Higher is better."
+msgstr ""
+
+#: modules/benchmark/benches.c:132
+msgid ""
+"Alexey Kopytov's <i><b>sysbench</b></i> is required.\n"
+"Results in MiB/second. Higher is better."
+msgstr ""
+
+#: modules/benchmark/benches.c:136
+msgid "Results in MiB/second. Higher is better."
+msgstr "结果以 MiB/秒为单位，越大越好。"
+
+#: modules/benchmark/benches.c:143
+msgid "Results in HIMarks. Higher is better."
+msgstr ""
+
+#: modules/benchmark/benches.c:149
 msgid "Results in seconds. Lower is better."
 msgstr "结果以秒为单位。越小越好。"
 
@@ -823,158 +1125,201 @@ msgstr "结果以秒为单位。越小越好。"
 #.
 #. / Used for an unknown value. Having it in only one place cleans up the .po line references
 #: modules/benchmark/bench_results.c:22 modules/computer.c:41
-#: modules/computer/display.c:41 modules/computer/os.c:279
-#: modules/devices.c:383 modules/devices/gpu.c:42 modules/devices/gpu.c:58
-#: modules/devices/gpu.c:150 modules/devices/gpu.c:151 modules/devices/pci.c:25
-#: modules/devices/pci.c:117 modules/devices/pci.c:118 modules/devices/usb.c:27
-#: modules/network/net.c:437 includes/cpu_util.h:11
+#: modules/computer/display.c:41 modules/computer/display.c:58
+#: modules/computer/os.c:286 modules/computer/os.c:346 modules/devices.c:488
+#: modules/devices/dmi_memory.c:52 modules/devices/dmi_memory.c:53
+#: modules/devices/dmi_memory.c:579 modules/devices/dmi_memory.c:719
+#: modules/devices/dmi_memory.c:855 modules/devices/gpu.c:42
+#: modules/devices/gpu.c:58 modules/devices/gpu.c:112 modules/devices/gpu.c:120
+#: modules/devices/gpu.c:154 modules/devices/gpu.c:155
+#: modules/devices/gpu.c:176 modules/devices/monitors.c:27
+#: modules/devices/monitors.c:28 modules/devices/monitors.c:153
+#: modules/devices/monitors.c:162 modules/devices/pci.c:25
+#: modules/devices/pci.c:135 modules/devices/pci.c:136
+#: modules/devices/spd-decode.c:306 modules/devices/spd-decode.c:307
+#: modules/devices/spd-decode.c:310 modules/devices/spd-decode.c:311
+#: modules/devices/spd-decode.c:914 modules/devices/spd-decode.c:915
+#: modules/devices/storage.c:247 modules/devices/storage.c:309
+#: modules/devices/usb.c:28 modules/network/net.c:437 includes/cpu_util.h:11
 msgid "(Unknown)"
 msgstr "(未知)"
 
-#: modules/benchmark/bench_results.c:47 modules/benchmark/bench_results.c:322
-#: modules/devices/alpha/processor.c:90 modules/devices/arm/processor.c:276
-#: modules/devices/arm/processor.c:289 modules/devices/arm/processor.c:331
-#: modules/devices/arm/processor.c:478 modules/devices.c:310
-#: modules/devices.c:318 modules/devices.c:346
-#: modules/devices/ia64/processor.c:167 modules/devices/ia64/processor.c:196
-#: modules/devices/m68k/processor.c:87 modules/devices/mips/processor.c:77
-#: modules/devices/parisc/processor.c:158
+#: modules/benchmark/bench_results.c:49 modules/benchmark/bench_results.c:330
+#: modules/devices/alpha/processor.c:90 modules/devices/arm/processor.c:290
+#: modules/devices/arm/processor.c:303 modules/devices/arm/processor.c:345
+#: modules/devices/arm/processor.c:500 modules/devices.c:325
+#: modules/devices.c:333 modules/devices.c:361 modules/devices/gpu.c:115
+#: modules/devices/gpu.c:117 modules/devices/gpu.c:123
+#: modules/devices/gpu.c:125 modules/devices/gpu.c:179
+#: modules/devices/gpu.c:181 modules/devices/ia64/processor.c:167
+#: modules/devices/ia64/processor.c:196 modules/devices/m68k/processor.c:87
+#: modules/devices/mips/processor.c:77 modules/devices/parisc/processor.c:158
 #: modules/devices/parisc/processor.c:191 modules/devices/ppc/processor.c:160
 #: modules/devices/ppc/processor.c:187 modules/devices/riscv/processor.c:186
 #: modules/devices/riscv/processor.c:214 modules/devices/s390/processor.c:160
 #: modules/devices/sh/processor.c:87 modules/devices/sh/processor.c:88
 #: modules/devices/sh/processor.c:89 modules/devices/x86/processor.c:318
-#: modules/devices/x86/processor.c:331 modules/devices/x86/processor.c:655
-#: modules/devices/x86/processor.c:726
+#: modules/devices/x86/processor.c:331 modules/devices/x86/processor.c:657
+#: modules/devices/x86/processor.c:780
 msgid "MHz"
 msgstr "MHz"
 
-#: modules/benchmark/bench_results.c:374 modules/benchmark/bench_results.c:441
+#: modules/benchmark/bench_results.c:396 modules/benchmark/bench_results.c:495
 msgid "kiB"
 msgstr "kiB"
 
-#: modules/benchmark/bench_results.c:389 modules/benchmark/bench_results.c:426
+#: modules/benchmark/bench_results.c:403 modules/benchmark/bench_results.c:453
+#, c-format
+msgid "%d-bit"
+msgstr ""
+
+#: modules/benchmark/bench_results.c:422 modules/benchmark/bench_results.c:477
 msgid "Benchmark Result"
 msgstr ""
 
-#: modules/benchmark/bench_results.c:390 modules/benchmark/bench_results.c:428
+#: modules/benchmark/bench_results.c:423 modules/benchmark/bench_results.c:479
 msgid "Threads"
 msgstr "线程"
 
-#: modules/benchmark/bench_results.c:391 modules/benchmark/bench_results.c:431
+#: modules/benchmark/bench_results.c:424 modules/benchmark/bench_results.c:481
+msgid "Elapsed Time"
+msgstr ""
+
+#: modules/benchmark/bench_results.c:424 modules/benchmark/bench_results.c:481
+msgid "seconds"
+msgstr ""
+
+#: modules/benchmark/bench_results.c:425 modules/computer/languages.c:101
+#: modules/devices/arm/processor.c:355 modules/devices/gpu.c:147
+#: modules/devices/ia64/processor.c:166 modules/devices/pci.c:132
+#: modules/devices/ppc/processor.c:159
+msgid "Revision"
+msgstr "修订版本"
+
+#: modules/benchmark/bench_results.c:426 modules/benchmark/bench_results.c:482
+msgid "Extra Information"
+msgstr ""
+
+#: modules/benchmark/bench_results.c:427 modules/benchmark/bench_results.c:483
+msgid "User Note"
+msgstr ""
+
+#: modules/benchmark/bench_results.c:429 modules/benchmark/bench_results.c:485
 msgid "Note"
 msgstr "注解"
 
-#: modules/benchmark/bench_results.c:392 modules/benchmark/bench_results.c:432
+#: modules/benchmark/bench_results.c:430 modules/benchmark/bench_results.c:486
 msgid ""
 "This result is from an old version of HardInfo. Results might not be "
 "comparable to current version. Some details are missing."
 msgstr ""
 
-#: modules/benchmark/bench_results.c:393 modules/benchmark/bench_results.c:433
+#: modules/benchmark/bench_results.c:431 modules/benchmark/bench_results.c:487
 #: modules/devices/devicetree/pmac_data.c:81 modules/devices/sh/processor.c:85
 msgid "Machine"
 msgstr ""
 
-#: modules/benchmark/bench_results.c:394 modules/benchmark/bench_results.c:434
-#: modules/devices/devicetree.c:206 modules/devices/dmi.c:45
+#: modules/benchmark/bench_results.c:432 modules/benchmark/bench_results.c:488
+#: modules/devices/devicetree.c:208 modules/devices/dmi.c:47
 msgid "Board"
 msgstr "主板"
 
-#: modules/benchmark/bench_results.c:395 modules/benchmark/bench_results.c:435
+#: modules/benchmark/bench_results.c:433 modules/benchmark/bench_results.c:489
 msgid "CPU Name"
 msgstr "处理器名称"
 
-#: modules/benchmark/bench_results.c:396 modules/benchmark/bench_results.c:436
+#: modules/benchmark/bench_results.c:434 modules/benchmark/bench_results.c:490
 msgid "CPU Description"
 msgstr "处理器描述"
 
-#: modules/benchmark/bench_results.c:397 modules/benchmark/bench_results.c:437
-#: modules/benchmark.c:390
+#: modules/benchmark/bench_results.c:435 modules/benchmark/bench_results.c:491
+#: modules/benchmark.c:442
 msgid "CPU Config"
 msgstr "CPU 配置"
 
-#: modules/benchmark/bench_results.c:398 modules/benchmark/bench_results.c:438
+#: modules/benchmark/bench_results.c:436 modules/benchmark/bench_results.c:492
 msgid "Threads Available"
 msgstr ""
 
-#: modules/benchmark/bench_results.c:399 modules/benchmark/bench_results.c:439
+#: modules/benchmark/bench_results.c:437 modules/benchmark/bench_results.c:493
 msgid "GPU"
 msgstr "GPU"
 
-#: modules/benchmark/bench_results.c:400 modules/benchmark/bench_results.c:440
-#: modules/computer.c:479
+#: modules/benchmark/bench_results.c:438 modules/benchmark/bench_results.c:494
+#: modules/computer.c:542
 msgid "OpenGL Renderer"
 msgstr "OpenGL 渲染器"
 
-#: modules/benchmark/bench_results.c:401 modules/benchmark/bench_results.c:441
-#: modules/computer.c:110 modules/computer.c:468 modules/devices.c:99
+#: modules/benchmark/bench_results.c:439 modules/benchmark/bench_results.c:495
+#: modules/computer.c:123 modules/computer.c:531 modules/computer.c:1000
+#: modules/devices/gpu.c:150
 msgid "Memory"
 msgstr "内存"
 
-#: modules/benchmark/bench_results.c:427
+#: modules/benchmark/bench_results.c:440 modules/benchmark/bench_results.c:496
+msgid "Pointer Size"
+msgstr ""
+
+#: modules/benchmark/bench_results.c:478
 msgid "Benchmark"
 msgstr "基准"
 
-#: modules/benchmark/bench_results.c:429
+#: modules/benchmark/bench_results.c:480 modules/devices/dmi_memory.c:879
+#: modules/devices/firmware.c:246 modules/devices/monitors.c:492
+#: modules/devices/x86/processor.c:691
 msgid "Result"
 msgstr "结果"
 
-#: modules/benchmark/bench_results.c:430
-msgid "Elapsed Time"
-msgstr ""
-
-#: modules/benchmark/bench_results.c:442
+#: modules/benchmark/bench_results.c:498
 msgid "Handles"
 msgstr "控制柄"
 
-#: modules/benchmark/bench_results.c:443
+#: modules/benchmark/bench_results.c:499
 msgid "mid"
 msgstr ""
 
-#: modules/benchmark/bench_results.c:444
+#: modules/benchmark/bench_results.c:500
 msgid "cfg_val"
 msgstr ""
 
-#: modules/benchmark.c:390
+#: modules/benchmark.c:442
 msgid "Results"
 msgstr "结果"
 
-#: modules/benchmark.c:390 modules/computer.c:811
-#: modules/devices/sparc/processor.c:75
+#: modules/benchmark.c:442 modules/devices/sparc/processor.c:75
 msgid "CPU"
 msgstr "CPU"
 
-#: modules/benchmark.c:460
+#: modules/benchmark.c:513
 #, c-format
 msgid "Benchmarking: <b>%s</b>."
 msgstr ""
 
-#: modules/benchmark.c:479 modules/benchmark.c:498
-msgid "Cancel"
-msgstr "取消"
-
-#: modules/benchmark.c:483 modules/benchmark.c:495
+#: modules/benchmark.c:527
 msgid "Benchmarking. Please do not move your mouse or press any keys."
 msgstr ""
 
-#: modules/benchmark.c:567
+#: modules/benchmark.c:530
+msgid "Cancel"
+msgstr "取消"
+
+#: modules/benchmark.c:601
 msgid "Benchmarks"
 msgstr ""
 
-#: modules/benchmark.c:585
+#: modules/benchmark.c:619
 msgid "Perform tasks and compare with other systems"
 msgstr ""
 
-#: modules/benchmark.c:692
+#: modules/benchmark.c:730
 msgid "Send benchmark results"
 msgstr ""
 
-#: modules/benchmark.c:697
+#: modules/benchmark.c:735
 msgid "Receive benchmark results"
 msgstr ""
 
-#: modules/computer/alsa.c:26 modules/computer.c:483
+#: modules/computer/alsa.c:26 modules/computer.c:546
 msgid "Audio Devices"
 msgstr "音频设备"
 
@@ -982,499 +1327,606 @@ msgstr "音频设备"
 msgid "Audio Adapter"
 msgstr "音频适配器"
 
-#: modules/computer.c:76
+#: modules/computer.c:80 modules/devices/firmware.c:104
 msgid "Summary"
 msgstr "概要"
 
-#: modules/computer.c:77 modules/computer.c:471 modules/computer.c:810
+#: modules/computer.c:81 modules/computer.c:534 modules/computer.c:999
 msgid "Operating System"
 msgstr "操作系统"
 
-#: modules/computer.c:78 modules/devices/gpu.c:151 modules/devices/pci.c:118
+#: modules/computer.c:82
+msgid "Security"
+msgstr ""
+
+#: modules/computer.c:83 modules/devices/gpu.c:155 modules/devices/pci.c:136
 msgid "Kernel Modules"
 msgstr "内核模块"
 
-#: modules/computer.c:79 modules/computer.c:540
+#: modules/computer.c:84 modules/computer.c:678
 msgid "Boots"
 msgstr "启动"
 
-#: modules/computer.c:80
+#: modules/computer.c:85
 msgid "Languages"
 msgstr "语言"
 
-#: modules/computer.c:81
+#: modules/computer.c:86
+msgid "Memory Usage"
+msgstr ""
+
+#: modules/computer.c:87
 msgid "Filesystems"
 msgstr "文件系统"
 
-#: modules/computer.c:82 modules/computer.c:476
+#: modules/computer.c:88 modules/computer.c:539
 msgid "Display"
 msgstr "显示"
 
-#: modules/computer.c:83 modules/computer/environment.c:32
+#: modules/computer.c:89 modules/computer/environment.c:32
 msgid "Environment Variables"
 msgstr "环境变量"
 
-#: modules/computer.c:85
+#: modules/computer.c:91
 msgid "Development"
 msgstr "开发"
 
-#: modules/computer.c:87 modules/computer.c:661
+#: modules/computer.c:93 modules/computer.c:802
 msgid "Users"
 msgstr "用户"
 
-#: modules/computer.c:88
+#: modules/computer.c:94
 msgid "Groups"
 msgstr "组"
 
-#: modules/computer.c:112
+#: modules/computer.c:125
 #, c-format
 msgid "%dMB (%dMB used)"
 msgstr ""
 
-#: modules/computer.c:114 modules/computer.c:514
+#: modules/computer.c:127 modules/computer.c:594
 msgid "Uptime"
 msgstr "启动时间"
 
-#: modules/computer.c:116 modules/computer.c:473
+#: modules/computer.c:129 modules/computer.c:536
 msgid "Date/Time"
 msgstr "日期/时间"
 
-#: modules/computer.c:121 modules/computer.c:515
+#: modules/computer.c:134 modules/computer.c:595
 msgid "Load Average"
 msgstr "负载均值"
 
-#: modules/computer.c:123 modules/computer.c:516
-msgid "Available entropy in /dev/random"
-msgstr ""
-
-#: modules/computer.c:211
+#: modules/computer.c:247
 msgid "Scripting Languages"
 msgstr "脚本语言"
 
-#: modules/computer.c:212
+#: modules/computer.c:248
 msgid "Gambas3 (gbr3)"
 msgstr "Gambas3 (gbr3)"
 
-#: modules/computer.c:213
-msgid "Python"
-msgstr "Python"
+#: modules/computer.c:249
+msgid "Python (default)"
+msgstr ""
 
-#: modules/computer.c:214
+#: modules/computer.c:250
 msgid "Python2"
 msgstr "Python2"
 
-#: modules/computer.c:215
+#: modules/computer.c:251
 msgid "Python3"
 msgstr "Python3"
 
-#: modules/computer.c:216
+#: modules/computer.c:252
 msgid "Perl"
 msgstr "Perl"
 
-#: modules/computer.c:217
+#: modules/computer.c:253
 msgid "Perl6 (VM)"
 msgstr "Perl6 (VM)"
 
-#: modules/computer.c:218
+#: modules/computer.c:254
 msgid "Perl6"
 msgstr "Perl6"
 
-#: modules/computer.c:219
+#: modules/computer.c:255
 msgid "PHP"
 msgstr "PHP"
 
-#: modules/computer.c:220
+#: modules/computer.c:256
 msgid "Ruby"
 msgstr "Ruby"
 
-#: modules/computer.c:221
+#: modules/computer.c:257
 msgid "Bash"
 msgstr "Bash"
 
-#: modules/computer.c:222
+#: modules/computer.c:258
+msgid "JavaScript (Node.js)"
+msgstr ""
+
+#: modules/computer.c:259
+msgid "awk"
+msgstr ""
+
+#: modules/computer.c:260
 msgid "Compilers"
 msgstr "编译器"
 
-#: modules/computer.c:223
+#: modules/computer.c:261
 msgid "C (GCC)"
 msgstr "C (GCC)"
 
-#: modules/computer.c:224
+#: modules/computer.c:262
 msgid "C (Clang)"
 msgstr "C (Clang)"
 
-#: modules/computer.c:225
+#: modules/computer.c:263
 msgid "D (dmd)"
 msgstr "D (dmd)"
 
-#: modules/computer.c:226
+#: modules/computer.c:264
 msgid "Gambas3 (gbc3)"
 msgstr "Gambas3 (gbc3)"
 
-#: modules/computer.c:227
+#: modules/computer.c:265
 msgid "Java"
 msgstr "Java"
 
-#: modules/computer.c:228
-msgid "CSharp (Mono, old)"
-msgstr "CSharp (Mono, old)"
+#: modules/computer.c:266
+msgid "C♯ (mcs)"
+msgstr ""
 
-#: modules/computer.c:229
-msgid "CSharp (Mono)"
-msgstr "CSharp (Mono)"
-
-#: modules/computer.c:230
+#: modules/computer.c:267
 msgid "Vala"
 msgstr "Vala"
 
-#: modules/computer.c:231
+#: modules/computer.c:268
 msgid "Haskell (GHC)"
 msgstr "Haskell (GHC)"
 
-#: modules/computer.c:232
+#: modules/computer.c:269
 msgid "FreePascal"
 msgstr ""
 
-#: modules/computer.c:233
+#: modules/computer.c:270
 msgid "Go"
 msgstr "Go"
 
-#: modules/computer.c:234
+#: modules/computer.c:271
+msgid "Rust"
+msgstr ""
+
+#: modules/computer.c:272
 msgid "Tools"
 msgstr "工具"
 
-#: modules/computer.c:235
+#: modules/computer.c:273
 msgid "make"
 msgstr "make"
 
-#: modules/computer.c:236
+#: modules/computer.c:274
+msgid "ninja"
+msgstr ""
+
+#: modules/computer.c:275
 msgid "GDB"
 msgstr "GDB"
 
-#: modules/computer.c:237
+#: modules/computer.c:276
+msgid "LLDB"
+msgstr ""
+
+#: modules/computer.c:277
 msgid "strace"
 msgstr ""
 
-#: modules/computer.c:238
+#: modules/computer.c:278
 msgid "valgrind"
 msgstr ""
 
-#: modules/computer.c:239
+#: modules/computer.c:279
 msgid "QMake"
 msgstr "QMake"
 
-#: modules/computer.c:240
+#: modules/computer.c:280
 msgid "CMake"
 msgstr "CMake"
 
-#: modules/computer.c:241
+#: modules/computer.c:281
 msgid "Gambas3 IDE"
 msgstr "Gambas3 IDE"
 
 #: modules/computer.c:282
+msgid "Radare2"
+msgstr ""
+
+#: modules/computer.c:283
+msgid "ltrace"
+msgstr ""
+
+#: modules/computer.c:324
 msgid "Not found"
 msgstr "找不到"
 
-#: modules/computer.c:287
+#: modules/computer.c:329
 #, c-format
 msgid "Detecting version: %s"
 msgstr "检测版本: %s"
 
-#: modules/computer.c:304
+#: modules/computer.c:347
 msgid "Program"
 msgstr "程序"
 
-#: modules/computer.c:324
+#: modules/computer.c:365
+msgid "Field"
+msgstr "域"
+
+#: modules/computer.c:365 modules/computer.c:667 modules/computer/modules.c:149
+#: modules/computer/modules.c:150 modules/devices/arm/processor.c:470
+msgid "Description"
+msgstr "描述"
+
+#: modules/computer.c:365 modules/devices.c:726
+msgid "Value"
+msgstr "亮度"
+
+#: modules/computer.c:385
 msgid "Single-board computer"
 msgstr ""
 
 #. /proc/apm
-#: modules/computer.c:373
+#: modules/computer.c:434
 msgid "Unknown physical machine type"
 msgstr ""
 
-#: modules/computer.c:393 modules/computer.c:394
+#: modules/computer.c:454 modules/computer.c:455
 msgid "Virtual (VMware)"
 msgstr "Virtual (VMware)"
 
-#: modules/computer.c:396 modules/computer.c:397 modules/computer.c:398
-#: modules/computer.c:399
+#: modules/computer.c:457 modules/computer.c:458 modules/computer.c:459
+#: modules/computer.c:460
 msgid "Virtual (QEMU)"
 msgstr "Virtual (QEMU)"
 
-#: modules/computer.c:401 modules/computer.c:402
+#: modules/computer.c:462 modules/computer.c:463
 msgid "Virtual (Unknown)"
 msgstr "Virtual (Unknown)"
 
-#: modules/computer.c:404 modules/computer.c:405 modules/computer.c:406
-#: modules/computer.c:427
+#: modules/computer.c:465 modules/computer.c:466 modules/computer.c:467
+#: modules/computer.c:488
 msgid "Virtual (VirtualBox)"
 msgstr "Virtual (VirtualBox)"
 
-#: modules/computer.c:408 modules/computer.c:409 modules/computer.c:410
-#: modules/computer.c:421
+#: modules/computer.c:469 modules/computer.c:470 modules/computer.c:471
+#: modules/computer.c:482
 msgid "Virtual (Xen)"
 msgstr "Virtual (Xen)"
 
-#: modules/computer.c:412
+#: modules/computer.c:473
 msgid "Virtual (hypervisor present)"
 msgstr "Virtual (hypervisor present)"
 
-#: modules/computer.c:465 modules/computer.c:769
+#: modules/computer.c:528 modules/computer.c:953
 msgid "Computer"
 msgstr "计算机"
 
-#: modules/computer.c:466 modules/devices/alpha/processor.c:87
-#: modules/devices/arm/processor.c:327 modules/devices.c:98
-#: modules/devices/ia64/processor.c:159 modules/devices/m68k/processor.c:83
-#: modules/devices/mips/processor.c:74 modules/devices/parisc/processor.c:154
-#: modules/devices/ppc/processor.c:157 modules/devices/riscv/processor.c:181
-#: modules/devices/s390/processor.c:131 modules/devices/sh/processor.c:83
-#: modules/devices/sparc/processor.c:74 modules/devices/x86/processor.c:644
-msgid "Processor"
-msgstr "处理器"
-
-#: modules/computer.c:469
+#: modules/computer.c:532
 msgid "Machine Type"
 msgstr "机器类型"
 
-#: modules/computer.c:472 modules/computer.c:508
+#: modules/computer.c:535 modules/computer.c:588
 msgid "User Name"
 msgstr "用户名"
 
-#: modules/computer.c:477
+#: modules/computer.c:540
 msgid "Resolution"
 msgstr "解决方案"
 
-#: modules/computer.c:477 modules/computer.c:607
+#: modules/computer.c:540 modules/computer.c:748
 #, c-format
 msgid "%dx%d pixels"
 msgstr ""
 
-#: modules/computer.c:480
+#: modules/computer.c:543
 msgid "Session Display Server"
 msgstr "会话显示服务器"
 
-#: modules/computer.c:485 modules/devices.c:106
+#: modules/computer.c:548 modules/devices.c:108
 msgid "Input Devices"
 msgstr "输入设备"
 
-#: modules/computer.c:500
+#: modules/computer.c:572
 msgid "Kernel"
 msgstr "内核"
 
-#: modules/computer.c:502
+#: modules/computer.c:573
+msgid "Command Line"
+msgstr ""
+
+#: modules/computer.c:575
 msgid "C Library"
 msgstr "C 库"
 
-#: modules/computer.c:503
+#: modules/computer.c:576
 msgid "Distribution"
 msgstr "发行版"
 
-#: modules/computer.c:506
+#: modules/computer.c:582
+msgid "Spin/Flavor"
+msgstr ""
+
+#: modules/computer.c:586
 msgid "Current Session"
 msgstr "当前会话"
 
-#: modules/computer.c:507
+#: modules/computer.c:587
 msgid "Computer Name"
 msgstr "计算机名称"
 
-#: modules/computer.c:509 modules/computer/languages.c:99
+#: modules/computer.c:589 modules/computer/languages.c:99
 msgid "Language"
 msgstr "语言"
 
-#: modules/computer.c:510 modules/computer/users.c:50
+#: modules/computer.c:590 modules/computer/users.c:50
 msgid "Home Directory"
 msgstr "主目录"
 
-#: modules/computer.c:513
+#: modules/computer.c:591
+msgid "Desktop Environment"
+msgstr ""
+
+#: modules/computer.c:594
 msgid "Misc"
 msgstr "其它"
 
-#: modules/computer.c:526
+#: modules/computer.c:607
+msgid "HardInfo"
+msgstr ""
+
+#: modules/computer.c:608
+msgid "HardInfo running as"
+msgstr ""
+
+#: modules/computer.c:609
+msgid "Superuser"
+msgstr ""
+
+#: modules/computer.c:609
+msgid "User"
+msgstr ""
+
+#: modules/computer.c:613
+msgid "Health"
+msgstr ""
+
+#: modules/computer.c:614
+msgid "Available entropy in /dev/random"
+msgstr ""
+
+#: modules/computer.c:618
+msgid "Hardening Features"
+msgstr ""
+
+#: modules/computer.c:619
+msgid "ASLR"
+msgstr ""
+
+#: modules/computer.c:620
+msgid "dmesg"
+msgstr ""
+
+#: modules/computer.c:624
+msgid "Linux Security Modules"
+msgstr ""
+
+#: modules/computer.c:625
+msgid "Modules available"
+msgstr ""
+
+#: modules/computer.c:626
+msgid "SELinux status"
+msgstr ""
+
+#: modules/computer.c:632
+msgid "CPU Vulnerabilities"
+msgstr ""
+
+#: modules/computer.c:664
 msgid "Loaded Modules"
 msgstr "已加载的模块"
 
-#: modules/computer.c:529 modules/computer/modules.c:145
-#: modules/computer/modules.c:147 modules/devices/arm/processor.c:448
-#: modules/devices.c:575
-msgid "Description"
-msgstr "描述"
-
-#: modules/computer.c:542
+#: modules/computer.c:680
 msgid "Date & Time"
 msgstr "日期和时间"
 
-#: modules/computer.c:543
+#: modules/computer.c:681
 msgid "Kernel Version"
 msgstr "内核版本"
 
-#: modules/computer.c:553
+#: modules/computer.c:691
 msgid "Available Languages"
 msgstr "可用语言"
 
-#: modules/computer.c:555
+#: modules/computer.c:693
 msgid "Language Code"
 msgstr "语言代码"
 
-#: modules/computer.c:567
+#: modules/computer.c:705
 msgid "Mounted File Systems"
 msgstr "已挂载的文件系统"
 
-#: modules/computer.c:569 modules/computer/filesystem.c:85
+#: modules/computer.c:707 modules/computer/filesystem.c:85
 msgid "Mount Point"
 msgstr "挂载点"
 
-#: modules/computer.c:570
+#: modules/computer.c:708
 msgid "Usage"
 msgstr "使用"
 
-#: modules/computer.c:571 modules/devices/gpu.c:93 modules/devices/gpu.c:101
-#: modules/devices/gpu.c:187 modules/devices/pci.c:70 modules/devices/pci.c:78
-#: modules/devices/pci.c:122 modules/devices/usb.c:72
+#: modules/computer.c:709 modules/devices/gpu.c:75 modules/devices/gpu.c:83
+#: modules/devices/gpu.c:225 modules/devices/pci.c:88 modules/devices/pci.c:96
+#: modules/devices/pci.c:140 modules/devices/usb.c:169
+#: modules/devices/usb.c:181
 msgid "Device"
 msgstr "设备"
 
-#: modules/computer.c:590
+#: modules/computer.c:731
 msgid "Session"
 msgstr "会话"
 
-#: modules/computer.c:591 modules/devices.c:614 modules/devices/dmi.c:53
-#: modules/devices/inputdevices.c:117
+#: modules/computer.c:732 modules/devices.c:726 modules/devices/dmi.c:55
+#: modules/devices/dmi_memory.c:603 modules/devices/dmi_memory.c:749
+#: modules/devices/inputdevices.c:112 modules/devices/x86/processor.c:714
 msgid "Type"
 msgstr "类别"
 
-#: modules/computer.c:594
+#: modules/computer.c:735
 msgid "Wayland"
 msgstr "Wayland"
 
-#: modules/computer.c:595 modules/computer.c:600
+#: modules/computer.c:736 modules/computer.c:741
 msgid "Current Display Name"
 msgstr "当前显示名称"
 
-#: modules/computer.c:599
+#: modules/computer.c:740
 msgid "X Server"
 msgstr "X 服务器"
 
-#: modules/computer.c:601 modules/computer.c:641 modules/devices/dmi.c:39
-#: modules/devices/dmi.c:43 modules/devices/dmi.c:47 modules/devices/dmi.c:52
-#: modules/devices/gpu.c:92 modules/devices/gpu.c:100 modules/devices/gpu.c:186
-#: modules/devices/ia64/processor.c:161 modules/devices/inputdevices.c:119
-#: modules/devices/pci.c:69 modules/devices/pci.c:77 modules/devices/usb.c:64
-#: modules/devices/x86/processor.c:651
+#: modules/computer.c:742 modules/computer.c:782 modules/devices/dmi.c:39
+#: modules/devices/dmi.c:45 modules/devices/dmi.c:49 modules/devices/dmi.c:54
+#: modules/devices/dmi_memory.c:750 modules/devices/dmi_memory.c:895
+#: modules/devices/firmware.c:105 modules/devices/firmware.c:168
+#: modules/devices/firmware.c:190 modules/devices/firmware.c:228
+#: modules/devices/gpu.c:74 modules/devices/gpu.c:82 modules/devices/gpu.c:224
+#: modules/devices/ia64/processor.c:161 modules/devices/inputdevices.c:114
+#: modules/devices/monitors.c:398 modules/devices/pci.c:87
+#: modules/devices/pci.c:95 modules/devices/usb.c:168
+#: modules/devices/x86/processor.c:653
 msgid "Vendor"
 msgstr "销售者"
 
-#: modules/computer.c:603
+#: modules/computer.c:744
 msgid "Release Number"
 msgstr ""
 
-#: modules/computer.c:611
+#: modules/computer.c:752
 msgid "Screens"
 msgstr "屏幕"
 
-#: modules/computer.c:617
+#: modules/computer.c:758
 msgid "Disconnected"
 msgstr "已断开"
 
-#: modules/computer.c:620
+#: modules/computer.c:761
 msgid "Connected"
 msgstr "已连接"
 
-#: modules/computer.c:624 modules/computer/os.c:78 modules/computer/os.c:234
-#: modules/computer/os.c:392 modules/devices.c:344 modules/devices.c:396
-#: modules/devices/printers.c:99 modules/devices/printers.c:106
-#: modules/devices/printers.c:116 modules/devices/printers.c:131
-#: modules/devices/printers.c:140 modules/devices/printers.c:243
-msgid "Unknown"
-msgstr "未知"
-
-#: modules/computer.c:628
+#: modules/computer.c:769
 msgid "Unused"
 msgstr "未使用"
 
-#: modules/computer.c:629
+#: modules/computer.c:770
 #, c-format
 msgid "%dx%d pixels, offset (%d, %d)"
 msgstr ""
 
-#: modules/computer.c:638
+#: modules/computer.c:779
 msgid "Outputs (XRandR)"
 msgstr "Outputs (XRandR)"
 
-#: modules/computer.c:640
+#: modules/computer.c:781
 msgid "OpenGL (GLX)"
 msgstr "OpenGL (GLX)"
 
-#: modules/computer.c:642
+#: modules/computer.c:783
 msgid "Renderer"
 msgstr "渲染器"
 
-#: modules/computer.c:643
+#: modules/computer.c:784
 msgid "Direct Rendering"
 msgstr "直接渲染"
 
-#: modules/computer.c:645
+#: modules/computer.c:786
 msgid "Version (Compatibility)"
 msgstr ""
 
-#: modules/computer.c:646
+#: modules/computer.c:787
 msgid "Shading Language Version (Compatibility)"
 msgstr ""
 
-#: modules/computer.c:647
+#: modules/computer.c:788
 msgid "Version (Core)"
 msgstr ""
 
-#: modules/computer.c:648
+#: modules/computer.c:789
 msgid "Shading Language Version (Core)"
 msgstr ""
 
-#: modules/computer.c:649
+#: modules/computer.c:790
 msgid "Version (ES)"
 msgstr ""
 
-#: modules/computer.c:650
+#: modules/computer.c:791
 msgid "Shading Language Version (ES)"
 msgstr ""
 
-#: modules/computer.c:651
+#: modules/computer.c:792
 msgid "GLX Version"
 msgstr "GLX 版本"
 
-#: modules/computer.c:672
+#: modules/computer.c:813
 msgid "Group"
 msgstr "组"
 
-#: modules/computer.c:675 modules/computer/users.c:49
+#: modules/computer.c:816 modules/computer/users.c:49
 msgid "Group ID"
 msgstr "组标识"
 
-#: modules/computer.c:811
-msgid "RAM"
-msgstr "内存"
+#. / <value> <unit> "usable memory"
+#: modules/computer.c:909
+#, c-format
+msgid "%0.1f %s available to Linux"
+msgstr ""
 
-#: modules/computer.c:811 modules/devices/devicetree/pmac_data.c:82
+#: modules/computer.c:911 modules/devices/dmi_memory.c:661
+#: modules/devices/dmi_memory.c:809 modules/devices/dmi_memory.c:936
+msgid "GiB"
+msgstr ""
+
+#: modules/computer.c:913 modules/devices/dmi_memory.c:581
+#: modules/devices/dmi_memory.c:663 modules/devices/dmi_memory.c:723
+#: modules/devices/dmi_memory.c:811 modules/devices/dmi_memory.c:857
+#: modules/devices/dmi_memory.c:938 modules/network/net.c:395
+#: modules/network/net.c:417 modules/network/net.c:418
+msgid "MiB"
+msgstr "MiB"
+
+#: modules/computer.c:915 modules/computer/memory_usage.c:77
+#: modules/computer/modules.c:149
+msgid "KiB"
+msgstr "KiB"
+
+#: modules/computer.c:972 modules/devices/devicetree/pmac_data.c:82
 msgid "Motherboard"
 msgstr "主板"
 
-#: modules/computer.c:811
+#: modules/computer.c:1000
 msgid "Graphics"
 msgstr "图形"
 
-#: modules/computer.c:812 modules/devices.c:107
+#: modules/computer.c:1001 modules/devices.c:109
 msgid "Storage"
 msgstr "存储器"
 
-#: modules/computer.c:812 modules/devices.c:103
+#: modules/computer.c:1001 modules/devices.c:105
 msgid "Printers"
 msgstr "打印机"
 
-#: modules/computer.c:812
+#: modules/computer.c:1001
 msgid "Audio"
 msgstr "音频"
 
-#: modules/computer.c:857
+#: modules/computer.c:1050
 msgid "Gathers high-level computer information"
 msgstr ""
 
@@ -1494,7 +1946,9 @@ msgstr "读/写模式"
 msgid "Read-Only"
 msgstr "只读模式"
 
-#: modules/computer/filesystem.c:86 modules/devices/spd-decode.c:1510
+#: modules/computer/filesystem.c:86 modules/devices/dmi_memory.c:609
+#: modules/devices/dmi_memory.c:754 modules/devices/dmi_memory.c:786
+#: modules/devices/dmi_memory.c:825 modules/devices/dmi_memory.c:894
 msgid "Size"
 msgstr "容量"
 
@@ -1510,7 +1964,8 @@ msgstr "可用"
 msgid "Locale Information"
 msgstr "区域信息"
 
-#: modules/computer/languages.c:96
+#: modules/computer/languages.c:96 modules/devices/dmi_memory.c:599
+#: modules/devices/gpu.c:204
 msgid "Source"
 msgstr "源代码"
 
@@ -1526,13 +1981,7 @@ msgstr "电子邮件"
 msgid "Territory"
 msgstr ""
 
-#: modules/computer/languages.c:101 modules/devices/arm/processor.c:341
-#: modules/devices/gpu.c:146 modules/devices/ia64/processor.c:166
-#: modules/devices/pci.c:114 modules/devices/ppc/processor.c:159
-msgid "Revision"
-msgstr "修订版本"
-
-#: modules/computer/languages.c:102 modules/devices/dmi.c:42
+#: modules/computer/languages.c:102 modules/devices/dmi.c:44
 msgid "Date"
 msgstr "时间"
 
@@ -1544,105 +1993,187 @@ msgstr "系统代码集"
 msgid "Couldn't obtain load average"
 msgstr ""
 
-#: modules/computer/modules.c:125 modules/computer/modules.c:126
-#: modules/computer/modules.c:127 modules/computer/modules.c:128
-#: modules/computer/modules.c:129 modules/devices/dmi.c:115
+#: modules/computer/memory_usage.c:106
+msgid "Total Memory"
+msgstr "总内存"
+
+#: modules/computer/memory_usage.c:107
+msgid "Free Memory"
+msgstr "可用内存"
+
+#: modules/computer/memory_usage.c:108
+msgid "Cached Swap"
+msgstr "已缓存的交换分区"
+
+#: modules/computer/memory_usage.c:109
+msgid "High Memory"
+msgstr "高内存"
+
+#: modules/computer/memory_usage.c:110
+msgid "Free High Memory"
+msgstr "可用高内存"
+
+#: modules/computer/memory_usage.c:111
+msgid "Low Memory"
+msgstr "低内存"
+
+#: modules/computer/memory_usage.c:112
+msgid "Free Low Memory"
+msgstr "可用低内存"
+
+#: modules/computer/memory_usage.c:113
+msgid "Virtual Memory"
+msgstr "虚拟内存"
+
+#: modules/computer/memory_usage.c:114
+msgid "Free Virtual Memory"
+msgstr "可用虚拟内存"
+
+#: modules/computer/modules.c:117 modules/computer/modules.c:118
+#: modules/computer/modules.c:119 modules/computer/modules.c:120
+#: modules/computer/modules.c:121 modules/computer/modules.c:122
+#: modules/devices/dmi.c:111 modules/devices/dmi_memory.c:881
+#: modules/devices/firmware.c:246 modules/devices/x86/processor.c:693
 msgid "(Not available)"
 msgstr "（不可用）"
 
-#: modules/computer/modules.c:142
+#: modules/computer/modules.c:148
 msgid "Module Information"
 msgstr "模块信息"
 
-#: modules/computer/modules.c:143
+#: modules/computer/modules.c:148 modules/devices/gpu.c:230
 msgid "Path"
 msgstr "路径"
 
-#: modules/computer/modules.c:144
+#: modules/computer/modules.c:148
 msgid "Used Memory"
 msgstr "已使用内存"
 
-#: modules/computer/modules.c:144 modules/devices/devmemory.c:72
-msgid "KiB"
-msgstr "KiB"
-
-#: modules/computer/modules.c:148
+#: modules/computer/modules.c:150
 msgid "Version Magic"
 msgstr "版本魔数"
 
-#: modules/computer/modules.c:149
+#: modules/computer/modules.c:151
+msgid "In Linus' Tree"
+msgstr ""
+
+#: modules/computer/modules.c:152
+msgid "Retpoline Enabled"
+msgstr ""
+
+#: modules/computer/modules.c:152
 msgid "Copyright"
 msgstr "版权所有"
 
-#: modules/computer/modules.c:150
+#: modules/computer/modules.c:152
 msgid "Author"
 msgstr "作者"
 
-#: modules/computer/modules.c:151
+#: modules/computer/modules.c:153
 msgid "License"
 msgstr "许可协议"
 
-#: modules/computer/modules.c:158
+#: modules/computer/modules.c:159
 msgid "Dependencies"
 msgstr "依赖"
 
-#: modules/computer/os.c:35 modules/computer/os.c:36 modules/computer/os.c:37
-#: modules/computer/os.c:38
+#: modules/computer/os.c:36 modules/computer/os.c:37 modules/computer/os.c:38
+#: modules/computer/os.c:39
 msgid "GNU C Library"
 msgstr "GNU C库"
 
-#: modules/computer/os.c:39
+#: modules/computer/os.c:40
 msgid "uClibc or uClibc-ng"
 msgstr "uClibc or uClibc-ng"
 
-#: modules/computer/os.c:40
+#: modules/computer/os.c:41
 msgid "diet libc"
 msgstr ""
 
-#: modules/computer/os.c:112 modules/computer/os.c:115
+#: modules/computer/os.c:113 modules/computer/os.c:116
 msgid "GNOME Shell "
 msgstr "GNOME Shell "
 
-#: modules/computer/os.c:123 modules/computer/os.c:126
+#: modules/computer/os.c:124 modules/computer/os.c:127
 msgid "Version: "
 msgstr "版本："
 
-#: modules/computer/os.c:157
+#: modules/computer/os.c:146 modules/computer/os.c:149
+msgid "MATE Desktop Environment "
+msgstr ""
+
+#: modules/computer/os.c:180
 #, c-format
 msgid "Unknown (Window Manager: %s)"
 msgstr "未知 (窗口管理器：%s)"
 
 #. /{desktop environment} on {session type}
-#: modules/computer/os.c:168
+#: modules/computer/os.c:191
 #, c-format
 msgid "%s on %s"
 msgstr ""
 
-#: modules/computer/os.c:232
+#: modules/computer/os.c:261
 msgid "Terminal"
 msgstr "终端"
 
+#: modules/computer/os.c:278
+msgid "User access allowed"
+msgstr ""
+
+#: modules/computer/os.c:280
+msgid "User access forbidden"
+msgstr ""
+
+#: modules/computer/os.c:282
+msgid "Access allowed (running as superuser)"
+msgstr ""
+
+#: modules/computer/os.c:284
+msgid "Access forbidden? (running as superuser)"
+msgstr ""
+
+#: modules/computer/os.c:294 modules/computer/os.c:560
+msgid "Disabled"
+msgstr ""
+
+#: modules/computer/os.c:296
+msgid "Partially enabled (mmap base+stack+VDSO base)"
+msgstr ""
+
+#: modules/computer/os.c:298
+msgid "Fully enabled (mmap base+stack+VDSO base+heap)"
+msgstr ""
+
 #. /bits of entropy for rng (0)
-#: modules/computer/os.c:241
+#: modules/computer/os.c:308
 msgid "(None or not available)"
 msgstr ""
 
 #. /bits of entropy for rng (low/poor value)
-#: modules/computer/os.c:242
+#: modules/computer/os.c:309
 #, c-format
 msgid "%d bits (low)"
 msgstr ""
 
 #. /bits of entropy for rng (medium value)
-#: modules/computer/os.c:243
+#: modules/computer/os.c:310
 #, c-format
 msgid "%d bits (medium)"
 msgstr ""
 
 #. /bits of entropy for rng (high/good value)
-#: modules/computer/os.c:244
+#: modules/computer/os.c:311
 #, c-format
 msgid "%d bits (healthy)"
+msgstr ""
+
+#: modules/computer/os.c:555
+msgid "Not installed"
+msgstr ""
+
+#: modules/computer/os.c:558
+msgid "Enabled"
 msgstr ""
 
 #: modules/computer/users.c:47
@@ -1657,13 +2188,13 @@ msgstr "用户标识"
 msgid "Default Shell"
 msgstr "默认 Shell"
 
-#: modules/devices/alpha/processor.c:88 modules/devices/devicetree.c:161
-#: modules/devices/devicetree.c:207 modules/devices/devicetree/pmac_data.c:80
-#: modules/devices/gpu.c:124 modules/devices/ia64/processor.c:165
+#: modules/devices/alpha/processor.c:88 modules/devices/devicetree.c:163
+#: modules/devices/devicetree.c:209 modules/devices/devicetree/pmac_data.c:80
+#: modules/devices/gpu.c:106 modules/devices/ia64/processor.c:165
 #: modules/devices/m68k/processor.c:84 modules/devices/mips/processor.c:75
-#: modules/devices/parisc/processor.c:155 modules/devices/ppc/processor.c:158
-#: modules/devices/riscv/processor.c:182 modules/devices/s390/processor.c:132
-#: modules/devices/spd-decode.c:1510
+#: modules/devices/monitors.c:400 modules/devices/parisc/processor.c:155
+#: modules/devices/ppc/processor.c:158 modules/devices/riscv/processor.c:182
+#: modules/devices/s390/processor.c:132
 msgid "Model"
 msgstr "模型"
 
@@ -1671,28 +2202,28 @@ msgstr "模型"
 msgid "Platform String"
 msgstr ""
 
-#: modules/devices/alpha/processor.c:90 modules/devices/arm/processor.c:331
+#: modules/devices/alpha/processor.c:90 modules/devices/arm/processor.c:345
 #: modules/devices/ia64/processor.c:167 modules/devices/m68k/processor.c:87
 #: modules/devices/mips/processor.c:77 modules/devices/parisc/processor.c:158
 #: modules/devices/ppc/processor.c:160 modules/devices/riscv/processor.c:186
-#: modules/devices/sh/processor.c:87 modules/devices/x86/processor.c:655
+#: modules/devices/sh/processor.c:87 modules/devices/x86/processor.c:657
 msgid "Frequency"
 msgstr "频率"
 
-#: modules/devices/alpha/processor.c:91 modules/devices/arm/processor.c:332
+#: modules/devices/alpha/processor.c:91 modules/devices/arm/processor.c:346
 #: modules/devices/ia64/processor.c:168 modules/devices/m68k/processor.c:88
 #: modules/devices/mips/processor.c:78 modules/devices/parisc/processor.c:159
 #: modules/devices/ppc/processor.c:161 modules/devices/s390/processor.c:134
-#: modules/devices/sh/processor.c:90 modules/devices/x86/processor.c:656
+#: modules/devices/sh/processor.c:90 modules/devices/x86/processor.c:658
 msgid "BogoMips"
 msgstr "BogoMips"
 
-#: modules/devices/alpha/processor.c:92 modules/devices/arm/processor.c:333
+#: modules/devices/alpha/processor.c:92 modules/devices/arm/processor.c:347
 #: modules/devices/ia64/processor.c:169 modules/devices/m68k/processor.c:89
 #: modules/devices/mips/processor.c:79 modules/devices/parisc/processor.c:160
 #: modules/devices/ppc/processor.c:162 modules/devices/riscv/processor.c:187
 #: modules/devices/s390/processor.c:135 modules/devices/sh/processor.c:91
-#: modules/devices/sparc/processor.c:77 modules/devices/x86/processor.c:657
+#: modules/devices/sparc/processor.c:77 modules/devices/x86/processor.c:659
 msgid "Byte Order"
 msgstr "字节序"
 
@@ -1866,76 +2397,77 @@ msgctxt "arm-flag"
 msgid "Advanced SIMD/NEON on AArch64 (arch>8)"
 msgstr ""
 
-#: modules/devices/arm/processor.c:142
+#: modules/devices/arm/processor.c:143
 msgid "ARM Processor"
 msgstr "ARM 处理器"
 
-#: modules/devices/arm/processor.c:200 modules/devices/riscv/processor.c:147
-#: modules/devices/x86/processor.c:606
+#: modules/devices/arm/processor.c:214 modules/devices/riscv/processor.c:147
+#: modules/devices/x86/processor.c:608
 msgid "Empty List"
 msgstr "空列表"
 
-#: modules/devices/arm/processor.c:226 modules/devices/x86/processor.c:268
+#: modules/devices/arm/processor.c:240 modules/devices/gpu.c:148
+#: modules/devices/gpu.c:226 modules/devices/x86/processor.c:268
 msgid "Clocks"
 msgstr "时钟"
 
-#: modules/devices/arm/processor.c:272 modules/devices/arm/processor.c:285
+#: modules/devices/arm/processor.c:286 modules/devices/arm/processor.c:299
 #: modules/devices/x86/processor.c:314 modules/devices/x86/processor.c:327
 #, c-format
 msgid "%.2f-%.2f %s=%dx\n"
 msgstr ""
 
-#: modules/devices/arm/processor.c:328
+#: modules/devices/arm/processor.c:342
 msgid "Linux Name"
 msgstr ""
 
-#: modules/devices/arm/processor.c:329
+#: modules/devices/arm/processor.c:343
 msgid "Decoded Name"
 msgstr ""
 
-#: modules/devices/arm/processor.c:330 modules/network/net.c:453
+#: modules/devices/arm/processor.c:344 modules/network/net.c:453
 msgid "Mode"
 msgstr "模式"
 
-#: modules/devices/arm/processor.c:336
+#: modules/devices/arm/processor.c:350
 msgid "ARM"
 msgstr "ARM"
 
-#: modules/devices/arm/processor.c:337
+#: modules/devices/arm/processor.c:351
 msgid "Implementer"
 msgstr ""
 
-#: modules/devices/arm/processor.c:338
+#: modules/devices/arm/processor.c:352 modules/devices/dmi_memory.c:896
 msgid "Part"
 msgstr ""
 
-#: modules/devices/arm/processor.c:339 modules/devices/ia64/processor.c:162
+#: modules/devices/arm/processor.c:353 modules/devices/ia64/processor.c:162
 #: modules/devices/parisc/processor.c:156 modules/devices/riscv/processor.c:183
 msgid "Architecture"
 msgstr "架构"
 
-#: modules/devices/arm/processor.c:340
+#: modules/devices/arm/processor.c:354
 msgid "Variant"
 msgstr "变量"
 
-#: modules/devices/arm/processor.c:342 modules/devices/riscv/processor.c:190
-#: modules/devices/sparc/processor.c:78 modules/devices/x86/processor.c:663
+#: modules/devices/arm/processor.c:356 modules/devices/riscv/processor.c:190
+#: modules/devices/sparc/processor.c:78 modules/devices/x86/processor.c:665
 msgid "Capabilities"
 msgstr "容量"
 
-#: modules/devices/arm/processor.c:446
+#: modules/devices/arm/processor.c:468
 msgid "SOC/Package"
 msgstr ""
 
-#: modules/devices/arm/processor.c:450 modules/devices/x86/processor.c:698
+#: modules/devices/arm/processor.c:472 modules/devices/x86/processor.c:751
 msgid "Logical CPU Config"
 msgstr "逻辑 CPU 配置"
 
-#: modules/devices/arm/processor.c:467
+#: modules/devices/arm/processor.c:489
 msgid "SOC/Package Information"
 msgstr ""
 
-#: modules/devices/battery.c:181
+#: modules/devices/battery.c:178
 #, c-format
 msgid ""
 "\n"
@@ -1948,7 +2480,7 @@ msgid ""
 "Serial Number=%s\n"
 msgstr ""
 
-#: modules/devices/battery.c:258
+#: modules/devices/battery.c:255
 #, c-format
 msgid ""
 "\n"
@@ -1961,7 +2493,7 @@ msgid ""
 "Serial Number=%s\n"
 msgstr ""
 
-#: modules/devices/battery.c:346
+#: modules/devices/battery.c:343
 #, c-format
 msgid ""
 "\n"
@@ -1973,7 +2505,7 @@ msgid ""
 "APM BIOS version=%s\n"
 msgstr ""
 
-#: modules/devices/battery.c:358
+#: modules/devices/battery.c:355
 #, c-format
 msgid ""
 "\n"
@@ -1984,7 +2516,7 @@ msgid ""
 "APM BIOS version=%s\n"
 msgstr ""
 
-#: modules/devices/battery.c:385
+#: modules/devices/battery.c:382
 msgid ""
 "[No batteries]\n"
 "No batteries found on this system=\n"
@@ -1994,31 +2526,40 @@ msgstr ""
 msgid "Graphics Processors"
 msgstr "图形处理器"
 
-#: modules/devices.c:101 modules/devices/pci.c:143
+#: modules/devices.c:101 modules/devices/monitors.c:445
+#: modules/devices/monitors.c:492
+msgid "Monitors"
+msgstr ""
+
+#: modules/devices.c:102 modules/devices/pci.c:163
 msgid "PCI Devices"
 msgstr "PCI 设备"
 
-#: modules/devices.c:102 modules/devices/usb.c:92
+#: modules/devices.c:103 modules/devices/usb.c:210
 msgid "USB Devices"
 msgstr "USB 设备"
 
 #: modules/devices.c:104
+msgid "Firmware"
+msgstr ""
+
+#: modules/devices.c:106
 msgid "Battery"
 msgstr "电池"
 
-#: modules/devices.c:105
+#: modules/devices.c:107
 msgid "Sensors"
 msgstr "传感器"
 
-#: modules/devices.c:109
-msgid "DMI"
-msgstr ""
-
 #: modules/devices.c:110
-msgid "Memory SPD"
+msgid "System DMI"
 msgstr ""
 
-#: modules/devices.c:115
+#: modules/devices.c:111
+msgid "Memory Devices"
+msgstr ""
+
+#: modules/devices.c:113 modules/devices.c:115
 msgid "Device Tree"
 msgstr "设备树"
 
@@ -2026,125 +2567,121 @@ msgstr "设备树"
 msgid "Resources"
 msgstr "资源"
 
-#: modules/devices.c:162
+#: modules/devices.c:177
 #, c-format
 msgid "%d physical processor"
 msgid_plural "%d physical processors"
 msgstr[0] ""
 
-#: modules/devices.c:163
+#: modules/devices.c:178
 #, c-format
 msgid "%d core"
 msgid_plural "%d cores"
 msgstr[0] ""
 
-#: modules/devices.c:164
+#: modules/devices.c:179
 #, c-format
 msgid "%d thread"
 msgid_plural "%d threads"
 msgstr[0] "%d 线程"
 
 #. /NP procs; NC cores; NT threads
-#: modules/devices.c:165
+#: modules/devices.c:180
 #, c-format
 msgid "%s; %s; %s"
 msgstr ""
 
-#: modules/devices.c:575
-msgid "Field"
-msgstr "域"
-
-#: modules/devices.c:575 modules/devices.c:614
-msgid "Value"
-msgstr "亮度"
-
-#: modules/devices.c:614
+#: modules/devices.c:726
 msgid "Sensor"
 msgstr "传感器"
 
-#: modules/devices.c:661
+#: modules/devices.c:773 modules/devices/dmi_memory.c:826
 msgid "Devices"
 msgstr "设备"
 
-#: modules/devices.c:673
+#: modules/devices.c:785
 msgid "Update PCI ID listing"
 msgstr ""
 
-#: modules/devices.c:685
+#: modules/devices.c:797
 msgid "Update CPU feature database"
 msgstr ""
 
-#: modules/devices.c:713
+#: modules/devices.c:825
 msgid "Gathers information about hardware devices"
 msgstr ""
 
-#: modules/devices.c:732
+#: modules/devices.c:844
 msgid "Resource information requires superuser privileges"
 msgstr ""
 
-#: modules/devices/devicetree.c:50
+#: modules/devices.c:850
+msgid ""
+"Any NVMe storage devices present are not listed.\n"
+"<b><i>udisksd</i></b> is required for NVMe devices."
+msgstr ""
+
+#: modules/devices/devicetree.c:52
 msgid "Properties"
 msgstr "属性"
 
-#: modules/devices/devicetree.c:51
+#: modules/devices/devicetree.c:53
 msgid "Children"
 msgstr "子女"
 
-#: modules/devices/devicetree.c:87
+#: modules/devices/devicetree.c:89
 msgid "Node"
 msgstr "节点"
 
-#: modules/devices/devicetree.c:88
+#: modules/devices/devicetree.c:90
 msgid "Node Path"
 msgstr "节点路径"
 
-#: modules/devices/devicetree.c:89
+#: modules/devices/devicetree.c:91
 msgid "Alias"
 msgstr "别名"
 
-#: modules/devices/devicetree.c:89 modules/devices/devicetree.c:90
-msgid "(None)"
-msgstr "（无）"
-
-#: modules/devices/devicetree.c:90
+#: modules/devices/devicetree.c:92
 msgid "Symbol"
 msgstr "符号"
 
-#: modules/devices/devicetree.c:143 modules/devices/devicetree/pmac_data.c:79
+#: modules/devices/devicetree.c:145 modules/devices/devicetree/pmac_data.c:79
 msgid "Platform"
 msgstr "平台"
 
-#: modules/devices/devicetree.c:144 modules/devices/devicetree.c:209
+#: modules/devices/devicetree.c:146 modules/devices/devicetree.c:211
+#: modules/devices/gpu.c:231
 msgid "Compatible"
 msgstr ""
 
-#: modules/devices/devicetree.c:145
+#: modules/devices/devicetree.c:147
 msgid "GPU-compatible"
 msgstr ""
 
-#: modules/devices/devicetree.c:160
+#: modules/devices/devicetree.c:162
 msgid "Raspberry Pi or Compatible"
 msgstr ""
 
-#: modules/devices/devicetree.c:162 modules/devices/devicetree.c:189
-#: modules/devices/devicetree.c:208 modules/devices/devicetree/rpi_data.c:161
-#: modules/devices/dmi.c:49 modules/devices/dmi.c:55
+#: modules/devices/devicetree.c:164 modules/devices/devicetree.c:191
+#: modules/devices/devicetree.c:210 modules/devices/devicetree/rpi_data.c:168
+#: modules/devices/dmi.c:41 modules/devices/dmi.c:51 modules/devices/dmi.c:57
+#: modules/devices/usb.c:178
 msgid "Serial Number"
 msgstr "序列号"
 
-#: modules/devices/devicetree.c:163 modules/devices/devicetree/rpi_data.c:158
+#: modules/devices/devicetree.c:165 modules/devices/devicetree/rpi_data.c:165
 msgid "RCode"
 msgstr ""
 
-#: modules/devices/devicetree.c:163
+#: modules/devices/devicetree.c:165
 msgid "No revision code available; unable to lookup model details."
 msgstr ""
 
-#: modules/devices/devicetree.c:188
+#: modules/devices/devicetree.c:190
 msgid "More"
 msgstr "更多"
 
-#: modules/devices/devicetree.c:268
+#: modules/devices/devicetree.c:271
 msgid "Messages"
 msgstr "消息"
 
@@ -2168,87 +2705,51 @@ msgstr "L2 缓存"
 msgid "PMAC Generation"
 msgstr ""
 
-#: modules/devices/devicetree/rpi_data.c:153
-#: modules/devices/devicetree/rpi_data.c:154
+#: modules/devices/devicetree/rpi_data.c:160
+#: modules/devices/devicetree/rpi_data.c:161
 msgid "Raspberry Pi"
 msgstr ""
 
-#: modules/devices/devicetree/rpi_data.c:154
+#: modules/devices/devicetree/rpi_data.c:161
 msgid "Board Name"
 msgstr "主板名称"
 
-#: modules/devices/devicetree/rpi_data.c:155
+#: modules/devices/devicetree/rpi_data.c:162
 msgid "PCB Revision"
 msgstr "PCB 修订版本"
 
-#: modules/devices/devicetree/rpi_data.c:156
+#: modules/devices/devicetree/rpi_data.c:163
 msgid "Introduction"
 msgstr "介绍"
 
-#: modules/devices/devicetree/rpi_data.c:157 modules/devices/spd-decode.c:1510
+#: modules/devices/devicetree/rpi_data.c:164 modules/devices/usb.c:170
 msgid "Manufacturer"
 msgstr "制造商"
 
-#: modules/devices/devicetree/rpi_data.c:159
+#: modules/devices/devicetree/rpi_data.c:166
 msgid "SOC (spec)"
 msgstr ""
 
-#: modules/devices/devicetree/rpi_data.c:160
+#: modules/devices/devicetree/rpi_data.c:167
 msgid "Memory (spec)"
 msgstr ""
 
-#: modules/devices/devicetree/rpi_data.c:162
+#: modules/devices/devicetree/rpi_data.c:169
 msgid "Permanent overvolt bit"
 msgstr ""
 
-#: modules/devices/devicetree/rpi_data.c:162
+#: modules/devices/devicetree/rpi_data.c:169
 msgctxt "rpi-ov-bit"
 msgid "Set"
 msgstr ""
 
-#: modules/devices/devicetree/rpi_data.c:162
+#: modules/devices/devicetree/rpi_data.c:169
 msgctxt "rpi-ov-bit"
 msgid "Not set"
 msgstr ""
 
-#: modules/devices/devmemory.c:101
-msgid "Total Memory"
-msgstr "总内存"
-
-#: modules/devices/devmemory.c:102
-msgid "Free Memory"
-msgstr "可用内存"
-
-#: modules/devices/devmemory.c:103
-msgid "Cached Swap"
-msgstr "已缓存的交换分区"
-
-#: modules/devices/devmemory.c:104
-msgid "High Memory"
-msgstr "高内存"
-
-#: modules/devices/devmemory.c:105
-msgid "Free High Memory"
-msgstr "可用高内存"
-
-#: modules/devices/devmemory.c:106
-msgid "Low Memory"
-msgstr "低内存"
-
-#: modules/devices/devmemory.c:107
-msgid "Free Low Memory"
-msgstr "可用低内存"
-
-#: modules/devices/devmemory.c:108
-msgid "Virtual Memory"
-msgstr "虚拟内存"
-
-#: modules/devices/devmemory.c:109
-msgid "Free Virtual Memory"
-msgstr "可用虚拟内存"
-
-#: modules/devices/dmi.c:36 modules/devices/inputdevices.c:120
-#: modules/devices/usb.c:63
+#: modules/devices/dmi.c:36 modules/devices/inputdevices.c:115
+#: modules/devices/usb.c:167
 msgid "Product"
 msgstr "产品"
 
@@ -2257,90 +2758,402 @@ msgstr "产品"
 msgid "Family"
 msgstr "家族"
 
-#: modules/devices/dmi.c:41
+#: modules/devices/dmi.c:42
+msgid "SKU"
+msgstr ""
+
+#: modules/devices/dmi.c:43
 msgid "BIOS"
 msgstr "BIOS"
 
-#: modules/devices/dmi.c:50 modules/devices/dmi.c:56
+#: modules/devices/dmi.c:52 modules/devices/dmi.c:58
 msgid "Asset Tag"
 msgstr ""
 
-#: modules/devices/dmi.c:51
-msgid "Chassis"
-msgstr ""
-
-#: modules/devices/dmi.c:116
+#: modules/devices/dmi.c:115 modules/devices/dmi_memory.c:882
+#: modules/devices/x86/processor.c:694
 msgid "(Not available; Perhaps try running HardInfo as root.)"
 msgstr ""
 
-#: modules/devices/gpu.c:102 modules/devices/pci.c:79
+#: modules/devices/dmi.c:156
+msgid "DMI Unavailable"
+msgstr ""
+
+#: modules/devices/dmi.c:158
+msgid "DMI is not avaliable. Perhaps this platform does not provide DMI."
+msgstr ""
+
+#: modules/devices/dmi.c:159
+msgid "DMI is not available; Perhaps try running HardInfo as root."
+msgstr ""
+
+#: modules/devices/dmi_memory.c:598
+msgid "Serial Presence Detect (SPD)"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:601
+msgid "SPD Revision"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:602 modules/devices/dmi_memory.c:748
+msgid "Form Factor"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:604
+msgid "Module Vendor"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:606
+msgid "DRAM Vendor"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:608 modules/devices/dmi_memory.c:753
+msgid "Part Number"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:610
+msgid "Manufacturing Date (Week / Year)"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:644 modules/devices/dmi_memory.c:879
+msgid "Memory Device List"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:686
+msgid "Memory Array"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:687 modules/devices/x86/processor.c:713
+msgid "DMI Handle"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:688 modules/devices/dmi_memory.c:746
+#: modules/devices/dmi_memory.c:784 modules/devices/dmi_memory.c:893
+msgid "Locator"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:689
+msgid "Use"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:690
+msgid "Error Correction Type"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:691
+msgid "Size (Present / Max)"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:692
+msgid "Devices (Populated / Sockets)"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:693 modules/devices/dmi_memory.c:827
+msgid "Types Present"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:744 modules/devices/dmi_memory.c:782
+msgid "Memory Socket"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:745 modules/devices/dmi_memory.c:783
+msgid "DMI Handles (Array, Socket)"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:747 modules/devices/dmi_memory.c:785
+msgid "Bank Locator"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:755
+msgid "Rated Speed"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:756
+msgid "Configured Speed"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:757
+msgid "Data Width/Total Width"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:758
+msgid "Rank"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:759
+msgid "Minimum Voltage"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:760
+msgid "Maximum Voltage"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:761
+msgid "Configured Voltage"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:786 modules/devices/dmi_memory.c:793
+#: modules/devices/monitors.c:492
+msgid "(Empty)"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:824
+msgid "Serial Presence Detect (SPD) Summary"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:947
+msgid " <b><i>dmidecode</i></b> utility available"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:948
+msgid " ... <i>and</i> HardInfo running with superuser privileges"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:949
+msgid " <b><i>eeprom</i></b> module loaded (for SDR, DDR, DDR2, DDR3)"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:950
+msgid ""
+" ... <i>or</i> <b><i>ee1004</i></b> module loaded <b>and configured!</b> "
+"(for DDR4)"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:961
+msgid "Memory information requires <b>one or both</b> of the following:"
+msgstr ""
+
+#: modules/devices/dmi_memory.c:982
+msgid ""
+"\"More often than not, information contained in the DMI tables is "
+"inaccurate,\n"
+"incomplete or simply wrong.\" -<i><b>dmidecode</b></i> manual page"
+msgstr ""
+
+#: modules/devices/firmware.c:69
+msgid "Device cannot be removed easily"
+msgstr ""
+
+#: modules/devices/firmware.c:70
+msgid "Device is updatable in this or any other mode"
+msgstr ""
+
+#: modules/devices/firmware.c:71
+msgid "Update can only be done from offline mode"
+msgstr ""
+
+#: modules/devices/firmware.c:72
+msgid "Requires AC power"
+msgstr ""
+
+#: modules/devices/firmware.c:73
+msgid "Is locked and can be unlocked"
+msgstr ""
+
+#: modules/devices/firmware.c:74
+msgid "Is found in current metadata"
+msgstr ""
+
+#: modules/devices/firmware.c:75
+msgid "Requires a bootloader mode to be manually enabled by the user"
+msgstr ""
+
+#: modules/devices/firmware.c:76
+msgid "Has been registered with other plugins"
+msgstr ""
+
+#: modules/devices/firmware.c:77
+msgid "Requires a reboot to apply firmware or to reload hardware"
+msgstr ""
+
+#: modules/devices/firmware.c:78
+msgid "Requires system shutdown to apply firmware"
+msgstr ""
+
+#: modules/devices/firmware.c:79
+msgid "Has been reported to a metadata server"
+msgstr ""
+
+#: modules/devices/firmware.c:80
+msgid "User has been notified"
+msgstr ""
+
+#: modules/devices/firmware.c:81
+msgid "Always use the runtime version rather than the bootloader"
+msgstr ""
+
+#: modules/devices/firmware.c:82
+msgid "Install composite firmware on the parent before the child"
+msgstr ""
+
+#: modules/devices/firmware.c:83
+msgid "Is currently in bootloader mode"
+msgstr ""
+
+#: modules/devices/firmware.c:84
+msgid "The hardware is waiting to be replugged"
+msgstr ""
+
+#: modules/devices/firmware.c:85
+msgid "Ignore validation safety checks when flashing this device"
+msgstr ""
+
+#: modules/devices/firmware.c:86
+msgid "Requires the update to be retried with a new plugin"
+msgstr ""
+
+#: modules/devices/firmware.c:87
+msgid "Do not add instance IDs from the device baseclass"
+msgstr ""
+
+#: modules/devices/firmware.c:88
+msgid "Device update needs to be separately activated"
+msgstr ""
+
+#: modules/devices/firmware.c:89
+msgid ""
+"Ensure the version is a valid semantic version, e.g. numbers separated with "
+"dots"
+msgstr ""
+
+#: modules/devices/firmware.c:90
+msgid "Extra metadata can be exposed about this device"
+msgstr ""
+
+#: modules/devices/firmware.c:104
+msgid "DeviceId"
+msgstr ""
+
+#: modules/devices/firmware.c:104
+msgid "Guid"
+msgstr ""
+
+#: modules/devices/firmware.c:104
+msgid "Plugin"
+msgstr ""
+
+#: modules/devices/firmware.c:104 modules/network.c:380
+msgid "Flags"
+msgstr "标志"
+
+#: modules/devices/firmware.c:105
+msgid "VendorId"
+msgstr ""
+
+#: modules/devices/firmware.c:105
+msgid "VersionBootloader"
+msgstr ""
+
+#: modules/devices/firmware.c:106
+msgid "Icon"
+msgstr ""
+
+#: modules/devices/firmware.c:106
+msgid "InstallDuration"
+msgstr ""
+
+#: modules/devices/firmware.c:106
+msgid "Created"
+msgstr ""
+
+#: modules/devices/firmware.c:245
+msgid "Firmware List"
+msgstr ""
+
+#: modules/devices/firmware.c:258
+msgid "Requires the <i><b>fwupdmgr</b></i> utility."
+msgstr ""
+
+#: modules/devices/gpu.c:84 modules/devices/pci.c:97
 msgid "SVendor"
 msgstr ""
 
-#: modules/devices/gpu.c:103 modules/devices/pci.c:80
+#: modules/devices/gpu.c:85 modules/devices/pci.c:98
 msgid "SDevice"
 msgstr ""
 
-#: modules/devices/gpu.c:111 modules/devices/pci.c:90
+#: modules/devices/gpu.c:93 modules/devices/pci.c:108
 msgid "PCI Express"
 msgstr ""
 
-#: modules/devices/gpu.c:112 modules/devices/pci.c:92
+#: modules/devices/gpu.c:94 modules/devices/pci.c:110
 msgid "Maximum Link Width"
 msgstr ""
 
-#: modules/devices/gpu.c:113 modules/devices/pci.c:94
+#: modules/devices/gpu.c:95 modules/devices/pci.c:112
 msgid "Maximum Link Speed"
 msgstr ""
 
-#: modules/devices/gpu.c:113 modules/devices/pci.c:93 modules/devices/pci.c:94
+#: modules/devices/gpu.c:95 modules/devices/pci.c:111 modules/devices/pci.c:112
 msgid "GT/s"
 msgstr "GT/s"
 
-#: modules/devices/gpu.c:123
+#: modules/devices/gpu.c:105
 msgid "NVIDIA"
 msgstr "NVIDIA"
 
-#: modules/devices/gpu.c:125
+#: modules/devices/gpu.c:107
 msgid "BIOS Version"
 msgstr "BIOS 版本"
 
-#: modules/devices/gpu.c:126
+#: modules/devices/gpu.c:108
 msgid "UUID"
 msgstr "UUID"
 
-#: modules/devices/gpu.c:141 modules/devices/gpu.c:183
-#: modules/devices/inputdevices.c:115 modules/devices/pci.c:111
-#: modules/devices/usb.c:62
+#: modules/devices/gpu.c:142 modules/devices/gpu.c:222
+#: modules/devices/inputdevices.c:110 modules/devices/pci.c:129
+#: modules/devices/usb.c:166
 msgid "Device Information"
 msgstr "设备信息"
 
-#: modules/devices/gpu.c:142 modules/devices/gpu.c:184
+#: modules/devices/gpu.c:143 modules/devices/gpu.c:223
 msgid "Location"
 msgstr "位置"
 
-#: modules/devices/gpu.c:143
+#: modules/devices/gpu.c:144
 msgid "DRM Device"
 msgstr "DRM 设备"
 
-#: modules/devices/gpu.c:144 modules/devices/pci.c:112 modules/devices/usb.c:67
+#: modules/devices/gpu.c:145 modules/devices/pci.c:130
+#: modules/devices/usb.c:133 modules/devices/usb.c:174
 msgid "Class"
 msgstr "分类"
 
-#: modules/devices/gpu.c:150 modules/devices/pci.c:117
+#: modules/devices/gpu.c:154 modules/devices/pci.c:135
 msgid "In Use"
 msgstr "使用中"
 
-#: modules/devices/gpu.c:174
+#: modules/devices/gpu.c:185
 msgid "Unknown integrated GPU"
 msgstr ""
 
-#: modules/devices/gpu.c:185
-msgid "DT Compatibility"
+#: modules/devices/gpu.c:191
+msgid "clock-frequency property"
 msgstr ""
 
-#: modules/devices/gpu.c:201
+#: modules/devices/gpu.c:192
+msgid "Operating Points (OPPv1)"
+msgstr ""
+
+#: modules/devices/gpu.c:193
+msgid "Operating Points (OPPv2)"
+msgstr ""
+
+#: modules/devices/gpu.c:229
+msgid "Device Tree Node"
+msgstr ""
+
+#: modules/devices/gpu.c:232 modules/devices/monitors.c:471
+#: modules/network/net.c:454
+msgid "Status"
+msgstr "状态"
+
+#: modules/devices/gpu.c:249
 msgid "GPUs"
+msgstr ""
+
+#: modules/devices/gpu.c:273
+msgid "No GPU devices found"
 msgstr ""
 
 #: modules/devices/ia64/processor.c:108
@@ -2359,16 +3172,16 @@ msgstr ""
 msgid "Features"
 msgstr "功能"
 
-#: modules/devices/inputdevices.c:118 modules/devices/pci.c:121
-#: modules/devices/usb.c:71
+#: modules/devices/inputdevices.c:113 modules/devices/pci.c:139
+#: modules/devices/usb.c:180
 msgid "Bus"
 msgstr "总线"
 
-#: modules/devices/inputdevices.c:124
+#: modules/devices/inputdevices.c:119
 msgid "Connected to"
 msgstr "连接到"
 
-#: modules/devices/inputdevices.c:128
+#: modules/devices/inputdevices.c:123
 msgid "InfraRed port"
 msgstr ""
 
@@ -2388,13 +3201,157 @@ msgstr "校正"
 msgid "System Type"
 msgstr "系统类型"
 
+#: modules/devices/monitors.c:29 modules/devices/monitors.c:253
+#: modules/devices/monitors.c:346 modules/devices/spd-decode.c:595
+msgid "(Unspecified)"
+msgstr ""
+
+#: modules/devices/monitors.c:228
+#, c-format
+msgid "Week %d of %d"
+msgstr ""
+
+#: modules/devices/monitors.c:238
+msgid "Ok"
+msgstr ""
+
+#: modules/devices/monitors.c:238
+msgid "Fail"
+msgstr ""
+
+#: modules/devices/monitors.c:266 modules/devices/monitors.c:274
+#: modules/devices/monitors.c:282 modules/devices/monitors.c:293
+#: modules/devices/monitors.c:301 modules/devices/monitors.c:308
+#: modules/devices/monitors.c:316 modules/devices/monitors.c:324
+#: modules/devices/monitors.c:332 modules/devices/monitors.c:338
+msgid "(Empty List)"
+msgstr ""
+
+#: modules/devices/monitors.c:390
+msgid "Signal Type"
+msgstr ""
+
+#: modules/devices/monitors.c:390
+msgid "Digital"
+msgstr ""
+
+#: modules/devices/monitors.c:390
+msgid "Analog"
+msgstr ""
+
+#: modules/devices/monitors.c:391 modules/devices/usb.c:132
+#: modules/network.c:310 modules/network.c:363 modules/network.c:380
+msgid "Interface"
+msgstr "界面"
+
+#: modules/devices/monitors.c:392
+msgid "Bits per Color Channel"
+msgstr ""
+
+#: modules/devices/monitors.c:393
+msgid "Speaker Allocation"
+msgstr ""
+
+#: modules/devices/monitors.c:394
+msgid "Output (Max)"
+msgstr ""
+
+#: modules/devices/monitors.c:397
+msgid "EDID Device"
+msgstr ""
+
+#: modules/devices/monitors.c:401
+msgid "Serial"
+msgstr ""
+
+#: modules/devices/monitors.c:402
+msgid "Manufacture Date"
+msgstr ""
+
+#: modules/devices/monitors.c:403
+msgid "EDID Meta"
+msgstr ""
+
+#: modules/devices/monitors.c:404
+msgid "Data Size"
+msgstr ""
+
+#: modules/devices/monitors.c:404
+msgid "bytes"
+msgstr ""
+
+#: modules/devices/monitors.c:406
+msgid "Extension Blocks"
+msgstr ""
+
+#: modules/devices/monitors.c:407
+msgid "Extended to"
+msgstr ""
+
+#: modules/devices/monitors.c:408
+msgid "Checksum"
+msgstr ""
+
+#: modules/devices/monitors.c:409
+msgid "EDID Descriptors"
+msgstr ""
+
+#: modules/devices/monitors.c:410
+msgid "Detailed Timing Descriptors (DTD)"
+msgstr ""
+
+#: modules/devices/monitors.c:411
+msgid "Established Timings Bitmap (ETB)"
+msgstr ""
+
+#: modules/devices/monitors.c:412
+msgid "Standard Timings (STD)"
+msgstr ""
+
+#: modules/devices/monitors.c:413
+msgid "E-EDID Extension Blocks"
+msgstr ""
+
+#: modules/devices/monitors.c:414
+msgid "EIA/CEA-861 Data Blocks"
+msgstr ""
+
+#: modules/devices/monitors.c:415
+msgid "EIA/CEA-861 Short Audio Descriptors"
+msgstr ""
+
+#: modules/devices/monitors.c:416
+msgid "EIA/CEA-861 Short Video Descriptors"
+msgstr ""
+
+#: modules/devices/monitors.c:417
+msgid "DisplayID Timings"
+msgstr ""
+
+#: modules/devices/monitors.c:418
+msgid "DisplayID Strings"
+msgstr ""
+
+#: modules/devices/monitors.c:419
+msgid "Hex Dump"
+msgstr ""
+
+#: modules/devices/monitors.c:419
+msgid "Data"
+msgstr ""
+
+#: modules/devices/monitors.c:469 modules/devices/monitors.c:501
+#: modules/devices/pci.c:137 modules/devices/usb.c:179
+msgid "Connection"
+msgstr "连接"
+
+#: modules/devices/monitors.c:470
+msgid "DRM"
+msgstr ""
+
 #: modules/devices/parisc/processor.c:107
 msgid "PA-RISC Processor"
 msgstr ""
-
-#: modules/devices/parisc/processor.c:157
-msgid "System"
-msgstr "系统"
 
 #: modules/devices/parisc/processor.c:161
 msgid "HVersion"
@@ -2404,31 +3361,23 @@ msgstr ""
 msgid "SVersion"
 msgstr ""
 
-#: modules/devices/parisc/processor.c:163 modules/devices/x86/processor.c:660
-msgid "Cache"
-msgstr "缓存"
-
-#: modules/devices/pci.c:91
+#: modules/devices/pci.c:109
 msgid "Link Width"
 msgstr ""
 
-#: modules/devices/pci.c:93
+#: modules/devices/pci.c:111
 msgid "Link Speed"
 msgstr ""
 
-#: modules/devices/pci.c:119 modules/devices/usb.c:70
-msgid "Connection"
-msgstr "连接"
-
-#: modules/devices/pci.c:120
+#: modules/devices/pci.c:138
 msgid "Domain"
 msgstr "域"
 
-#: modules/devices/pci.c:123
+#: modules/devices/pci.c:141
 msgid "Function"
 msgstr "功能"
 
-#: modules/devices/pci.c:161
+#: modules/devices/pci.c:185
 msgid "No PCI devices found"
 msgstr "未找到 PCI 设备"
 
@@ -2636,52 +3585,429 @@ msgstr ""
 msgid "Module Frequency"
 msgstr ""
 
-#: modules/devices/spd-decode.c:1475
+#: modules/devices/spd-decode.c:306
+msgid "Row address bits"
+msgstr ""
+
+#: modules/devices/spd-decode.c:307
+msgid "Column address bits"
+msgstr ""
+
+#: modules/devices/spd-decode.c:308
+msgid "Number of rows"
+msgstr ""
+
+#: modules/devices/spd-decode.c:309
+msgid "Data width"
+msgstr ""
+
+#: modules/devices/spd-decode.c:310
+msgid "Interface signal levels"
+msgstr ""
+
+#: modules/devices/spd-decode.c:311
+msgid "Configuration type"
+msgstr ""
+
+#: modules/devices/spd-decode.c:312
+msgid "Refresh"
+msgstr ""
+
+#: modules/devices/spd-decode.c:313 modules/devices/spd-decode.c:397
+#: modules/devices/spd-decode.c:492 modules/devices/spd-decode.c:617
+msgid "Timings"
+msgstr ""
+
+#: modules/devices/spd-decode.c:593
+msgid "Ranks"
+msgstr ""
+
+#: modules/devices/spd-decode.c:594
+msgid "IO Pins per Chip"
+msgstr ""
+
+#: modules/devices/spd-decode.c:595
+msgid "Die count"
+msgstr ""
+
+#: modules/devices/spd-decode.c:596
+msgid "Thermal Sensor"
+msgstr ""
+
+#: modules/devices/spd-decode.c:596
+msgid "Present"
+msgstr ""
+
+#: modules/devices/spd-decode.c:596
+msgid "Not present"
+msgstr ""
+
+#: modules/devices/spd-decode.c:597
+msgid "Supported Voltages"
+msgstr ""
+
+#: modules/devices/spd-decode.c:601
+msgid "Supported CAS Latencies"
+msgstr ""
+
+#: modules/devices/spd-decode.c:638
+msgid "Invalid"
+msgstr ""
+
+#: modules/devices/spd-decode.c:870
+msgid "XMP Profile"
+msgstr ""
+
+#: modules/devices/spd-decode.c:871 modules/devices/usb.c:173
+msgid "Speed"
+msgstr ""
+
+#: modules/devices/spd-decode.c:872 modules/devices/spd-decode.c:914
+#: modules/devices/x86/processor.c:715
+msgid "Voltage"
+msgstr ""
+
+#: modules/devices/spd-decode.c:873
+msgid "XMP Timings"
+msgstr ""
+
+#: modules/devices/spd-decode.c:915
+msgid "XMP"
+msgstr ""
+
+#: modules/devices/spd-decode.c:916
+msgid "JEDEC Timings"
+msgstr ""
+
+#: modules/devices/storage.c:84
+msgid "Read Error Rate"
+msgstr ""
+
+#: modules/devices/storage.c:85
+msgid "Throughput Performance"
+msgstr ""
+
+#: modules/devices/storage.c:86
+msgid "Spin-Up Time"
+msgstr ""
+
+#: modules/devices/storage.c:87
+msgid "Start/Stop Count"
+msgstr ""
+
+#: modules/devices/storage.c:88
+msgid "Reallocated Sector Count"
+msgstr ""
+
+#: modules/devices/storage.c:89
+msgid "Read Channel Margin"
+msgstr ""
+
+#: modules/devices/storage.c:90
+msgid "Seek Error Rate"
+msgstr ""
+
+#: modules/devices/storage.c:91
+msgid "Seek Timer Performance"
+msgstr ""
+
+#: modules/devices/storage.c:92 modules/devices/storage.c:131
+msgid "Power-On Hours"
+msgstr ""
+
+#: modules/devices/storage.c:93
+msgid "Spin Retry Count"
+msgstr ""
+
+#: modules/devices/storage.c:94
+msgid "Calibration Retry Count"
+msgstr ""
+
+#: modules/devices/storage.c:95
+msgid "Power Cycle Count"
+msgstr ""
+
+#: modules/devices/storage.c:96 modules/devices/storage.c:113
+msgid "Soft Read Error Rate"
+msgstr ""
+
+#: modules/devices/storage.c:97
+msgid "Runtime Bad Block"
+msgstr ""
+
+#: modules/devices/storage.c:98
+msgid "End-to-End error"
+msgstr ""
+
+#: modules/devices/storage.c:99
+msgid "Reported Uncorrectable Errors"
+msgstr ""
+
+#: modules/devices/storage.c:100
+msgid "Command Timeout"
+msgstr ""
+
+#: modules/devices/storage.c:101
+msgid "High Fly Writes"
+msgstr ""
+
+#: modules/devices/storage.c:102
+msgid "Airflow Temperature"
+msgstr ""
+
+#: modules/devices/storage.c:103
+msgid "G-sense Error Rate"
+msgstr ""
+
+#: modules/devices/storage.c:104
+msgid "Power-off Retract Count"
+msgstr ""
+
+#: modules/devices/storage.c:105
+msgid "Load Cycle Count"
+msgstr ""
+
+#: modules/devices/storage.c:106 modules/devices/storage.c:129
+msgid "Temperature"
+msgstr ""
+
+#: modules/devices/storage.c:107
+msgid "Hardware ECC Recovered"
+msgstr ""
+
+#: modules/devices/storage.c:108
+msgid "Reallocation Event Count"
+msgstr ""
+
+#: modules/devices/storage.c:109
+msgid "Current Pending Sector Count"
+msgstr ""
+
+#: modules/devices/storage.c:110
+msgid "Uncorrectable Sector Count"
+msgstr ""
+
+#: modules/devices/storage.c:111
+msgid "UltraDMA CRC Error Count"
+msgstr ""
+
+#: modules/devices/storage.c:112
+msgid "Multi-Zone Error Rate"
+msgstr ""
+
+#: modules/devices/storage.c:114
+msgid "Run Out Cancel"
+msgstr ""
+
+#: modules/devices/storage.c:115
+msgid "Flying Height"
+msgstr ""
+
+#: modules/devices/storage.c:116
+msgid "Spin High Current"
+msgstr ""
+
+#: modules/devices/storage.c:117
+msgid "Spin Buzz"
+msgstr ""
+
+#: modules/devices/storage.c:118
+msgid "Offline Seek Performance"
+msgstr ""
+
+#: modules/devices/storage.c:119
+msgid "Disk Shift"
+msgstr ""
+
+#: modules/devices/storage.c:120
+msgid "G-Sense Error Rate"
+msgstr ""
+
+#: modules/devices/storage.c:121
+msgid "Loaded Hours"
+msgstr ""
+
+#: modules/devices/storage.c:122
+msgid "Load/Unload Retry Count"
+msgstr ""
+
+#: modules/devices/storage.c:123
+msgid "Load Friction"
+msgstr ""
+
+#: modules/devices/storage.c:124
+msgid "Load/Unload Cycle Count"
+msgstr ""
+
+#: modules/devices/storage.c:125
+msgid "Load-in time"
+msgstr ""
+
+#: modules/devices/storage.c:126
+msgid "Torque Amplification Count"
+msgstr ""
+
+#: modules/devices/storage.c:127
+msgid "Power-Off Retract Count"
+msgstr ""
+
+#: modules/devices/storage.c:128
+msgid "GMR Head Amplitude"
+msgstr ""
+
+#: modules/devices/storage.c:130
+msgid "Endurance Remaining"
+msgstr ""
+
+#: modules/devices/storage.c:132
+msgid "Good Block Rate"
+msgstr ""
+
+#: modules/devices/storage.c:133
+msgid "Head Flying Hours"
+msgstr ""
+
+#: modules/devices/storage.c:134
+msgid "Read Error Retry Rate"
+msgstr ""
+
+#: modules/devices/storage.c:135
+msgid "Total LBAs Written"
+msgstr ""
+
+#: modules/devices/storage.c:136
+msgid "Total LBAs Read"
+msgstr ""
+
+#: modules/devices/storage.c:141
 msgid ""
-"[SPD]\n"
-"Please load the eeprom module to obtain information about memory SPD=\n"
-"[$ShellParam$]\n"
-"ReloadInterval=500\n"
+"\n"
+"[UDisks2]\n"
 msgstr ""
 
-#: modules/devices/spd-decode.c:1480
+#: modules/devices/storage.c:199
+msgid "Removable"
+msgstr ""
+
+#: modules/devices/storage.c:199
+msgid "Fixed"
+msgstr ""
+
+#: modules/devices/storage.c:202
+msgid "Ejectable"
+msgstr ""
+
+#: modules/devices/storage.c:205
+msgid "Self-monitoring (S.M.A.R.T.)"
+msgstr ""
+
+#: modules/devices/storage.c:208 modules/devices/x86/processor.c:663
+msgid "Power Management"
+msgstr "电源管理"
+
+#: modules/devices/storage.c:211
+msgid "Advanced Power Management"
+msgstr ""
+
+#: modules/devices/storage.c:214
+msgid "Automatic Acoustic Management"
+msgstr ""
+
+#: modules/devices/storage.c:217
+#, c-format
 msgid ""
-"[SPD]\n"
-"Reading memory SPD not supported on this system=\n"
+"[Drive Information]\n"
+"Model=%s\n"
 msgstr ""
 
-#: modules/devices/spd-decode.c:1509
-msgid "SPD"
+#: modules/devices/storage.c:221 modules/devices/storage.c:449
+#: modules/devices/storage.c:648
+#, c-format
+msgid "Vendor=%s\n"
 msgstr ""
 
-#: modules/devices/spd-decode.c:1510
-msgid "Bank"
+#: modules/devices/storage.c:226
+#, c-format
+msgid ""
+"Revision=%s\n"
+"Block Device=%s\n"
+"Serial=%s\n"
+"Size=%s\n"
+"Features=%s\n"
 msgstr ""
 
-#: modules/devices/storage.c:43
+#: modules/devices/storage.c:240
+#, c-format
+msgid "Rotation Rate=%d RPM\n"
+msgstr ""
+
+#: modules/devices/storage.c:243
+#, c-format
+msgid ""
+"Media=%s\n"
+"Media compatibility=%s\n"
+msgstr ""
+
+#: modules/devices/storage.c:250
+#, c-format
+msgid "Connection bus=%s\n"
+msgstr ""
+
+#: modules/devices/storage.c:253
+#, c-format
+msgid ""
+"[Self-monitoring (S.M.A.R.T.)]\n"
+"Status=%s\n"
+"Bad Sectors=%ld\n"
+"Power on time=%d days %d hours\n"
+"Temperature=%d°C\n"
+msgstr ""
+
+#: modules/devices/storage.c:259
+msgid "Failing"
+msgstr ""
+
+#: modules/devices/storage.c:259
+msgid "OK"
+msgstr ""
+
+#: modules/devices/storage.c:265
+msgid ""
+"[S.M.A.R.T. Attributes]\n"
+"Attribute=Normalized Value / Worst / Threshold\n"
+msgstr ""
+
+#: modules/devices/storage.c:297
+#, c-format
+msgid "(%d) %s=%s\n"
+msgstr ""
+
+#: modules/devices/storage.c:306
+#, c-format
+msgid ""
+"[Partition table]\n"
+"Type=%s\n"
+msgstr ""
+
+#: modules/devices/storage.c:325
+#, c-format
+msgid "Partition %s=%s\n"
+msgstr ""
+
+#: modules/devices/storage.c:375
 msgid ""
 "\n"
 "[SCSI Disks]\n"
 msgstr ""
 
-#: modules/devices/storage.c:114 modules/devices/storage.c:320
+#: modules/devices/storage.c:446 modules/devices/storage.c:645
 #, c-format
 msgid ""
 "[Device Information]\n"
 "Model=%s\n"
 msgstr ""
 
-#: modules/devices/storage.c:119 modules/devices/storage.c:326
-#, c-format
-msgid "Vendor=%s (%s)\n"
-msgstr ""
-
-#: modules/devices/storage.c:124 modules/devices/storage.c:328
-#, c-format
-msgid "Vendor=%s\n"
-msgstr ""
-
-#: modules/devices/storage.c:129
+#: modules/devices/storage.c:453
 #, c-format
 msgid ""
 "Type=%s\n"
@@ -2693,18 +4019,18 @@ msgid ""
 "LUN=%d\n"
 msgstr ""
 
-#: modules/devices/storage.c:174
+#: modules/devices/storage.c:499
 msgid ""
 "\n"
 "[IDE Disks]\n"
 msgstr ""
 
-#: modules/devices/storage.c:257
+#: modules/devices/storage.c:582
 #, c-format
 msgid "Driver=%s\n"
 msgstr ""
 
-#: modules/devices/storage.c:331
+#: modules/devices/storage.c:650
 #, c-format
 msgid ""
 "Device Name=hd%c\n"
@@ -2712,7 +4038,7 @@ msgid ""
 "Cache=%dkb\n"
 msgstr ""
 
-#: modules/devices/storage.c:341
+#: modules/devices/storage.c:660
 #, c-format
 msgid ""
 "[Geometry]\n"
@@ -2720,41 +4046,49 @@ msgid ""
 "Logical=%s\n"
 msgstr ""
 
-#: modules/devices/storage.c:351
+#: modules/devices/storage.c:670
 #, c-format
 msgid ""
 "[Capabilities]\n"
 "%s"
 msgstr ""
 
-#: modules/devices/storage.c:358
+#: modules/devices/storage.c:677
 #, c-format
 msgid ""
 "[Speeds]\n"
 "%s"
 msgstr ""
 
-#: modules/devices/usb.c:65
-msgid "Max Current"
-msgstr ""
-
-#: modules/devices/usb.c:65
-msgid "mA"
-msgstr "mA"
-
-#: modules/devices/usb.c:66
-msgid "USB Version"
-msgstr "USB 版本"
-
-#: modules/devices/usb.c:68
+#: modules/devices/usb.c:134 modules/devices/usb.c:175
 msgid "Sub-class"
 msgstr ""
 
-#: modules/devices/usb.c:69
+#: modules/devices/usb.c:135 modules/devices/usb.c:176 modules/network.c:347
+msgid "Protocol"
+msgstr "协议"
+
+#: modules/devices/usb.c:143 modules/network/net.c:451
+msgid "Mb/s"
+msgstr "Mb/s"
+
+#: modules/devices/usb.c:171
+msgid "Max Current"
+msgstr ""
+
+#: modules/devices/usb.c:171
+msgid "mA"
+msgstr "mA"
+
+#: modules/devices/usb.c:172
+msgid "USB Version"
+msgstr "USB 版本"
+
+#: modules/devices/usb.c:177
 msgid "Device Version"
 msgstr "设备版本"
 
-#: modules/devices/usb.c:103
+#: modules/devices/usb.c:221
 msgid "No USB devices found."
 msgstr "没找到 USB 设备"
 
@@ -2794,47 +4128,59 @@ msgstr "缓存"
 msgid "Level %d (%s)#%d=%dx %dKB (%dKB), %d-way set-associative, %d sets\n"
 msgstr ""
 
-#: modules/devices/x86/processor.c:645
+#: modules/devices/x86/processor.c:647
 msgid "Model Name"
 msgstr "型号名称"
 
-#: modules/devices/x86/processor.c:646
+#: modules/devices/x86/processor.c:648
 msgid "Family, model, stepping"
 msgstr ""
 
-#: modules/devices/x86/processor.c:652
+#: modules/devices/x86/processor.c:654
 msgid "Microcode Version"
 msgstr ""
 
-#: modules/devices/x86/processor.c:653
+#: modules/devices/x86/processor.c:655
 msgid "Configuration"
 msgstr "配置"
 
-#: modules/devices/x86/processor.c:654
+#: modules/devices/x86/processor.c:656
 msgid "Cache Size"
 msgstr "缓存大小"
 
-#: modules/devices/x86/processor.c:654
+#: modules/devices/x86/processor.c:656
 msgid "kb"
 msgstr "kb"
 
-#: modules/devices/x86/processor.c:661
-msgid "Power Management"
-msgstr "电源管理"
-
-#: modules/devices/x86/processor.c:662
+#: modules/devices/x86/processor.c:664
 msgid "Bug Workarounds"
 msgstr ""
 
-#: modules/devices/x86/processor.c:695 modules/devices/x86/processor.c:715
+#: modules/devices/x86/processor.c:691
+msgid "Socket Information"
+msgstr ""
+
+#: modules/devices/x86/processor.c:712
+msgid "CPU Socket"
+msgstr ""
+
+#: modules/devices/x86/processor.c:716
+msgid "External Clock"
+msgstr ""
+
+#: modules/devices/x86/processor.c:717
+msgid "Max Frequency"
+msgstr ""
+
+#: modules/devices/x86/processor.c:748 modules/devices/x86/processor.c:769
 msgid "Package Information"
 msgstr ""
 
-#: modules/devices/x86/processor.c:742
+#: modules/devices/x86/processor.c:796
 msgid "Socket:Core"
 msgstr ""
 
-#: modules/devices/x86/processor.c:742
+#: modules/devices/x86/processor.c:796
 msgid "Thread"
 msgstr "线程"
 
@@ -4174,181 +5520,175 @@ msgctxt "x86-flag"
 msgid "CPU is affected by speculative store bypass attack"
 msgstr ""
 
+#. /bug:l1tf
+#: modules/devices/x86/x86_data.c:286
+msgctxt "x86-flag"
+msgid "CPU is affected by L1 Terminal Fault"
+msgstr ""
+
 #. /x86/kernel/cpu/powerflags.h
 #. /flag:pm:ts
-#: modules/devices/x86/x86_data.c:288
+#: modules/devices/x86/x86_data.c:289
 msgctxt "x86-flag"
 msgid "temperature sensor"
 msgstr ""
 
 #. /flag:pm:fid
-#: modules/devices/x86/x86_data.c:289
+#: modules/devices/x86/x86_data.c:290
 msgctxt "x86-flag"
 msgid "frequency id control"
 msgstr ""
 
 #. /flag:pm:vid
-#: modules/devices/x86/x86_data.c:290
+#: modules/devices/x86/x86_data.c:291
 msgctxt "x86-flag"
 msgid "voltage id control"
 msgstr ""
 
 #. /flag:pm:ttp
-#: modules/devices/x86/x86_data.c:291
+#: modules/devices/x86/x86_data.c:292
 msgctxt "x86-flag"
 msgid "thermal trip"
 msgstr ""
 
 #. /flag:pm:tm
-#: modules/devices/x86/x86_data.c:292
+#: modules/devices/x86/x86_data.c:293
 msgctxt "x86-flag"
 msgid "hardware thermal control"
 msgstr ""
 
 #. /flag:pm:stc
-#: modules/devices/x86/x86_data.c:293
+#: modules/devices/x86/x86_data.c:294
 msgctxt "x86-flag"
 msgid "software thermal control"
 msgstr ""
 
 #. /flag:pm:100mhzsteps
-#: modules/devices/x86/x86_data.c:294
+#: modules/devices/x86/x86_data.c:295
 msgctxt "x86-flag"
 msgid "100 MHz multiplier control"
 msgstr ""
 
 #. /flag:pm:hwpstate
-#: modules/devices/x86/x86_data.c:295
+#: modules/devices/x86/x86_data.c:296
 msgctxt "x86-flag"
 msgid "hardware P-state control"
 msgstr ""
 
 #. /flag:pm:cpb
-#: modules/devices/x86/x86_data.c:296
+#: modules/devices/x86/x86_data.c:297
 msgctxt "x86-flag"
 msgid "core performance boost"
 msgstr ""
 
 #. /flag:pm:eff_freq_ro
-#: modules/devices/x86/x86_data.c:297
+#: modules/devices/x86/x86_data.c:298
 msgctxt "x86-flag"
 msgid "Readonly aperf/mperf"
 msgstr ""
 
 #. /flag:pm:proc_feedback
-#: modules/devices/x86/x86_data.c:298
+#: modules/devices/x86/x86_data.c:299
 msgctxt "x86-flag"
 msgid "processor feedback interface"
 msgstr ""
 
 #. /flag:pm:acc_power
-#: modules/devices/x86/x86_data.c:299
+#: modules/devices/x86/x86_data.c:300
 msgctxt "x86-flag"
 msgid "accumulated power mechanism"
 msgstr ""
 
-#: modules/network.c:59
+#: modules/network.c:61
 msgid "Interfaces"
 msgstr "界面"
 
-#: modules/network.c:60
+#: modules/network.c:62
 msgid "IP Connections"
 msgstr "IP 连接"
 
-#: modules/network.c:61
+#: modules/network.c:63
 msgid "Routing Table"
 msgstr ""
 
-#: modules/network.c:62 modules/network.c:303
+#: modules/network.c:64 modules/network.c:309
 msgid "ARP Table"
 msgstr ""
 
-#: modules/network.c:63
+#: modules/network.c:65
 msgid "DNS Servers"
 msgstr "DNS 服务器"
 
-#: modules/network.c:64
+#: modules/network.c:66
 msgid "Statistics"
 msgstr "统计信息"
 
-#: modules/network.c:65
+#: modules/network.c:67
 msgid "Shared Directories"
 msgstr "共享目录"
 
-#: modules/network.c:304 modules/network.c:326 modules/network.c:357
+#: modules/network.c:310 modules/network.c:332 modules/network.c:363
 #: modules/network/net.c:472
 msgid "IP Address"
 msgstr "IP 地址"
 
-#: modules/network.c:304 modules/network.c:357 modules/network.c:374
-msgid "Interface"
-msgstr "界面"
-
-#: modules/network.c:304
+#: modules/network.c:310
 msgid "MAC Address"
 msgstr "MAC 地址"
 
-#: modules/network.c:313
+#: modules/network.c:319
 msgid "SAMBA"
 msgstr ""
 
-#: modules/network.c:314
+#: modules/network.c:320
 msgid "NFS"
 msgstr "NFS"
 
-#: modules/network.c:325
+#: modules/network.c:331
 msgid "Name Servers"
 msgstr "名称服务器"
 
-#: modules/network.c:340
+#: modules/network.c:346
 msgid "Connections"
 msgstr "连接"
 
-#: modules/network.c:341
+#: modules/network.c:347
 msgid "Local Address"
 msgstr "本地地址"
 
-#: modules/network.c:341
-msgid "Protocol"
-msgstr "协议"
-
-#: modules/network.c:341
+#: modules/network.c:347
 msgid "Foreign Address"
 msgstr "外部地址"
 
-#: modules/network.c:341
+#: modules/network.c:347
 msgid "State"
 msgstr "状态"
 
-#: modules/network.c:357
+#: modules/network.c:363
 msgid "Sent"
 msgstr "已发送"
 
-#: modules/network.c:357
+#: modules/network.c:363
 msgid "Received"
 msgstr "已接收"
 
-#: modules/network.c:373
+#: modules/network.c:379
 msgid "IP routing table"
 msgstr "IP 路由表"
 
-#: modules/network.c:374
+#: modules/network.c:380
 msgid "Destination/Gateway"
 msgstr ""
 
-#: modules/network.c:374
-msgid "Flags"
-msgstr "标志"
-
-#: modules/network.c:374 modules/network/net.c:473
+#: modules/network.c:380 modules/network/net.c:473
 msgid "Mask"
 msgstr "掩码"
 
-#: modules/network.c:402
+#: modules/network.c:408
 msgid "Network"
 msgstr "网络"
 
-#: modules/network.c:435
+#: modules/network.c:441
 msgid "Gathers information about this computer's network connection"
 msgstr ""
 
@@ -4518,11 +5858,6 @@ msgstr "网络接口"
 msgid "None Found"
 msgstr "未找到"
 
-#: modules/network/net.c:395 modules/network/net.c:417
-#: modules/network/net.c:418
-msgid "MiB"
-msgstr "MiB"
-
 #: modules/network/net.c:409
 msgid "Network Adapter Properties"
 msgstr ""
@@ -4572,17 +5907,9 @@ msgstr ""
 msgid "Bit Rate"
 msgstr "比特率"
 
-#: modules/network/net.c:451
-msgid "Mb/s"
-msgstr "Mb/s"
-
 #: modules/network/net.c:452
 msgid "Transmission Power"
 msgstr ""
-
-#: modules/network/net.c:454
-msgid "Status"
-msgstr "状态"
 
 #: modules/network/net.c:455
 msgid "Link Quality"
@@ -4604,3 +5931,15 @@ msgstr "(未设定)"
 #: modules/network/net.c:474
 msgid "Broadcast Address"
 msgstr "广播地址"
+
+#~ msgid "Python"
+#~ msgstr "Python"
+
+#~ msgid "CSharp (Mono, old)"
+#~ msgstr "CSharp (Mono, old)"
+
+#~ msgid "CSharp (Mono)"
+#~ msgstr "CSharp (Mono)"
+
+#~ msgid "RAM"
+#~ msgstr "内存"


### PR DESCRIPTION
make fails after 8fd37c17522681918345c0d0f4b8cd561f4f74a6 due to errors in fr.po. First commit removes the problem strings, second commit re-syncs the strings from hardinfo.pot because a couple of problems were translations of older versions of c-strings.