### PR TITLE
[Needs testing] New flag/funcs for escaping label part in shell keys

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -281,6 +281,7 @@ add_executable(hardinfo
 	hardinfo/socket.c
 	hardinfo/util.c
 	hardinfo/gg_key_file_parse_string_as_value.c
+	hardinfo/gg_strescape.c
 	hardinfo/problem_marker.c
 	hardinfo/hinote_util.c
 	hardinfo/vendor.c
@@ -320,6 +321,7 @@ add_executable(hardinfo
 	hardinfo/socket.c
 	hardinfo/util.c
 	hardinfo/gg_key_file_parse_string_as_value.c
+	hardinfo/gg_strescape.c
 	hardinfo/problem_marker.c
 	hardinfo/hinote_util.c
 	hardinfo/vendor.c

--- a/hardinfo/gg_strescape.c
+++ b/hardinfo/gg_strescape.c
@@ -1,0 +1,138 @@
+/* Base on: GLIB - Library of useful routines for C programming
+ * Copyright (C) 1995-1997  Peter Mattis, Spencer Kimball and Josh MacDonald
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+
+#include <glib.h>
+
+guchar excmap_def[256] = {1,0};
+static void make_excmap_def() {
+  int i;
+  for(i=0; i<256; i++){
+    switch ((guchar)i)
+      {
+      case '\b':
+      case '\f':
+      case '\n':
+      case '\r':
+      case '\t':
+      case '\\':
+      case '"':
+        excmap_def[i] = 0;
+        break;
+      default:
+        if ((i < ' ') || (i >= 0177))
+          excmap_def[i] = 0;
+        else
+          excmap_def[i] = 1;
+        break;
+      }
+  }
+}
+
+gchar *
+gg_strescape (const gchar *source,
+             const gchar *exceptions,
+             const gchar *extra)
+{
+  const guchar *p;
+  gchar *dest;
+  gchar *q;
+  guchar excmap[256];
+
+  g_return_val_if_fail (source != NULL, NULL);
+
+  if (excmap_def[0]) /* [0] should be 0 or it isn't initialized */
+    make_excmap_def();
+
+  memcpy(excmap, excmap_def, 256);
+
+  p = (guchar *) source;
+  /* Each source byte needs maximally four destination chars (\777) */
+  q = dest = g_malloc (strlen (source) * 4 + 1);
+
+  if (exceptions)
+    {
+      guchar *e = (guchar *) exceptions;
+
+      while (*e)
+        {
+          excmap[*e] = 1;
+          e++;
+        }
+    }
+
+  if (extra)
+    {
+      guchar *e = (guchar *) extra;
+
+      while (*e)
+        {
+          excmap[*e] = 0;
+          e++;
+        }
+    }
+
+  while (*p)
+    {
+      if (excmap[*p])
+        *q++ = *p;
+      else
+        {
+          switch (*p)
+            {
+            case '\b':
+              *q++ = '\\';
+              *q++ = 'b';
+              break;
+            case '\f':
+              *q++ = '\\';
+              *q++ = 'f';
+              break;
+            case '\n':
+              *q++ = '\\';
+              *q++ = 'n';
+              break;
+            case '\r':
+              *q++ = '\\';
+              *q++ = 'r';
+              break;
+            case '\t':
+              *q++ = '\\';
+              *q++ = 't';
+              break;
+            case '\\':
+              *q++ = '\\';
+              *q++ = '\\';
+              break;
+            case '"':
+              *q++ = '\\';
+              *q++ = '"';
+              break;
+            default:
+              *q++ = '\\';
+              *q++ = '0' + (((*p) >> 6) & 07);
+              *q++ = '0' + (((*p) >> 3) & 07);
+              *q++ = '0' + ((*p) & 07);
+              break;
+            }
+        }
+      p++;
+    }
+  *q = 0;
+  return dest;
+}

--- a/hardinfo/info.c
+++ b/hardinfo/info.c
@@ -496,8 +496,8 @@ struct Info *info_unflatten(const gchar *str)
 
             for (k = 0; keys[k]; k++) {
                 struct InfoField field = {};
-                gchar *flags, *tag, *name;
-                key_get_components(keys[k], &flags, &tag, &name, NULL, NULL, TRUE);
+                gchar *flags, *tag, *name, *label, *dis;
+                key_get_components(keys[k], &flags, &tag, &name, &label, &dis, TRUE);
                 gchar *value = g_key_file_get_value(key_file, group_name, keys[k], NULL);
 
                 field.tag = tag;
@@ -511,8 +511,13 @@ struct Info *info_unflatten(const gchar *str)
                     field.highlight = TRUE;
                 if (key_value_has_vendor_string(flags))
                     field.value_has_vendor = TRUE;
+                if (key_label_is_escaped(flags)) {
+                    //TODO:...
+                }
 
                 g_free(flags);
+                g_free(label);
+                g_free(dis);
                 g_array_append_val(group.fields, field);
             }
             g_array_append_val(info->groups, group);

--- a/includes/hardinfo.h
+++ b/includes/hardinfo.h
@@ -213,6 +213,13 @@ gboolean hardinfo_spawn_command_line_sync(const gchar *command_line,
 /* a marker in text to point out problems, using markup where possible */
 const char *problem_marker();
 
+/* a version of g_strescape() that allows escaping extra characters.
+ * use with g_strcompress() as normal. */
+gchar *
+gg_strescape (const gchar *source,
+             const gchar *exceptions,
+             const gchar *extra);
+
 /* hinote helpers */
 #define note_max_len 512
 #define note_printf(note_buff, fmt, ...)  \

--- a/includes/info.h
+++ b/includes/info.h
@@ -65,6 +65,7 @@ struct InfoField {
     gboolean highlight;      /* select in GUI, highlight in report (flag:*) */
     gboolean report_details; /* show moreinfo() in report (flag:!) */
     gboolean value_has_vendor; /* (flag:^) */
+    gboolean label_is_escaped;  /* if the label will need g_strcompress() before display use */
 
     gboolean free_name_on_flatten;
     gboolean free_value_on_flatten;

--- a/includes/shell.h
+++ b/includes/shell.h
@@ -227,11 +227,16 @@ void		shell_set_remote_label(Shell *shell, gchar *label);
  *  ! = show details (moreinfo) in reports
  *  * = highlight/select this row
  *  ^ = value is/has a vendor string
+ *  @ = label is escaped with key_label_escape()
  */
 gboolean    key_is_flagged(const gchar *key);       /* has $[<flags>][<tag>]$ at the start of the key */
 gboolean    key_is_highlighted(const gchar *key);   /* flag '*' = select/highlight */
 gboolean    key_wants_details(const gchar *key);    /* flag '!' = report should include the "moreinfo" */
 gboolean key_value_has_vendor_string(const gchar *key); /* flag '^' = try and match the value to a vendor */
+#define key_label_escape(LBL) (gg_strescape(LBL, NULL, "=$#"))
+gboolean    key_label_is_escaped(const gchar *key); /* flag '@' = the label part is key_label_escape()-d and
+                                                     * needs to be g_strcompress()-ed before use.
+                                                     * key_get_components() will do this automatically for label. */
 gchar       *key_mi_tag(const gchar *key);          /* moreinfo lookup tag */
 const gchar *key_get_name(const gchar *key);        /* get the key's name, flagged or not */
 /*

--- a/modules/benchmark.c
+++ b/modules/benchmark.c
@@ -314,20 +314,28 @@ gchar *hi_get_field(gchar * field)
 
 static void br_mi_add(char **results_list, bench_result *b, gboolean select) {
     static unsigned int ri = 0; /* to ensure key is unique */
-    gchar *ckey, *rkey;
+    gchar *rkey, *lbl, *elbl, *this_marker;
 
-    ckey = hardinfo_clean_label(b->machine->cpu_name, 0);
+    this_marker = format_with_ansi_color(_("This Machine"), "0;30;43", params.fmt_opts);
+
     rkey = g_strdup_printf("%s__%d", b->machine->mid, ri++);
 
-    *results_list = h_strdup_cprintf("$%s%s$%s%s=%.2f|%s\n", *results_list,
-        select ? "*" : "", rkey, ckey,
-        b->legacy ? problem_marker() : "",
+    lbl = g_strdup_printf("%s%s%s%s",
+        select ? this_marker : "", select ? " " : "",
+        b->machine->cpu_name,
+        b->legacy ? problem_marker() : "");
+    elbl = key_label_escape(lbl);
+
+    *results_list = h_strdup_cprintf("$@%s%s$%s=%.2f|%s\n", *results_list,
+        select ? "*" : "", rkey, elbl,
         b->bvalue.result, b->machine->cpu_config);
 
     moreinfo_add_with_prefix("BENCH", rkey, bench_result_more_info(b) );
 
-    g_free(ckey);
+    g_free(lbl);
+    g_free(elbl);
     g_free(rkey);
+    g_free(this_marker);
 }
 
 gint bench_result_sort (gconstpointer a, gconstpointer b) {

--- a/shell/shell.c
+++ b/shell/shell.c
@@ -2342,11 +2342,9 @@ void key_get_components(const gchar *key,
             *dis = g_strdup(lbp + 1);
 
         if (flags && *flags && strchr(*flags, '@')) {
-            printf("flag@: %s\n", *label);
             gchar *ol = *label;
             *label = g_strcompress(ol);
             g_free(ol);
-            printf("..... %s\n", *label);
         }
     }
 }


### PR DESCRIPTION
Adds a new flag `@` to mark the label portion of the key as escaped with `key_label_escape()`. 
`key_get_components()` will automatically un-escape the label part when used.

`key_label_escape()` is just an alias for `gg_strescape()`, a modified version of glib's `g_strescape()` that allows specifying extra characters to escape, in our case "$#=" which have special meaning in the conf file format or in hardinfo. `g_strcompress()` is used as normal to un-escape it. Of course, the escape could be done manually: `=` is `\075`, for example.

Fixes #509.

Still needs some testing, there are a couple TODO:s added, so the LGTM bot will need to comment on every little change....