### PR TITLE
x86/processor: bigger buffer for cpuinfo

### DIFF
--- a/modules/devices/x86/processor.c
+++ b/modules/devices/x86/processor.c
@@ -454,8 +454,9 @@ GSList *processor_scan(void)
     GSList *procs = NULL, *l = NULL;
     Processor *processor = NULL;
     FILE *cpuinfo;
-    gchar buffer[PROC_SCAN_READ_BUFFER_SIZE];
+    gchar *buffer;
 
+    buffer = (gchar *) g_malloc(PROC_SCAN_READ_BUFFER_SIZE * sizeof(gchar));
     cpuinfo = fopen(PROC_CPUINFO, "r");
     if (!cpuinfo)
         return NULL;
@@ -513,6 +514,7 @@ GSList *processor_scan(void)
     }
 
     fclose(cpuinfo);
+    g_free(buffer);
 
     /* finish last */
     if (processor)

--- a/modules/devices/x86/processor.c
+++ b/modules/devices/x86/processor.c
@@ -448,7 +448,7 @@ gchar *caches_summary(GSList * processors)
     return ret;
 }
 
-#define PROC_SCAN_READ_BUFFER_SIZE 896
+#define PROC_SCAN_READ_BUFFER_SIZE 1024
 GSList *processor_scan(void)
 {
     GSList *procs = NULL, *l = NULL;

--- a/modules/devices/x86/processor.c
+++ b/modules/devices/x86/processor.c
@@ -456,7 +456,7 @@ GSList *processor_scan(void)
     FILE *cpuinfo;
     gchar *buffer;
 
-    buffer = (gchar *) g_malloc(PROC_SCAN_READ_BUFFER_SIZE * sizeof(gchar));
+    buffer = g_malloc(PROC_SCAN_READ_BUFFER_SIZE);
     cpuinfo = fopen(PROC_CPUINFO, "r");
     if (!cpuinfo)
         return NULL;


### PR DESCRIPTION
Removes warning `Warning: truncated a line (probably flags list) longer than 896 bytes while reading /proc/cpuinfo.`