### PR TITLE
Fix #545 info_add_group may goes wrong

### DIFF
--- a/hardinfo/info.c
+++ b/hardinfo/info.c
@@ -79,7 +79,7 @@ void info_group_add_fields(struct InfoGroup *group, ...)
 struct InfoGroup *info_add_group(struct Info *info, const gchar *group_name, ...)
 {
     struct InfoGroup group = {
-        .name = group_name,
+        .name = g_strdup(group_name),
         .fields = g_array_new(FALSE, FALSE, sizeof(struct InfoField))
     };
     va_list ap;


### PR DESCRIPTION
```
void info_add_group(struct Info *info, const gchar *group_name, ...)
{
    struct InfoGroup group = {
        .name = group_name,
        .fields = g_array_new(FALSE, FALSE, sizeof(struct InfoField))
    };
    /* ... */
}
```

Before we directly assign the second parameter to the `group.name`, but it is may gose wrong if the second parameter is a array or pointer. If we pass a pointer to the second parameter, continuously modify the value of this pointer in the loop to create multiple groups, all group will have same `group.name` ! So we assign the duplication of second parameter to the `group.name` now.

More info see #545 , google translation, may you can understand :)