### PR TITLE
pci: get list from sysfs without using lscpi/pciutils

### DIFF
--- a/hardinfo/pci_util.c
+++ b/hardinfo/pci_util.c
@@ -62,13 +62,14 @@ char *pci_lookup_ids_vendor_str(uint32_t id) {
     return ret;
 }
 
-static void pci_lookup_ids(pcid *d) {
+static gboolean pci_lookup_ids(pcid *d) {
+    gboolean ret = FALSE;
     ids_query_result result = {};
     gchar *qpath;
 
     if (!pci_ids_file)
         find_pci_ids_file();
-    if (!pci_ids_file) return;
+    if (!pci_ids_file) return FALSE;
 
     /* lookup vendor, device, sub device */
     qpath = g_strdup_printf("%04x/%04x/%04x %04x",
@@ -77,14 +78,17 @@ static void pci_lookup_ids(pcid *d) {
     if (result.results[0]) {
         if (d->vendor_id_str) g_free(d->vendor_id_str);
         d->vendor_id_str = g_strdup(result.results[0]);
+        ret = TRUE;
     }
     if (result.results[1]) {
         if (d->device_id_str) g_free(d->device_id_str);
         d->device_id_str = g_strdup(result.results[1]);
+        ret = TRUE;
     }
     if (result.results[2]) {
         if (d->sub_device_id_str) g_free(d->sub_device_id_str);
         d->sub_device_id_str = g_strdup(result.results[2]);
+        ret = TRUE;
     }
     g_free(qpath);
 
@@ -94,8 +98,10 @@ static void pci_lookup_ids(pcid *d) {
     if (result.results[0]) {
         if (d->sub_vendor_id_str) g_free(d->sub_vendor_id_str);
         d->sub_vendor_id_str = g_strdup(result.results[0]);
-    }
+        ret = TRUE;
+    };
     g_free(qpath);
+    return ret;
 }
 
 pcid *pcid_new() {
@@ -327,9 +333,11 @@ pcid *pci_get_device(uint32_t dom, uint32_t bus, uint32_t dev, uint32_t func) {
     gboolean ok = FALSE;
     if (s) {
         ok = pci_get_device_sysfs(dom, bus, dev, func, s);
-        ok |= pci_get_device_lspci(dom, bus, dev, func, s);
-        /* TODO: other methods */
-
+        if (ok) {
+            ok |= pci_lookup_ids(s);
+            if (!ok)
+                ok |= pci_get_device_lspci(dom, bus, dev, func, s);
+        }
         if (!ok) {
             pcid_free(s);
             s = NULL;
@@ -374,9 +382,47 @@ static pcid *pci_get_device_list_lspci(uint32_t class_min, uint32_t class_max) {
     return head;
 }
 
+static pcid *pci_get_device_list_sysfs(uint32_t class_min, uint32_t class_max) {
+    pcid *head = NULL, *nd;
+    uint32_t dom, bus, dev, func, cls;
+    int ec;
+
+    if (class_max == 0) class_max = 0xffff;
+
+    const gchar *f = NULL;
+    GDir *d = g_dir_open("/sys/bus/pci/devices", 0, NULL);
+    if (!d) return 0;
+
+    while((f = g_dir_read_name(d))) {
+        ec = sscanf(f, "%x:%x:%x.%x", &dom, &bus, &dev, &func);
+        if (ec == 4) {
+            gchar *cf = g_strdup_printf("/sys/bus/pci/devices/%s/class", f);
+            gchar *cstr = NULL;
+            if (g_file_get_contents(cf, &cstr, NULL, NULL) ) {
+                cls = strtoul(cstr, NULL, 16) >> 8;
+                if (cls >= class_min && cls <= class_max) {
+                    nd = pci_get_device(dom, bus, dev, func);
+                    pci_fill_details(nd);
+                    if (head == NULL) {
+                        head = nd;
+                    } else {
+                        pcid_list_append(head, nd);
+                    }
+                }
+            }
+            g_free(cstr);
+            g_free(cf);
+        }
+    }
+    g_dir_close(d);
+    return head;
+}
+
 pcid *pci_get_device_list(uint32_t class_min, uint32_t class_max) {
-    /* try lspci */
-    return pci_get_device_list_lspci(class_min, class_max);
-    /* TODO: other methods */
+    pcid *ret = NULL;
+    ret = pci_get_device_list_sysfs(class_min, class_max);
+    if (!ret)
+        ret = pci_get_device_list_lspci(class_min, class_max);
+    return ret;
 }
 

--- a/hardinfo/pci_util.c
+++ b/hardinfo/pci_util.c
@@ -23,6 +23,15 @@
 #include "util_ids.h"
 
 gchar *pci_ids_file = NULL;
+const gboolean nolspci = FALSE; /* true for testing */
+
+/* Two pieces of info still only from lspci:
+ * - kernel driver in use
+ * - kernel modules list
+ *
+ * TODO: could use readlink() and basename() to get kernel driver from sysfs
+ * - /sys/bus/pci/devices/<addy>/driver is a symlink
+ */
 
 static void find_pci_ids_file() {
     if (pci_ids_file) return;
@@ -101,6 +110,26 @@ static gboolean pci_lookup_ids(pcid *d) {
         ret = TRUE;
     };
     g_free(qpath);
+
+    /* lookup class */
+    qpath = g_strdup_printf("C %02x/%02x", (d->class >> 8) & 0xff, (d->class & 0xff));
+    scan_ids_file(pci_ids_file, qpath, &result, -1);
+    if (result.results[0]) {
+        if (d->class_str) g_free(d->class_str);
+        d->class_str = g_strdup(result.results[0]);
+        if (result.results[1]
+            && !SEQ(result.results[0], result.results[1]) ) {
+                /* options 1: results[0] + " :: " + results[1] */
+                //d->class_str = appf(d->class_str, " :: ", "%s", result.results[1]);
+
+                /* option 2: results[1] or results[0] */
+                g_free(d->class_str);
+                d->class_str = g_strdup(result.results[1]);
+        }
+        ret = TRUE;
+    }
+    g_free(qpath);
+
     return ret;
 }
 
@@ -177,6 +206,7 @@ static int lspci_line_string_and_code(char *line, char *prefix, char **str, uint
 }
 
 static gboolean pci_fill_details(pcid *s) {
+    if (nolspci) return FALSE;
     gboolean spawned;
     gchar *out, *err, *p, *l, *next_nl;
     gchar *pci_loc = pci_address_str(s->domain, s->bus, s->device, s->function);
@@ -284,6 +314,7 @@ static gboolean pci_get_device_sysfs(uint32_t dom, uint32_t bus, uint32_t dev, u
 }
 
 static gboolean pci_get_device_lspci(uint32_t dom, uint32_t bus, uint32_t dev, uint32_t func, pcid *s) {
+    if (nolspci) return FALSE;
     gboolean spawned;
     gchar *out, *err, *p, *l, *next_nl;
     gchar *pci_loc = pci_address_str(dom, bus, dev, func);
@@ -347,6 +378,7 @@ pcid *pci_get_device(uint32_t dom, uint32_t bus, uint32_t dev, uint32_t func) {
 }
 
 static pcid *pci_get_device_list_lspci(uint32_t class_min, uint32_t class_max) {
+    if (nolspci) return NULL;
     gboolean spawned;
     gchar *out, *err, *p, *next_nl;
     pcid *head = NULL, *nd;

--- a/modules/devices/pci.c
+++ b/modules/devices/pci.c
@@ -61,7 +61,7 @@ static const gchar *find_icon_for_class(uint32_t class)
 
 static gchar *_pci_dev(const pcid *p, gchar *icons) {
     gchar *str;
-    const gchar *class, *vendor, *svendor, *product, *sproduct;
+    const gchar *class, *vendor, *svendor, *product, *sproduct, *lproduct;
     gchar *name, *key;
 
     gboolean device_is_sdevice = (p->vendor_id == p->sub_vendor_id && p->device_id == p->sub_device_id);
@@ -69,20 +69,21 @@ static gchar *_pci_dev(const pcid *p, gchar *icons) {
     class = UNKIFNULL_AC(p->class_str);
     vendor = UNKIFNULL_AC(p->vendor_id_str);
     svendor = UNKIFNULL_AC(p->sub_vendor_id_str);
-    product = p->device_id_str ? p->device_id_str : p->class_str;
-    product = UNKIFNULL_AC(product);
+    product = UNKIFNULL_AC(p->device_id_str);
     sproduct = UNKIFNULL_AC(p->sub_device_id_str);
+    lproduct = p->device_id_str ? p->device_id_str : p->class_str;
+    lproduct = UNKIFNULL_AC(lproduct);
 
     gchar *ven_tag = vendor_match_tag(p->vendor_id_str, params.fmt_opts);
     gchar *sven_tag = vendor_match_tag(p->sub_vendor_id_str, params.fmt_opts);
     if (ven_tag) {
         if (sven_tag && p->vendor_id != p->sub_vendor_id) {
-            name = g_strdup_printf("%s %s %s", sven_tag, ven_tag, product);
+            name = g_strdup_printf("%s %s %s", sven_tag, ven_tag, lproduct);
         } else {
-            name = g_strdup_printf("%s %s", ven_tag, product);
+            name = g_strdup_printf("%s %s", ven_tag, lproduct);
         }
     } else {
-        name = g_strdup_printf("%s %s", vendor, product);
+        name = g_strdup_printf("%s %s", vendor, lproduct);
     }
     g_free(ven_tag);
     g_free(sven_tag);

--- a/modules/devices/pci.c
+++ b/modules/devices/pci.c
@@ -61,7 +61,7 @@ static const gchar *find_icon_for_class(uint32_t class)
 
 static gchar *_pci_dev(const pcid *p, gchar *icons) {
     gchar *str;
-    gchar *class, *vendor, *svendor, *product, *sproduct;
+    const gchar *class, *vendor, *svendor, *product, *sproduct;
     gchar *name, *key;
 
     gboolean device_is_sdevice = (p->vendor_id == p->sub_vendor_id && p->device_id == p->sub_device_id);
@@ -69,7 +69,8 @@ static gchar *_pci_dev(const pcid *p, gchar *icons) {
     class = UNKIFNULL_AC(p->class_str);
     vendor = UNKIFNULL_AC(p->vendor_id_str);
     svendor = UNKIFNULL_AC(p->sub_vendor_id_str);
-    product = UNKIFNULL_AC(p->device_id_str);
+    product = p->device_id_str ? p->device_id_str : p->class_str;
+    product = UNKIFNULL_AC(product);
     sproduct = UNKIFNULL_AC(p->sub_device_id_str);
 
     gchar *ven_tag = vendor_match_tag(p->vendor_id_str, params.fmt_opts);


### PR DESCRIPTION
The lspci-using code is still there as fallback. Happy new year.