### PR TITLE
Don't count ROM as RAM in Memory Devices/Arrays

### DIFF
--- a/deps/sysobj_early/data/vendor.ids
+++ b/deps/sysobj_early/data/vendor.ids
@@ -1278,6 +1278,13 @@ name Westinghouse Electronics
     ansi_color 0;97;44
     match_string Westinghouse
 
+name Winbond Electronics Corporation
+    name_short Winbond
+    url www.winbond.com
+    wikipedia Winbond
+    ansi_color 0;31;107
+    match_string Winbond
+
 name X.Org Foundation
     name_short X.Org
     url www.x.org
@@ -1309,3 +1316,4 @@ name ZOTAC International
     url_support www.zotac.com/support/
     ansi_color 0;90;43
     match_string ZOTAC
+


### PR DESCRIPTION
Fixes #536. Although, this is the only example I have of a dmidecode memory device that is not RAM, so I don't know how universal it is.
![Screenshot_2020-03-28_00-37-00](https://user-images.githubusercontent.com/1758090/77815879-5ca0dd00-708c-11ea-9a12-03436cbd0828.png)
