### PR TITLE
README updates and fix json link error due benchmarck depens links

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,9 +89,7 @@ else()
 endif()
 
 pkg_check_modules(LIBSOUP libsoup-2.4>=2.42)
-if (LIBSOUP_FOUND)
-	pkg_check_modules(JSON_GLIB REQUIRED json-glib-1.0)
-endif()
+pkg_check_modules(JSON_GLIB REQUIRED json-glib-1.0)
 
 pkg_check_modules(X11 REQUIRED x11)
 

--- a/README.md
+++ b/README.md
@@ -21,12 +21,14 @@ DEPENDENCIES
 ------------
 
 Required:
-- GTK+ 2.10 (or newer)
-- GLib 2.10 (or newer)
+- Cmake 3.1 (or newer)
+- GTK+ 2.20 (or newer)
+- GLib 2.24 (or newer)
+- GLib JSON (for benchmarks)
 - Zlib (for zlib benchmark)
 
 Optional (for synchronization/remote):
-- Libsoup 2.24 (or newer)
+- Libsoup 2.42 (or newer)
 
 BUILDING
 --------
@@ -46,8 +48,6 @@ There are some variables that can be changed:
    * `[Default: Release]` ``Debug`` prints messages to console and is not recommended for general use.
  * `CMAKE_INSTALL_PREFIX`: Sets the installation prefix.
    * `[Default: /usr/local]`: Distributions usually change this to `/usr`.
- * `HARDINFO_NOSYNC`: Disables network synchronization.
-   * `[Default: 1]`: Disabled by default due to the server being lost.
 
 To set a variable, use cmake's -D parameter. For example:
 


### PR DESCRIPTION
i dont know but seems are need.. in gtk3 does work perfect, event if soup are disabled! it need for other compilations, so i'll update README