### PR TITLE
computer/display: add hinotes for wanted extern utils when missing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -216,6 +216,7 @@ set_source_files_properties(
 	modules/devices/dmi_memory.c
 #	modules/devices/spd-decode.c
 	hardinfo/problem_marker.c
+	hardinfo/hinote_util.c
 	PROPERTIES
 	COMPILE_FLAGS "-std=c99 -Wall -Wextra -Wno-unused-function -Wno-deprecated-declarations -Wno-switch"
 )
@@ -278,6 +279,7 @@ add_executable(hardinfo
 	hardinfo/util.c
 	hardinfo/gg_key_file_parse_string_as_value.c
 	hardinfo/problem_marker.c
+	hardinfo/hinote_util.c
 	hardinfo/vendor.c
 	hardinfo/info.c
 	hardinfo/cpu_util.c
@@ -316,6 +318,7 @@ add_executable(hardinfo
 	hardinfo/util.c
 	hardinfo/gg_key_file_parse_string_as_value.c
 	hardinfo/problem_marker.c
+	hardinfo/hinote_util.c
 	hardinfo/vendor.c
 	hardinfo/info.c
 	hardinfo/cpu_util.c

--- a/hardinfo/hinote_util.c
+++ b/hardinfo/hinote_util.c
@@ -1,0 +1,27 @@
+
+#include "hardinfo.h"
+
+/* requires COMPILE_FLAGS "-std=c99" */
+
+static const char bullet_yes[] = "<big><b>\u2713</b></big>";
+static const char bullet_no[] = "<big><b>\u2022<tt> </tt></b></big>";
+static const char bullet_yes_text[] = "[X]";
+static const char bullet_no_text[] = "[ ]";
+
+gboolean note_cond_bullet(gboolean cond, gchar *note_buff, const gchar *desc_str) {
+    int l = strlen(note_buff);
+    if (params.markup_ok)
+        snprintf(note_buff + l, note_max_len - l - 1, "%s %s\n",
+            cond ? bullet_yes : bullet_no, desc_str);
+    else
+        snprintf(note_buff + l, note_max_len - l - 1, "%s %s\n",
+            cond ? bullet_yes_text : bullet_no_text, desc_str);
+    return cond;
+}
+
+gboolean note_require_tool(const gchar *tool, gchar *note_buff, const gchar *desc_str) {
+    gchar *tl = find_program((gchar*)tool);
+    gboolean found = note_cond_bullet(!!tl, note_buff, desc_str);
+    g_free(tl);
+    return found;
+}

--- a/includes/hardinfo.h
+++ b/includes/hardinfo.h
@@ -210,4 +210,13 @@ gboolean hardinfo_spawn_command_line_sync(const gchar *command_line,
 /* a marker in text to point out problems, using markup where possible */
 const char *problem_marker();
 
+/* hinote helpers */
+#define note_max_len 512
+#define note_printf(note_buff, fmt, ...)  \
+    snprintf((note_buff) + strlen(note_buff), note_max_len - strlen(note_buff) - 1, \
+        fmt, ##__VA_ARGS__)
+#define note_print(note_buff, str) note_printf((note_buff), "%s", str)
+gboolean note_cond_bullet(gboolean cond, gchar *note_buff, const gchar *desc_str);
+gboolean note_require_tool(const gchar *tool, gchar *note_buff, const gchar *desc_str);
+
 #endif				/* __HARDINFO_H__ */

--- a/modules/computer.c
+++ b/modules/computer.c
@@ -76,22 +76,40 @@ void scan_env_var(gboolean reload);
 void scan_dev(gboolean reload);
 #endif /* GLIB_CHECK_VERSION(2,14,0) */
 
+enum {
+    ENTRY_SUMMARY,
+    ENTRY_OS,
+    ENTRY_SECURITY,
+    ENTRY_KMOD,
+    ENTRY_BOOTS,
+    ENTRY_LANGUAGES,
+    ENTRY_MEMORY_USAGE,
+    ENTRY_FS,
+    ENTRY_DISPLAY,
+    ENTRY_ENV,
+    ENTRY_DEVEL,
+    ENTRY_USERS,
+    ENTRY_GROUPS
+};
+
 static ModuleEntry entries[] = {
-    {N_("Summary"), "summary.png", callback_summary, scan_summary, MODULE_FLAG_NONE},
-    {N_("Operating System"), "os.png", callback_os, scan_os, MODULE_FLAG_NONE},
-    {N_("Security"), "security.png", callback_security, scan_security, MODULE_FLAG_NONE},
-    {N_("Kernel Modules"), "module.png", callback_modules, scan_modules, MODULE_FLAG_NONE},
-    {N_("Boots"), "boot.png", callback_boots, scan_boots, MODULE_FLAG_NONE},
-    {N_("Languages"), "language.png", callback_locales, scan_locales, MODULE_FLAG_NONE},
-    {N_("Memory Usage"), "memory.png", callback_memory_usage, scan_memory_usage, MODULE_FLAG_NONE},
-    {N_("Filesystems"), "dev_removable.png", callback_fs, scan_fs, MODULE_FLAG_NONE},
-    {N_("Display"), "monitor.png", callback_display, scan_display, MODULE_FLAG_NONE},
-    {N_("Environment Variables"), "environment.png", callback_env_var, scan_env_var, MODULE_FLAG_NONE},
+    [ENTRY_SUMMARY] = {N_("Summary"), "summary.png", callback_summary, scan_summary, MODULE_FLAG_NONE},
+    [ENTRY_OS] = {N_("Operating System"), "os.png", callback_os, scan_os, MODULE_FLAG_NONE},
+    [ENTRY_SECURITY] = {N_("Security"), "security.png", callback_security, scan_security, MODULE_FLAG_NONE},
+    [ENTRY_KMOD] = {N_("Kernel Modules"), "module.png", callback_modules, scan_modules, MODULE_FLAG_NONE},
+    [ENTRY_BOOTS] = {N_("Boots"), "boot.png", callback_boots, scan_boots, MODULE_FLAG_NONE},
+    [ENTRY_LANGUAGES] = {N_("Languages"), "language.png", callback_locales, scan_locales, MODULE_FLAG_NONE},
+    [ENTRY_MEMORY_USAGE] = {N_("Memory Usage"), "memory.png", callback_memory_usage, scan_memory_usage, MODULE_FLAG_NONE},
+    [ENTRY_FS] = {N_("Filesystems"), "dev_removable.png", callback_fs, scan_fs, MODULE_FLAG_NONE},
+    [ENTRY_DISPLAY] = {N_("Display"), "monitor.png", callback_display, scan_display, MODULE_FLAG_NONE},
+    [ENTRY_ENV] = {N_("Environment Variables"), "environment.png", callback_env_var, scan_env_var, MODULE_FLAG_NONE},
 #if GLIB_CHECK_VERSION(2,14,0)
-    {N_("Development"), "devel.png", callback_dev, scan_dev, MODULE_FLAG_NONE},
+    [ENTRY_DEVEL] = {N_("Development"), "devel.png", callback_dev, scan_dev, MODULE_FLAG_NONE},
+#else
+    [ENTRY_DEVEL] = {N_("Development"), "devel.png", callback_dev, scan_dev, MODULE_FLAG_HIDE},
 #endif /* GLIB_CHECK_VERSION(2,14,0) */
-    {N_("Users"), "users.png", callback_users, scan_users, MODULE_FLAG_NONE},
-    {N_("Groups"), "users.png", callback_groups, scan_groups, MODULE_FLAG_NONE},
+    [ENTRY_USERS] = {N_("Users"), "users.png", callback_users, scan_users, MODULE_FLAG_NONE},
+    [ENTRY_GROUPS] = {N_("Groups"), "users.png", callback_groups, scan_groups, MODULE_FLAG_NONE},
     {NULL},
 };
 
@@ -1055,3 +1073,30 @@ ModuleAbout *hi_module_get_about(void)
     return ma;
 }
 
+static const gchar *hinote_kmod() {
+    static gchar note[note_max_len] = "";
+    gboolean ok = TRUE;
+    *note = 0; /* clear */
+    ok &= note_require_tool("lsmod", note, _("<i><b>lsmod</b></i> is required."));
+    return ok ? NULL : g_strstrip(note); /* remove last \n */
+}
+
+static const gchar *hinote_display() {
+    static gchar note[note_max_len] = "";
+    gboolean ok = TRUE;
+    *note = 0; /* clear */
+    ok &= note_require_tool("xrandr", note, _("X.org's <i><b>xrandr</b></i> utility provides additional details when available."));
+    ok &= note_require_tool("glxinfo", note, _("Mesa's <i><b>glxinfo</b></i> utility is required for OpenGL information."));
+    return ok ? NULL : g_strstrip(note); /* remove last \n */
+}
+
+const gchar *hi_note_func(gint entry)
+{
+    if (entry == ENTRY_KMOD) {
+        return hinote_kmod();
+    }
+    else if (entry == ENTRY_DISPLAY) {
+        return hinote_display();
+    }
+    return NULL;
+}

--- a/modules/devices/dmi_memory.c
+++ b/modules/devices/dmi_memory.c
@@ -977,10 +977,9 @@ gchar *memory_devices_get_system_memory_str() {
     return ret;
 }
 
-static gchar *note_state = NULL;
+static gchar note_state[note_max_len] = "";
 
 gboolean memory_devices_hinote(const char **msg) {
-
     gchar *want_dmi    = _(" <b><i>dmidecode</i></b> utility available");
     gchar *want_root   = _(" ... <i>and</i> HardInfo running with superuser privileges");
     gchar *want_eeprom = _(" <b><i>eeprom</i></b> module loaded (for SDR, DDR, DDR2, DDR3)");
@@ -991,15 +990,17 @@ gboolean memory_devices_hinote(const char **msg) {
     gboolean has_eeprom = g_file_test("/sys/bus/i2c/drivers/eeprom", G_FILE_TEST_IS_DIR);
     gboolean has_ee1004 = g_file_test("/sys/bus/i2c/drivers/ee1004", G_FILE_TEST_IS_DIR);
 
-    char *bullet_yes = "<big><b>\u2713</b></big>";
-    char *bullet_no = "<big><b>\u2022<tt> </tt></b></big>";
-
-    g_free(note_state);
-    note_state = g_strdup(_("Memory information requires <b>one or both</b> of the following:"));
-    note_state = appfnl(note_state, "<tt>1. </tt>%s%s", has_dmi ? bullet_yes : bullet_no, want_dmi);
-    note_state = appfnl(note_state, "<tt>   </tt>%s%s", has_root ? bullet_yes : bullet_no, want_root);
-    note_state = appfnl(note_state, "<tt>2. </tt>%s%s", has_eeprom ? bullet_yes : bullet_no, want_eeprom);
-    note_state = appfnl(note_state, "<tt>   </tt>%s%s", has_ee1004 ? bullet_yes : bullet_no, want_ee1004);
+    *note_state = 0; /* clear */
+    note_printf(note_state, "%s\n", _("Memory information requires <b>one or both</b> of the following:"));
+    note_print(note_state, "<tt>1. </tt>");
+    note_cond_bullet(has_dmi, note_state, want_dmi);
+    note_print(note_state, "<tt>   </tt>");
+    note_cond_bullet(has_root, note_state, want_root);
+    note_print(note_state, "<tt>2. </tt>");
+    note_cond_bullet(has_eeprom, note_state, want_eeprom);
+    note_print(note_state, "<tt>   </tt>");
+    note_cond_bullet(has_ee1004, note_state, want_ee1004);
+    g_strstrip(note_state); /* remove last \n */
 
     gboolean ddr3_ee1004 = ((dmi_ram_types & (1<<DDR3_SDRAM)) && has_ee1004);
 


### PR DESCRIPTION
* The check/bullet style for requirements used in Memory Devices can now be used anywhere.
* Used to show requirements for Computer/Display; needs `xrandr` and `glxinfo` or information will be missing. 
* Could be used for others in #243.

Ex: when `xrandr` is available, but `glxinfo` is not:
![Screenshot_2019-12-26_12-20-24](https://user-images.githubusercontent.com/1758090/71486116-5a538c00-27da-11ea-9285-bec84b64aef3.png)

Style from Memory Devices:
![Screenshot_2019-12-26_12-21-10](https://user-images.githubusercontent.com/1758090/71486120-5c1d4f80-27da-11ea-8c40-6481f913a2cf.png)
