### PR TITLE
Show NVMe controller information in Storage

### DIFF
--- a/hardinfo/info.c
+++ b/hardinfo/info.c
@@ -109,7 +109,7 @@ struct InfoField info_field_printf(const gchar *name, const gchar *format, ...)
     };
 }
 
-static void info_group_strip_extra(struct InfoGroup *group)
+void info_group_strip_extra(struct InfoGroup *group)
 {
     guint fi;
     char *val, *oldval;

--- a/hardinfo/pci_util.c
+++ b/hardinfo/pci_util.c
@@ -322,6 +322,18 @@ static gboolean pci_get_device_lspci(uint32_t dom, uint32_t bus, uint32_t dev, u
     return FALSE;
 }
 
+pcid *pci_get_device_str(const char *addy) {
+    uint32_t dom, bus, dev, func, cls;
+    int ec;
+    if (addy) {
+        ec = sscanf(addy, "%x:%x:%x.%x", &dom, &bus, &dev, &func);
+        if (ec == 4) {
+            return pci_get_device(dom, bus, dev, func);
+        }
+    }
+    return NULL;
+}
+
 pcid *pci_get_device(uint32_t dom, uint32_t bus, uint32_t dev, uint32_t func) {
     pcid *s = pcid_new();
     gboolean ok = FALSE;

--- a/hardinfo/pci_util.c
+++ b/hardinfo/pci_util.c
@@ -323,7 +323,7 @@ static gboolean pci_get_device_lspci(uint32_t dom, uint32_t bus, uint32_t dev, u
 }
 
 pcid *pci_get_device_str(const char *addy) {
-    uint32_t dom, bus, dev, func, cls;
+    uint32_t dom, bus, dev, func;
     int ec;
     if (addy) {
         ec = sscanf(addy, "%x:%x:%x.%x", &dom, &bus, &dev, &func);

--- a/includes/info.h
+++ b/includes/info.h
@@ -76,6 +76,7 @@ struct InfoField {
 struct Info *info_new(void);
 
 struct InfoGroup *info_add_group(struct Info *info, const gchar *group_name, ...);
+void info_group_strip_extra(struct InfoGroup *group);
 
 void info_add_computed_group(struct Info *info, const gchar *name, const gchar *value);
 void info_add_computed_group_wo_extra(struct Info *info, const gchar *name, const gchar *value);

--- a/includes/pci_util.h
+++ b/includes/pci_util.h
@@ -67,6 +67,8 @@ int pcid_list_count(pcid *);
 void pcid_list_free(pcid *);
 
 pcid *pci_get_device(uint32_t dom, uint32_t bus, uint32_t dev, uint32_t func);
+pcid *pci_get_device_str(const char *addy);
+
 void pcid_free(pcid *);
 
 char *pci_lookup_ids_vendor_str(uint32_t id);

--- a/includes/udisks2_util.h
+++ b/includes/udisks2_util.h
@@ -1,4 +1,5 @@
 #include "vendor.h"
+#include "pci_util.h"
 
 typedef struct udiskp {
     gchar *block;
@@ -43,6 +44,7 @@ typedef struct udiskd {
     gint64 smart_bad_sectors;
     gint32 smart_temperature;
     udisksa *smart_attributes;
+    pcid *nvme_controller;
     vendor_list vendors;
 } udiskd;
 

--- a/modules/computer.c
+++ b/modules/computer.c
@@ -1009,7 +1009,7 @@ gchar *hi_module_get_summary(void)
                     "Method=computer::getDisplaySummary\n"
                     "[%s]\n"
                     "Icon=hdd.png\n"
-                    "Method=devices::getStorageDevices\n"
+                    "Method=devices::getStorageDevicesSimple\n"
                     "[%s]\n"
                     "Icon=printer.png\n"
                     "Method=devices::getPrinters\n"

--- a/modules/devices/storage.c
+++ b/modules/devices/storage.c
@@ -61,9 +61,11 @@ gchar *nvme_pci_sections(pcid *p) {
     gchar *pcie_str;
     if (p->pcie_width_curr) {
         pcie_str = g_strdup_printf("[%s]\n"
+                     /* Addy */    "%s=PCI/%s\n"
                      /* Width (max) */  "%s=x%u\n"
                      /* Speed (max) */  "%s=%0.1f %s\n",
                     _("PCI Express"),
+                    _("Location"), p->slot_str,
                     _("Maximum Link Width"), p->pcie_width_max,
                     _("Maximum Link Speed"), p->pcie_speed_max, _("GT/s") );
     } else

--- a/modules/devices/storage.c
+++ b/modules/devices/storage.c
@@ -81,8 +81,8 @@ gboolean __scan_udisks2_devices(void) {
     udiskp *part;
     udisksa *attrib;
     gchar *udisks2_storage_list = NULL, *features = NULL, *moreinfo = NULL;
-    gchar *devid, *label, *size, *tmp = NULL, *media_comp = NULL, *ven_tag = NULL;
-    const gchar *url, *vendor_str, *media_label, *alabel, *icon, *media_curr = NULL;
+    gchar *devid, *size, *tmp = NULL, *media_comp = NULL, *ven_tag = NULL;
+    const gchar *url, *media_label, *alabel, *icon, *media_curr = NULL;
     int n = 0, i, j;
 
     // http://storaged.org/doc/udisks2-api/latest/gdbus-org.freedesktop.UDisks2.Drive.html#gdbus-property-org-freedesktop-UDisks2-Drive.MediaCompatibility
@@ -195,13 +195,6 @@ gboolean __scan_udisks2_devices(void) {
         disk = (udiskd *)node->data;
         devid = g_strdup_printf("UDISKS%d", n++);
 
-        if (disk->vendor && strlen(disk->vendor) > 0)
-            vendor_str = disk->vendor;
-        else
-            vendor_str = _("(Unknown)");
-
-        label = g_strdup(disk->model);
-
         icon = NULL;
 
         media_curr = disk->media;
@@ -245,8 +238,8 @@ gboolean __scan_udisks2_devices(void) {
         size = size_human_readable((gfloat) disk->size);
         ven_tag = vendor_list_ribbon(disk->vendors, params.fmt_opts);
 
-        udisks2_storage_list = h_strdup_cprintf("$%s$%s=%s|%s\n", udisks2_storage_list, devid, label, ven_tag ? ven_tag : "", size);
-        storage_icons = h_strdup_cprintf("Icon$%s$%s=%s.png\n", storage_icons, devid, label, icon);
+        udisks2_storage_list = h_strdup_cprintf("$%s$%s=%s|%s %s\n", udisks2_storage_list, devid, disk->block_dev, size, ven_tag ? ven_tag : "", disk->model);
+        storage_icons = h_strdup_cprintf("Icon$%s$%s=%s.png\n", storage_icons, devid, disk->model, icon);
         features = h_strdup_cprintf("%s", features, disk->removable ? _("Removable"): _("Fixed"));
 
         if (disk->ejectable) {
@@ -267,11 +260,13 @@ gboolean __scan_udisks2_devices(void) {
 
         moreinfo = g_strdup_printf(_("[Drive Information]\n"
                                    "Model=%s\n"),
-                                   label);
+                                   disk->model);
 
-        moreinfo = h_strdup_cprintf("$^$%s=%s\n",
-                                     moreinfo,
-                                     _("Vendor"), vendor_str);
+        if (disk->vendor && *disk->vendor) {
+            moreinfo = h_strdup_cprintf("$^$%s=%s\n",
+                                        moreinfo,
+                                        _("Vendor"), disk->vendor);
+        }
 
         moreinfo = h_strdup_cprintf(_("Revision=%s\n"
                                     "Block Device=%s\n"
@@ -391,7 +386,6 @@ gboolean __scan_udisks2_devices(void) {
         moreinfo_add_with_prefix("DEV", devid, moreinfo);
         g_free(devid);
         g_free(features);
-        g_free(label);
         g_free(media_comp);
         media_comp = NULL;
 
@@ -497,7 +491,7 @@ void __scan_scsi_devices(void)
                 }
 
                 gchar *devid = g_strdup_printf("SCSI%d", n);
-                scsi_storage_list = h_strdup_cprintf("$%s$%s=\n", scsi_storage_list, devid, model);
+                scsi_storage_list = h_strdup_cprintf("$%s$scsi%d=|%s\n", scsi_storage_list, devid, scsi_controller, model);
                 storage_icons = h_strdup_cprintf("Icon$%s$%s=%s.png\n", storage_icons, devid, model, icon);
 
                 gchar *strhash = g_strdup_printf(_("[Device Information]\n"
@@ -694,7 +688,7 @@ void __scan_ide_devices(void)
 
 	    gchar *devid = g_strdup_printf("IDE%d", n);
 
-	    ide_storage_list = h_strdup_cprintf("$%s$%s=\n", ide_storage_list, devid, model);
+	    ide_storage_list = h_strdup_cprintf("$%s$%hd%c=|%s\n", ide_storage_list, devid, iface, model);
 	    storage_icons =
 		h_strdup_cprintf("Icon$%s$%s=%s.png\n", storage_icons,
 				 devid, model, g_str_equal(media, "cdrom") ? "cdrom" : "hdd");

--- a/modules/devices/storage.c
+++ b/modules/devices/storage.c
@@ -195,16 +195,12 @@ gboolean __scan_udisks2_devices(void) {
         disk = (udiskd *)node->data;
         devid = g_strdup_printf("UDISKS%d", n++);
 
-        if (disk->vendor && strlen(disk->vendor) > 0) {
-            label = g_strdup_printf("%s %s", disk->vendor, disk->model);
+        if (disk->vendor && strlen(disk->vendor) > 0)
             vendor_str = disk->vendor;
-        }
-        else{
-            label = g_strdup(disk->model);
-            /* try and pull one out of the model */
-            const Vendor *v = vendor_match(disk->model, NULL);
-            vendor_str = v ? v->name : _("(Unknown)");
-        }
+        else
+            vendor_str = _("(Unknown)");
+
+        label = g_strdup(disk->model);
 
         icon = NULL;
 


### PR DESCRIPTION
Shows the PCIe vendor/device and link information for NVMe storage.

Updated screengrab with @ocerman's changes:
![Screenshot_2020-01-02_12-09-44](https://user-images.githubusercontent.com/1758090/71683923-7a92c600-2d59-11ea-8fcf-17f33acf976f.png)

