### PR TITLE
Vendor Info and colored vendor tags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -236,6 +236,7 @@ add_library(sysobj_early STATIC
 	deps/sysobj_early/src/nice_name.c
 	deps/sysobj_early/gui/uri_handler.c
 	deps/sysobj_early/src/util_edid.c
+	deps/sysobj_early/src/format_early.c
 )
 set_target_properties(sysobj_early PROPERTIES COMPILE_FLAGS "-std=c99 -Wall -Wextra -Wno-parentheses -Wno-unused-function")
 target_link_libraries(sysobj_early m)

--- a/deps/sysobj_early/data/vendor.ids
+++ b/deps/sysobj_early/data/vendor.ids
@@ -1092,6 +1092,13 @@ name CDEmu
     url cdemu.sourceforge.io
     match_string CDEmu
 
+name X.Org Foundation
+    name_short X.Org
+    url www.x.org
+    wikipedia X.Org Foundation
+    ansi_color 0;30;43
+    match_string X.Org
+
 #
 # x86 vendor strings
 #

--- a/deps/sysobj_early/data/vendor.ids
+++ b/deps/sysobj_early/data/vendor.ids
@@ -9,11 +9,21 @@
 #    wikipedia [language:]<article title>[#section]
 #    note <short note>
 #    ansi_color n[;n][...]
-#    [match_string|match_string_case|match_string_exact] <match>
+#    <match_rule> <match_string>
 #    ...
-#    [match_string|match_string_case|match_string_exact] <match>
-#    [match_string|match_string_case|match_string_exact] <match>
+#    <match_rule> <match_string>
+#    <match_rule> <match_string>
 #
+# match rules:
+#    match_string - match a word, ignore case
+#    match_string_case - match a word, consider case
+#    match_string_exact - entire string must match exactly
+#    match_string_prefix - prefix of a word, ignore case
+#    match_string_prefix_case - prefix of a word, consider case
+#    match_string_suffix - suffix of a word, ignore case
+#    match_string_suffix_case - suffix of a word, consider case
+#    match_string_num_prefix - prefix next character must be a digit, ignore case
+#    match_string_num_prefix_case - prefix next character must be a digit, consider case
 #
 # Except for the newline, trailing whitespace is included in the string.
 # Match strings should be unique.

--- a/deps/sysobj_early/include/format_early.h
+++ b/deps/sysobj_early/include/format_early.h
@@ -1,0 +1,43 @@
+/*
+ * sysobj - https://github.com/bp0/verbose-spork
+ * Copyright (C) 2018  Burt P. <pburt0@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ */
+
+#ifndef _FORMAT_EARLY_H_
+#define _FORMAT_EARLY_H_
+
+#include <glib.h>
+#include <strings.h>
+#include "appf.h"
+#include "util_sysobj.h"
+
+enum {
+    FMT_OPT_ATERM  = 1<<16,  /* ANSI color terminal */
+    FMT_OPT_PANGO  = 1<<17,  /* pango markup for gtk */
+    FMT_OPT_HTML   = 1<<18,  /* html */
+};
+
+gchar *safe_ansi_color(gchar *ansi_color, gboolean free_in); /* verify the ansi color */
+const gchar *color_lookup(int ansi_color); /* ansi_color to html color */
+/* wrap the input str with color based on fmt_opts (none,term,html,pango) */
+gchar *format_with_ansi_color(const gchar *str, const gchar *ansi_color, int fmt_opts);
+
+void tag_vendor(gchar **str, guint offset, const gchar *vendor_str, const char *ansi_color, int fmt_opts);
+gchar *vendor_match_tag(const gchar *vendor_str, int fmt_opts);
+
+#endif

--- a/deps/sysobj_early/include/format_early.h
+++ b/deps/sysobj_early/include/format_early.h
@@ -27,6 +27,7 @@
 #include "util_sysobj.h"
 
 enum {
+    FMT_OPT_NONE   = 0,
     FMT_OPT_ATERM  = 1<<16,  /* ANSI color terminal */
     FMT_OPT_PANGO  = 1<<17,  /* pango markup for gtk */
     FMT_OPT_HTML   = 1<<18,  /* html */

--- a/deps/sysobj_early/include/format_early.h
+++ b/deps/sysobj_early/include/format_early.h
@@ -25,6 +25,7 @@
 #include <strings.h>
 #include "appf.h"
 #include "util_sysobj.h"
+#include "vendor.h"
 
 enum {
     FMT_OPT_NONE   = 0,
@@ -40,5 +41,7 @@ gchar *format_with_ansi_color(const gchar *str, const gchar *ansi_color, int fmt
 
 void tag_vendor(gchar **str, guint offset, const gchar *vendor_str, const char *ansi_color, int fmt_opts);
 gchar *vendor_match_tag(const gchar *vendor_str, int fmt_opts);
+
+gchar *vendor_list_ribbon(const vendor_list vl_in, int fmt_opts);
 
 #endif

--- a/deps/sysobj_early/src/format_early.c
+++ b/deps/sysobj_early/src/format_early.c
@@ -1,0 +1,130 @@
+/*
+ * sysobj - https://github.com/bp0/verbose-spork
+ * Copyright (C) 2018  Burt P. <pburt0@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ */
+
+#include "format_early.h"
+#include "vendor.h"
+
+#define ANSI_COLOR_RESET   "\x1b[0m"
+
+const gchar *color_lookup(int ansi_color) {
+    static struct { int ansi; const gchar *html; } tab[] = {
+        { 30,  "#010101" }, { 31,  "#de382b" }, { 32,  "#39b54a" }, { 33,  "#ffc706" },
+        { 34,  "#006fb8" }, { 35,  "#762671" }, { 36,  "#2cb5e9" }, { 37,  "#cccccc" },
+        { 90,  "#808080" }, { 91,  "#ff0000" }, { 92,  "#00ff00" }, { 93,  "#ffff00" },
+        { 94,  "#0000ff" }, { 95,  "#ff00ff" }, { 96,  "#00ffff" }, { 97,  "#ffffff" },
+        { 40,  "#010101" }, { 41,  "#de382b" }, { 42,  "#39b54a" }, { 43,  "#ffc706" },
+        { 44,  "#006fb8" }, { 45,  "#762671" }, { 46,  "#2cb5e9" }, { 47,  "#cccccc" },
+        { 100, "#808080" }, { 101, "#ff0000" }, { 102, "#00ff00" }, { 103, "#ffff00" },
+        { 104, "#0000ff" }, { 105, "#ff00ff" }, { 106, "#00ffff" }, { 107, "#ffffff" },
+    };
+    for (int i = 0; i<(int)G_N_ELEMENTS(tab); i++)
+        if (tab[i].ansi == ansi_color)
+            return tab[i].html;
+    return NULL;
+}
+
+gchar *safe_ansi_color(gchar *ansi_color, gboolean free_in) {
+    if (!ansi_color) return NULL;
+    gchar *ret = NULL;
+    gchar **codes = g_strsplit(ansi_color, ";", -1);
+    if (free_in)
+        g_free(ansi_color);
+    int len = g_strv_length(codes);
+    for(int i = 0; i < len; i++) {
+        int c = atoi(codes[i]);
+        if (c == 0 || c == 1
+            || ( c >= 30 && c <= 37)
+            || ( c >= 40 && c <= 47)
+            || ( c >= 90 && c <= 97)
+            || ( c >= 100 && c <= 107) ) {
+                ret = appf(ret, ";", "%s", codes[i]);
+        }
+    }
+    g_strfreev(codes);
+    return ret;
+}
+
+gchar *format_with_ansi_color(const gchar *str, const gchar *ansi_color, int fmt_opts) {
+    gchar *ret = NULL;
+
+    gchar *safe_color = g_strdup(ansi_color);
+    util_strstrip_double_quotes_dumb(safe_color);
+
+    if (fmt_opts & FMT_OPT_ATERM) {
+        safe_color = safe_ansi_color(safe_color, TRUE);
+        ret = g_strdup_printf("\x1b[%sm%s" ANSI_COLOR_RESET, safe_color, str);
+        goto format_with_ansi_color_end;
+    }
+
+    if (fmt_opts & FMT_OPT_PANGO || fmt_opts & FMT_OPT_HTML) {
+        int fgc = 37, bgc = 40;
+        gchar **codes = g_strsplit(safe_color, ";", -1);
+        int len = g_strv_length(codes);
+        for(int i = 0; i < len; i++) {
+            int c = atoi(codes[i]);
+            if ( (c >= 30 && c <= 37)
+               || ( c >= 90 && c <= 97 ) ) {
+                fgc = c;
+            }
+            if ( (c >= 40 && c <= 47)
+               || ( c >= 100 && c <= 107) ) {
+                bgc = c;
+            }
+        }
+        g_strfreev(codes);
+        const gchar *html_color_fg = color_lookup(fgc);
+        const gchar *html_color_bg = color_lookup(bgc);
+        if (fmt_opts & FMT_OPT_PANGO)
+            ret = g_strdup_printf("<span background=\"%s\" color=\"%s\"><b> %s </b></span>", html_color_bg, html_color_fg, str);
+        else if (fmt_opts & FMT_OPT_HTML)
+            ret = g_strdup_printf("<span style=\"background-color: %s; color: %s;\"><b>&nbsp;%s&nbsp;</b></span>", html_color_bg, html_color_fg, str);
+    }
+
+format_with_ansi_color_end:
+    g_free(safe_color);
+    if (!ret)
+        ret = g_strdup(str);
+    return ret;
+}
+
+void tag_vendor(gchar **str, guint offset, const gchar *vendor_str, const char *ansi_color, int fmt_opts) {
+    if (!str || !*str) return;
+    if (!vendor_str || !ansi_color) return;
+    gchar *work = *str, *new = NULL;
+    if (g_str_has_prefix(work + offset, vendor_str)
+        || strncasecmp(work + offset, vendor_str, strlen(vendor_str)) == 0) {
+        gchar *cvs = format_with_ansi_color(vendor_str, ansi_color, fmt_opts);
+        *(work+offset) = 0;
+        new = g_strdup_printf("%s%s%s", work, cvs, work + offset + strlen(vendor_str) );
+        g_free(work);
+        *str = new;
+        g_free(cvs);
+    }
+}
+
+gchar *vendor_match_tag(const gchar *vendor_str, int fmt_opts) {
+    const Vendor *v = vendor_match(vendor_str, NULL);
+    if (v) {
+        gchar *ven_tag = v->name_short ? g_strdup(v->name_short) : g_strdup(v->name);
+        tag_vendor(&ven_tag, 0, ven_tag, v->ansi_color, fmt_opts);
+        return ven_tag;
+    }
+    return NULL;
+}

--- a/hardinfo/info.c
+++ b/hardinfo/info.c
@@ -276,16 +276,17 @@ static void flatten_group(GString *output, const struct InfoGroup *group, guint 
 
             const gchar *tp = field->tag;
             gboolean tagged = !!tp;
-            gboolean flagged = field->highlight || field->report_details;
+            gboolean flagged = field->highlight || field->report_details || field->value_has_vendor;
             if (!tp) {
                 snprintf(tmp_tag, 255, "ITEM%d-%d", group_count, i);
                 tp = tmp_tag;
             }
 
             if (tagged || flagged || field->icon) {
-                g_string_append_printf(output, "$%s%s%s$",
+                g_string_append_printf(output, "$%s%s%s%s$",
                     field->highlight ? "*" : "",
                     field->report_details ? "!" : "",
+                    field->value_has_vendor ? "^" : "",
                     tp);
             }
 
@@ -462,6 +463,8 @@ struct Info *info_unflatten(const gchar *str)
                     field.report_details = TRUE;
                 if (key_is_highlighted(flags))
                     field.highlight = TRUE;
+                if (key_value_has_vendor_string(flags))
+                    field.value_has_vendor = TRUE;
 
                 g_free(flags);
                 g_array_append_val(group.fields, field);

--- a/hardinfo/usb_util.c
+++ b/hardinfo/usb_util.c
@@ -58,6 +58,7 @@ usbd *usbd_new() {
 void usbd_free(usbd *s) {
     if (s) {
         usbi_list_free(s->if_list);
+        vendor_list_free(s->vendors);
         g_free(s->vendor);
         g_free(s->product);
         g_free(s->manufacturer);
@@ -517,11 +518,17 @@ static usbd *usb_get_device_list_sysfs() {
 }
 
 usbd *usb_get_device_list() {
-    usbd *lst;
+    usbd *lst, *l;
 
     lst = usb_get_device_list_sysfs();
     if (lst == NULL)
         lst = usb_get_device_list_lsusb();
+
+    l = lst;
+    while(l) {
+        l->vendors = vendor_list_remove_duplicates_deep(vendors_match(l->vendor, l->manufacturer, NULL));
+        l = l->next;
+    }
 
     return lst;
 }

--- a/hardinfo/util.c
+++ b/hardinfo/util.c
@@ -535,6 +535,9 @@ void parameters_init(int *argc, char ***argv, ProgramParameters * param)
     if (param->create_report && param->report_format != REPORT_FORMAT_HTML)
         param->markup_ok = FALSE;
 
+    // TODO: fmt_opts: FMT_OPT_ATERM, FMT_OPT_HTML, FMT_OPT_PANGO...
+    param->fmt_opts = FMT_OPT_NONE;
+
     gchar *confdir = g_build_filename(g_get_user_config_dir(), "hardinfo", NULL);
     if (!g_file_test(confdir, G_FILE_TEST_EXISTS)) {
         mkdir(confdir, 0744);

--- a/includes/hardinfo.h
+++ b/includes/hardinfo.h
@@ -29,6 +29,7 @@
 #include "vendor.h"
 #include "gettext.h"
 #include "info.h"
+#include "format_early.h"
 
 #define HARDINFO_COPYRIGHT_LATEST_YEAR 2019
 
@@ -65,6 +66,7 @@ struct _ProgramParameters {
    * https://developer.gnome.org/pango/stable/PangoMarkupFormat.html
    */
   gboolean markup_ok;
+  int fmt_opts;
 
   gint     report_format;
   gint     max_bench_results;

--- a/includes/info.h
+++ b/includes/info.h
@@ -64,6 +64,7 @@ struct InfoField {
     int update_interval;
     gboolean highlight;      /* select in GUI, highlight in report (flag:*) */
     gboolean report_details; /* show moreinfo() in report (flag:!) */
+    gboolean value_has_vendor; /* (flag:^) */
 
     gboolean free_name_on_flatten;
     gboolean free_value_on_flatten;

--- a/includes/shell.h
+++ b/includes/shell.h
@@ -223,18 +223,20 @@ void		shell_set_remote_label(Shell *shell, gchar *label);
  * key syntax:
  *  [$[<flags>][<tag>]$]<name>[#[<dis>]]
  * flags:
- *  [[!][*]]
+ *  [[!][*][^]]
  *  ! = show details (moreinfo) in reports
  *  * = highlight/select this row
+ *  ^ = value is/has a vendor string
  */
 gboolean    key_is_flagged(const gchar *key);       /* has $[<flags>][<tag>]$ at the start of the key */
 gboolean    key_is_highlighted(const gchar *key);   /* flag '*' = select/highlight */
 gboolean    key_wants_details(const gchar *key);    /* flag '!' = report should include the "moreinfo" */
+gboolean key_value_has_vendor_string(const gchar *key); /* flag '^' = try and match the value to a vendor */
 gchar       *key_mi_tag(const gchar *key);          /* moreinfo lookup tag */
 const gchar *key_get_name(const gchar *key);        /* get the key's name, flagged or not */
 /*
  * example for key = "$*!Foo$Bar#7":
- * flags = "$*!Foo$"  // key_is/wants_*() still works on flags
+ * flags = "$*!^Foo$"  // key_is/wants_*() still works on flags
  * tag = "Foo"        // the moreinfo/icon tag
  * name = "Bar#7"     // the full unique name
  * label = "Bar"      // the label displayed

--- a/includes/usb_util.h
+++ b/includes/usb_util.h
@@ -43,6 +43,8 @@ typedef struct usbd {
 
     int speed_mbs;
 
+    vendor_list vendors;
+
     gboolean user_scan; /* not scanned as root */
     struct usbi *if_list;
 

--- a/modules/computer.c
+++ b/modules/computer.c
@@ -592,12 +592,14 @@ gchar *callback_os(void)
         info_field(_("Version"), computer->os->kernel_version),
         info_field(_("C Library"), computer->os->libc),
         info_field(_("Distribution"), computer->os->distro,
+                   .value_has_vendor = TRUE,
                    .icon = distro_icon),
         info_field_last());
 
     if (computer->os->distro_flavor) {
         info_group_add_field(version_group,
             info_field(_("Spin/Flavor"), computer->os->distro_flavor->name,
+                .value_has_vendor = TRUE,
                 .icon = computer->os->distro_flavor->icon) );
     }
 
@@ -757,7 +759,7 @@ gchar *callback_display(void)
 
     info_add_group(info, _("X Server"),
         info_field(_("Current Display Name"), THISORUNK(xi->display_name) ),
-        info_field(_("Vendor"), THISORUNK(xi->vendor) ),
+        info_field(_("Vendor"), THISORUNK(xi->vendor), .value_has_vendor = TRUE ),
         info_field(_("Version"), THISORUNK(xi->version) ),
         info_field(_("Release Number"), THISORUNK(xi->release_number) ),
         info_field_last());
@@ -797,7 +799,7 @@ gchar *callback_display(void)
     info_add_computed_group(info, _("Outputs (XRandR)"), outputs_str);
 
     info_add_group(info, _("OpenGL (GLX)"),
-        info_field(_("Vendor"), THISORUNK(glx->ogl_vendor) ),
+        info_field(_("Vendor"), THISORUNK(glx->ogl_vendor), .value_has_vendor = TRUE ),
         info_field(_("Renderer"), THISORUNK(glx->ogl_renderer) ),
         info_field(_("Direct Rendering"),
             glx->direct_rendering ? _("Yes") : _("No")),

--- a/modules/devices/dmi.c
+++ b/modules/devices/dmi.c
@@ -30,28 +30,29 @@ struct _DMIInfo {
   const gchar *name;
   const gchar *id_str;
   int group;
+  gboolean maybe_vendor;
 };
 
 DMIInfo dmi_info_table[] = {
   { N_("Product"), NULL, 1 },
   { N_("Name"), "system-product-name", 0 },
   { N_("Family"), "system-product-family", 0 },
-  { N_("Vendor"), "system-manufacturer", 0 },
+  { N_("Vendor"), "system-manufacturer", 0, TRUE },
   { N_("Version"), "system-version", 0 },
   { N_("Serial Number"), "system-serial-number", 0 },
   { N_("SKU"), "system-sku", 0 },
   { N_("BIOS"), NULL, 1 },
   { N_("Date"), "bios-release-date", 0 },
-  { N_("Vendor"), "bios-vendor", 0 },
+  { N_("Vendor"), "bios-vendor", 0, TRUE },
   { N_("Version"), "bios-version", 0 },
   { N_("Board"), NULL, 1 },
   { N_("Name"), "baseboard-product-name", 0 },
-  { N_("Vendor"), "baseboard-manufacturer", 0 },
+  { N_("Vendor"), "baseboard-manufacturer", 0, TRUE },
   { N_("Version"), "baseboard-version", 0 },
   { N_("Serial Number"), "baseboard-serial-number", 0 },
   { N_("Asset Tag"), "baseboard-asset-tag", 0 },
   { N_("Chassis"), NULL, 1 },
-  { N_("Vendor"), "chassis-manufacturer", 0 },
+  { N_("Vendor"), "chassis-manufacturer", 0, TRUE },
   { N_("Type"), "chassis-type", 0 },
   { N_("Version"), "chassis-version", 0 },
   { N_("Serial Number"), "chassis-serial-number", 0 },
@@ -125,10 +126,10 @@ gboolean dmi_get_info(void)
                 break;
             case 3: /* good value */
             {
-                gchar *link = vendor_get_link(value);
                 dmi_info =
-                    h_strdup_cprintf("%s=%s\n", dmi_info, _(info->name), link);
-                g_free(link);
+                    h_strdup_cprintf("%s%s=%s\n", dmi_info,
+                        info->maybe_vendor ? "$^$" : "",
+                        _(info->name), value);
                 add_to_moreinfo(group, info->name, value);
                 dmi_succeeded = TRUE;
                 break;

--- a/modules/devices/dmi_memory.c
+++ b/modules/devices/dmi_memory.c
@@ -787,7 +787,7 @@ gchar *memory_devices_get_info() {
                             );
             g_free(spd);
             moreinfo_add_with_prefix(tag_prefix, tag, details); /* moreinfo now owns *details */
-            const gchar *mfgr = s->mfgr ? vendor_get_shortest_name(s->mfgr) : NULL;
+            gchar *mfgr = s->mfgr ? vendor_match_tag(s->mfgr,  params.fmt_opts) : NULL;
             ret = h_strdup_cprintf("$!%s$%s=%s|%s|%s\n",
                     ret,
                     tag,
@@ -796,6 +796,7 @@ gchar *memory_devices_get_info() {
                     );
             icons = h_strdup_cprintf("Icon$%s$=%s\n", icons, tag, mem_icon);
             g_free(size_str);
+            g_free(mfgr);
         } else {
             gchar *details = g_strdup_printf("[%s]\n"
                             "%s=0x%"PRIx32", 0x%"PRIx32"\n"

--- a/modules/devices/dmi_memory.c
+++ b/modules/devices/dmi_memory.c
@@ -604,14 +604,6 @@ gchar *make_spd_section(spd_data *spd) {
             default:
                 DEBUG("blug for type: %d %s\n", spd->type, ram_types[spd->type]);
         }
-        gchar *vendor_str = NULL;
-        if (spd->vendor) {
-            vendor_str = vendor_get_link_from_vendor(spd->vendor);
-        }
-        gchar *dram_vendor_str = NULL;
-        if (spd->dram_vendor) {
-            dram_vendor_str = vendor_get_link_from_vendor(spd->dram_vendor);
-        }
         gchar *size_str = NULL;
         if (!spd->size_MiB)
             size_str = g_strdup(_("(Unknown)"));
@@ -627,8 +619,8 @@ gchar *make_spd_section(spd_data *spd) {
                     "%s=%d.%d\n"
                     "%s=%s\n"
                     "%s=%s\n"
-                    "%s=[%02x%02x] %s%s\n" /* module vendor */
-                    "%s=[%02x%02x] %s%s\n" /* dram vendor */
+                    "$^$%s=[%02x%02x] %s\n" /* module vendor */
+                    "$^$%s=[%02x%02x] %s\n" /* dram vendor */
                     "%s=%s\n" /* part */
                     "%s=%s\n" /* size */
                     "%s=%s\n" /* mfg date */
@@ -640,16 +632,15 @@ gchar *make_spd_section(spd_data *spd) {
                     _("Form Factor"), UNKIFNULL2(spd->form_factor),
                     _("Type"), UNKIFEMPTY2(spd->type_detail),
                     _("Module Vendor"), spd->vendor_bank, spd->vendor_index,
-                        UNKIFNULL2(spd->vendor_str), vendor_str ? vendor_str : "",
+                        UNKIFNULL2(spd->vendor_str),
                     _("DRAM Vendor"), spd->dram_vendor_bank, spd->dram_vendor_index,
-                        UNKIFNULL2(spd->dram_vendor_str), dram_vendor_str ? dram_vendor_str : "",
+                        UNKIFNULL2(spd->dram_vendor_str),
                     _("Part Number"), UNKIFEMPTY2(spd->partno),
                     _("Size"), size_str,
                     _("Manufacturing Date (Week / Year)"), UNKIFNULL2(mfg_date_str),
                     full_spd ? full_spd : ""
                     );
         g_free(full_spd);
-        g_free(vendor_str);
         g_free(size_str);
         g_free(mfg_date_str);
     }
@@ -748,10 +739,6 @@ gchar *memory_devices_get_info() {
         tag_make_safe_inplace(tag);
 
         if (s->populated) {
-            gchar *vendor_str = NULL;
-            if (s->vendor) {
-                vendor_str = vendor_get_link_from_vendor(s->vendor);
-            }
             gchar *size_str = NULL;
             if (!s->size_str)
                 size_str = g_strdup(_("(Unknown)"));
@@ -768,7 +755,7 @@ gchar *memory_devices_get_info() {
                             "%s=%s\n"
                             "%s=%s\n"
                             "%s=%s / %s\n"
-                            "%s=[%02x%02x] %s%s\n"
+                            "$^$%s=[%02x%02x] %s\n"
                             "%s=%s\n"
                             "%s=%s\n"
                             "%s=%s\n"
@@ -786,8 +773,7 @@ gchar *memory_devices_get_info() {
                             _("Form Factor"), UNKIFNULL2(s->form_factor),
                             _("Type"), UNKIFNULL2(s->type), UNKIFNULL2(s->type_detail),
                             _("Vendor"),
-                                s->mfgr_bank, s->mfgr_index,
-                                UNKIFNULL2(s->mfgr), vendor_str ? vendor_str : "",
+                                s->mfgr_bank, s->mfgr_index, UNKIFNULL2(s->mfgr),
                             _("Part Number"), UNKIFNULL2(s->partno),
                             _("Size"), size_str,
                             _("Rated Speed"), UNKIFNULL2(s->speed_str),
@@ -809,7 +795,6 @@ gchar *memory_devices_get_info() {
                     UNKIFNULL2(s->partno), size_str, UNKIFNULL2(mfgr)
                     );
             icons = h_strdup_cprintf("Icon$%s$=%s\n", icons, tag, mem_icon);
-            g_free(vendor_str);
             g_free(size_str);
         } else {
             gchar *details = g_strdup_printf("[%s]\n"

--- a/modules/devices/firmware.c
+++ b/modules/devices/firmware.c
@@ -163,9 +163,10 @@ gchar *fwupdmgr_get_devices_info() {
             *next_nl = 0;
             if (!isspace(*p) && *p != 0) {
                 if (gv && !has_vendor_field) {
-                    gchar *vstr = vendor_get_link_from_vendor(gv);
                     info_group_add_field(this_group,
-                        info_field(_("Vendor"), vstr, .free_value_on_flatten = TRUE) );
+                        info_field(_("Vendor"), gv->name,
+                            .value_has_vendor = TRUE,
+                            .free_value_on_flatten = FALSE) );
                 }
                 g_strstrip(p);
                 this_group = info_add_group(info, g_strdup(p), info_field_last());
@@ -185,10 +186,10 @@ gchar *fwupdmgr_get_devices_info() {
                         has_vendor_field = TRUE;
                         const Vendor* v = vendor_match(col+1, NULL);
                         if (v) {
-                            gchar *vstr = vendor_get_link_from_vendor(v);
                             info_group_add_field(this_group,
-                                info_field(_("Vendor"), vstr,
-                                .free_value_on_flatten = TRUE) );
+                                info_field(_("Vendor"), v->name,
+                                .value_has_vendor = TRUE,
+                                .free_value_on_flatten = FALSE) );
                         } else {
                             info_group_add_field(this_group,
                                 info_field(find_translation(p), g_strdup(col+1),
@@ -223,9 +224,10 @@ gchar *fwupdmgr_get_devices_info() {
         }
 
         if (gv && !has_vendor_field) {
-            gchar *vstr = vendor_get_link_from_vendor(gv);
             info_group_add_field(this_group,
-                info_field(_("Vendor"), vstr, .free_value_on_flatten = TRUE) );
+                info_field(_("Vendor"), gv->name,
+                    .value_has_vendor = TRUE,
+                    .free_value_on_flatten = FALSE) );
         }
 
         g_free(out);

--- a/modules/devices/monitors.c
+++ b/modules/devices/monitors.c
@@ -164,8 +164,10 @@ gchar *monitor_name(monitor *m, gboolean include_vendor) {
     if (include_vendor) {
         if (e->ven.type != VEN_TYPE_INVALID) {
             gchar *vstr = monitor_vendor_str(m, FALSE, FALSE);
-            desc = appfsp(desc, "%s", vendor_get_shortest_name(vstr));
+            gchar *vtag = vendor_match_tag(vstr, params.fmt_opts);
+                desc = appfsp(desc, "%s", vtag ? vtag : vstr);
             g_free(vstr);
+            g_free(vtag);
         } else
             desc = appfsp(desc, "%s", "Unknown");
     }
@@ -221,7 +223,7 @@ static gchar *make_edid_section(monitor *m) {
     int i;
     edid *e = m->e;
     if (e->len) {
-        gchar *vstr = monitor_vendor_str(m, TRUE, TRUE);
+        gchar *vstr = monitor_vendor_str(m, TRUE, FALSE);
 
         gchar *dom = NULL;
         if (!e->dom.is_model_year && e->dom.week && e->dom.year)
@@ -364,7 +366,7 @@ static gchar *make_edid_section(monitor *m) {
             "%s=%s\n" /* base out */
             "%s=%s\n" /* ext out */
             "[%s]\n"
-            "%s=%s\n" /* vendor */
+            "$^$%s=%s\n" /* vendor */
             "%s=%s\n" /* name */
             "%s=[%04x-%08x] %u-%u\n" /* model, n_serial */
             "%s=%s\n" /* serial */

--- a/modules/devices/pci.c
+++ b/modules/devices/pci.c
@@ -59,8 +59,6 @@ static const gchar *find_icon_for_class(uint32_t class)
     return "devices.png";
 }
 
-#include "format_early.h"
-
 static gchar *_pci_dev(const pcid *p, gchar *icons) {
     gchar *str;
     gchar *class, *vendor, *svendor, *product, *sproduct;
@@ -74,8 +72,8 @@ static gchar *_pci_dev(const pcid *p, gchar *icons) {
     product = UNKIFNULL_AC(p->device_id_str);
     sproduct = UNKIFNULL_AC(p->sub_device_id_str);
 
-    gchar *ven_tag = vendor_match_tag(p->vendor_id_str, FMT_OPT_PANGO); /* TODO:FIX FOR REPORT! */
-    gchar *sven_tag = vendor_match_tag(p->sub_vendor_id_str, FMT_OPT_PANGO); /* TODO:FIX FOR REPORT! */
+    gchar *ven_tag = vendor_match_tag(p->vendor_id_str, params.fmt_opts);
+    gchar *sven_tag = vendor_match_tag(p->sub_vendor_id_str, params.fmt_opts);
     if (ven_tag) {
         if (sven_tag && !vendor_is_svendor) {
             name = g_strdup_printf("%s %s %s", sven_tag, ven_tag, product);

--- a/modules/devices/printers.c
+++ b/modules/devices/printers.c
@@ -144,10 +144,11 @@ gchar *__cups_callback_boolean(gchar *value)
 const struct {
   char *key, *name;
   gchar *(*callback)(gchar *value);
+  gboolean maybe_vendor;
 } cups_fields[] = {
   { "Printer Information", NULL, NULL },
   { "printer-info", "Destination Name", NULL },
-  { "printer-make-and-model", "Make and Model", NULL },
+  { "printer-make-and-model", "Make and Model", NULL, TRUE },
 
   { "Capabilities", NULL, NULL },
   { "printer-type", "#", __cups_callback_ptype },
@@ -244,8 +245,9 @@ scan_printers_do(void)
                   }
                 }
 
-                prn_moreinfo = h_strdup_cprintf("%s=%s\n",
+                prn_moreinfo = h_strdup_cprintf("%s%s=%s\n",
                                                 prn_moreinfo,
+                                                cups_fields[j].maybe_vendor ? "$^$" : "",
                                                 cups_fields[j].name,
                                                 temp);
 

--- a/modules/devices/storage.c
+++ b/modules/devices/storage.c
@@ -151,7 +151,9 @@ gboolean __scan_udisks2_devices(void) {
         }
         else{
             label = g_strdup(disk->model);
-            vendor_str = disk->model;
+            /* try and pull one out of the model */
+            const Vendor *v = vendor_match(disk->model, NULL);
+            vendor_str = v ? v->name : _("(Unknown)");
         }
 
         icon = NULL;
@@ -218,9 +220,9 @@ gboolean __scan_udisks2_devices(void) {
                                    "Model=%s\n"),
                                    label);
 
-        moreinfo = h_strdup_cprintf(_("Vendor=%s\n"),
+        moreinfo = h_strdup_cprintf("$^$%s=%s\n",
                                      moreinfo,
-                                     idle_free(vendor_get_link(vendor_str)));
+                                     _("Vendor"), vendor_str);
 
         size = size_human_readable((gfloat) disk->size);
         moreinfo = h_strdup_cprintf(_("Revision=%s\n"
@@ -446,9 +448,9 @@ void __scan_scsi_devices(void)
                 gchar *strhash = g_strdup_printf(_("[Device Information]\n"
                                                  "Model=%s\n"), model);
 
-                strhash = h_strdup_cprintf(_("Vendor=%s\n"),
+                strhash = h_strdup_cprintf("$^$%s=%s\n",
                                            strhash,
-                                           idle_free(vendor_get_link(model)));
+                                           _("Vendor"), model);
 
                 strhash = h_strdup_cprintf(_("Type=%s\n"
                                            "Revision=%s\n"
@@ -645,7 +647,8 @@ void __scan_ide_devices(void)
 	    gchar *strhash = g_strdup_printf(_("[Device Information]\n" "Model=%s\n"),
 					     model);
 
-            strhash = h_strdup_cprintf(_("Vendor=%s\n"), strhash, idle_free(vendor_get_link(model)));
+            strhash = h_strdup_cprintf("$^$%s=%s\n",
+                            strhash, _("Vendor"), model);
 
 	    strhash = h_strdup_cprintf(_("Device Name=hd%c\n"
 					 "Media=%s\n" "Cache=%dkb\n"), strhash, iface, media, cache);

--- a/modules/devices/usb.c
+++ b/modules/devices/usb.c
@@ -109,7 +109,12 @@ static void _usb_dev(const usbd *u) {
     manufacturer = UNKIFNULL_AC(u->manufacturer);
     device = UNKIFNULL_AC(u->device);
 
-    name = g_strdup_printf("%s %s", u->vendor? vendor: manufacturer, u->product? product: device);
+    if (u->vendors) {
+        gchar *ribbon = vendor_list_ribbon(u->vendors, params.fmt_opts);
+        name = g_strdup_printf("%s %s", ribbon, u->product? product: device);
+    } else {
+        name = g_strdup_printf("%s %s", u->vendor? vendor: manufacturer, u->product? product: device);
+    }
     key = g_strdup_printf("USB%03d:%03d:%03d", u->bus, u->dev, 0);
     label = g_strdup_printf("%03d:%03d", u->bus, u->dev);
     icon = get_usbdev_icon(u);

--- a/modules/devices/usb.c
+++ b/modules/devices/usb.c
@@ -98,7 +98,7 @@ static const char* get_usbdev_icon(const usbd *u) {
 }
 
 static void _usb_dev(const usbd *u) {
-    gchar *name, *key, *v_str, *mv_str, *label, *str, *speed;
+    gchar *name, *key, *label, *str, *speed;
     gchar *product, *vendor, *manufacturer, *device;  /* don't free */
     gchar *interfaces = strdup("");
     usbi *i;
@@ -116,9 +116,6 @@ static void _usb_dev(const usbd *u) {
 
     usb_list = h_strdup_cprintf("$%s$%s=%s\n", usb_list, key, label, name);
     usb_icons = h_strdup_cprintf("Icon$%s$%s=%s.png\n", usb_icons, key, label, icon ? icon: "usb");
-
-    v_str = vendor_get_link(vendor);
-    mv_str = vendor_get_link(manufacturer);
 
     if (u->if_list != NULL) {
         i = u->if_list;
@@ -148,9 +145,9 @@ static void _usb_dev(const usbd *u) {
 
     str = g_strdup_printf("[%s]\n"
              /* Product */      "%s=[0x%04x] %s\n"
-             /* Vendor */       "%s=[0x%04x] %s\n"
+             /* Vendor */       "$^$%s=[0x%04x] %s\n"
              /* Device */       "%s=%s\n"
-             /* Manufacturer */ "%s=%s\n"
+             /* Manufacturer */ "$^$%s=%s\n"
              /* Max Current */  "%s=%d %s\n"
              /* USB Version */ "%s=%s\n"
              /* Speed */       "%s=%s\n"
@@ -165,9 +162,9 @@ static void _usb_dev(const usbd *u) {
              /* Interfaces */  "%s",
                 _("Device Information"),
                 _("Product"), u->product_id, product,
-                _("Vendor"), u->vendor_id, v_str,
+                _("Vendor"), u->vendor_id, vendor,
                 _("Device"), device,
-                _("Manufacturer"), mv_str,
+                _("Manufacturer"), manufacturer,
                 _("Max Current"), u->max_curr_ma, _("mA"),
                 _("USB Version"), u->usb_version,
                 _("Speed"), speed,
@@ -185,8 +182,6 @@ static void _usb_dev(const usbd *u) {
     moreinfo_add_with_prefix("DEV", key, str); /* str now owned by morinfo */
 
     g_free(speed);
-    g_free(v_str);
-    g_free(mv_str);
     g_free(name);
     g_free(key);
     g_free(label);

--- a/shell/report.c
+++ b/shell/report.c
@@ -929,6 +929,9 @@ static gboolean report_generate(ReportDialog * rd)
     gchar *file;
     FILE *stream;
 
+    int old_fmt_opts = params.fmt_opts;
+    params.fmt_opts =  FMT_OPT_NONE; // FIXME: FMT_OPT_HTML for HTML
+
     if (!(file = report_get_filename()))
 	return FALSE;
 
@@ -943,6 +946,7 @@ static gboolean report_generate(ReportDialog * rd)
 	g_warning(_("Cannot create ReportContext. Programming bug?"));
 	g_free(file);
 	fclose(stream);
+    params.fmt_opts = old_fmt_opts;
 	return FALSE;
     }
 
@@ -984,6 +988,7 @@ static gboolean report_generate(ReportDialog * rd)
     report_context_free(ctx);
     g_free(file);
 
+    params.fmt_opts = old_fmt_opts;
     return TRUE;
 }
 

--- a/shell/report.c
+++ b/shell/report.c
@@ -889,6 +889,9 @@ void report_context_free(ReportContext * ctx)
 
 void report_create_from_module_list(ReportContext * ctx, GSList * modules)
 {
+    if (ctx->format == REPORT_FORMAT_HTML)
+        params.fmt_opts = FMT_OPT_HTML;
+
     report_header(ctx);
 
     report_create_inner_from_module_list(ctx, modules);
@@ -930,7 +933,7 @@ static gboolean report_generate(ReportDialog * rd)
     FILE *stream;
 
     int old_fmt_opts = params.fmt_opts;
-    params.fmt_opts =  FMT_OPT_NONE; // FIXME: FMT_OPT_HTML for HTML
+    params.fmt_opts = FMT_OPT_NONE;
 
     if (!(file = report_get_filename()))
 	return FALSE;

--- a/shell/shell.c
+++ b/shell/shell.c
@@ -1612,17 +1612,6 @@ static void module_selected_show_info_detail(GKeyFile *key_file,
 
                 gboolean has_ven = key_value_has_vendor_string(flags);
                 const Vendor *v = has_ven ? vendor_match(value, NULL) : NULL;
-                gchar *value_markup = NULL;
-
-/*
-                if (v) {
-                    gchar *vendor_markup = vendor_info_markup(v);
-                    value_markup = g_strdup_printf("%s\n%s", value, vendor_markup);
-                    g_free(vendor_markup);
-                } else { */
-                    value_markup = g_strdup(value);
-                    g_free(value);
-                //}
 
                 key_markup =
                     g_strdup_printf("<span color=\"#666\">%s</span>", label);
@@ -1631,7 +1620,7 @@ static void module_selected_show_info_detail(GKeyFile *key_file,
                 gtk_label_set_use_markup(GTK_LABEL(key_label), TRUE);
                 gtk_misc_set_alignment(GTK_MISC(key_label), 1.0f, 0.5f);
 
-                GtkWidget *value_label = gtk_label_new(value_markup);
+                GtkWidget *value_label = gtk_label_new(value);
                 gtk_label_set_use_markup(GTK_LABEL(value_label), TRUE);
                 gtk_label_set_selectable(GTK_LABEL(value_label), TRUE);
 #if !GTK_CHECK_VERSION(3, 0, 0)
@@ -1687,7 +1676,7 @@ static void module_selected_show_info_detail(GKeyFile *key_file,
                 }
 
                 g_free(flags);
-                g_free(value_markup);
+                g_free(value);
                 g_free(key_markup);
                 g_free(label);
             }

--- a/shell/shell.c
+++ b/shell/shell.c
@@ -2256,11 +2256,13 @@ gboolean key_value_has_vendor_string(const gchar *key) {
 }
 
 gchar *key_mi_tag(const gchar *key) {
+    static char flag_list[] = "*!^";
     gchar *p = (gchar*)key, *l, *t;
 
     if (key_is_flagged(key)) {
         l = strchr(key+1, '$');
-        while(p < l && (*p == '$' || *p == '*' || *p == '!') ) {
+        if (*p == '$') p++; /* skip first if exists */
+        while(p < l && strchr(flag_list, *p)) {
             p++;
         }
         if (strlen(p)) {

--- a/shell/shell.c
+++ b/shell/shell.c
@@ -747,6 +747,7 @@ void shell_init(GSList * modules)
     DEBUG("initializing shell");
 
     uri_set_function(hardinfo_link);
+    params.fmt_opts = FMT_OPT_PANGO;
 
     create_window();
 
@@ -1523,8 +1524,6 @@ static void module_selected_show_info_list(GKeyFile *key_file,
 static gboolean detail_activate_link (GtkLabel *label, gchar *uri, gpointer user_data) {
     return uri_open(uri);
 }
-
-#include "format_early.h"
 
 static gchar *vendor_info_markup(const Vendor *v) {
     if (!v) return NULL;


### PR DESCRIPTION
As I said in #493, I think it's better to have the vendor values be the actual data from the hardware or lookup, and the vendor.c match data along side it instead of making a link.

Reasons:
* The actual value is interesting by itself
* There's usually more info available for a vendor than one link
* There might be a mismatch

So instead of doing the vendor lookup ourselves, we can just mark the value as a (possible) vendor
value and then it will be looked up by the shell, and a little info box will be added below it for any match.

To mark the field value as a possible vendor string:
* In the old shell conf style use the flag `^`.
* struct Info style use `(struct InfoField).value_has_vendor`.
* shell function: `key_value_has_vendor_string()` to check for the flag

I've converted these: dmi, x86 processor, gpus, monitors, pci, usb, memory devices, storage, printers.

Also, you might notice that I brought the little colored vendor tags over from sysobj.

Here are some screenshots:
![Screenshot_2019-12-27_19-59-14](https://user-images.githubusercontent.com/1758090/71537595-f61cef00-28e3-11ea-80a3-0d53e2e03c02.png)
![Screenshot_2019-12-27_18-12-36](https://user-images.githubusercontent.com/1758090/71537596-f61cef00-28e3-11ea-80c7-3bb2805d18b5.png)
![Screenshot_2019-12-27_18-24-08](https://user-images.githubusercontent.com/1758090/71537597-f61cef00-28e3-11ea-839a-081ae25b660c.png)
![Screenshot_2019-12-27_18-58-42](https://user-images.githubusercontent.com/1758090/71537598-f61cef00-28e3-11ea-828b-c1615d067485.png)
![Screenshot_2019-12-27_19-52-14](https://user-images.githubusercontent.com/1758090/71537599-f61cef00-28e3-11ea-868d-b5533d847024.png)
![Screenshot_2019-12-27_19-52-49](https://user-images.githubusercontent.com/1758090/71537600-f61cef00-28e3-11ea-9181-54be4134ce35.png)
