### PR TITLE
devices/storage: Improved S.M.A.R.T. report

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -26,6 +26,7 @@ Here is an incomplete list of contributors:
 * Mattia Rizzolo <mattia@mapreri.org>
 * Yo <yoldc22@free.fr>
 * "jamesbond" (http://chiselapp.com/user/jamesbond/)
+* Ondrej Čerman <ocerman@sda1.eu>
 
 Includes code from or based on:
 

--- a/includes/udisks2_util.h
+++ b/includes/udisks2_util.h
@@ -10,12 +10,23 @@ typedef struct udiskp {
     struct udiskp* next;
 } udiskp;
 
+enum{
+    UDSK_INTPVAL_SKIP          = 0,
+    UDSK_INTPVAL_DIMENSIONLESS = 1,
+    UDSK_INTPVAL_MILISECONDS   = 2,
+    UDSK_INTPVAL_HOURS         = 3,
+    UDSK_INTPVAL_SECTORS       = 4,
+    UDSK_INTPVAL_CELSIUS       = 5,
+};
+
 typedef struct udisksa {
     guint8 id;
     gchar *identifier;
     gint value;
     gint worst;
     gint threshold;
+    gint64 interpreted;
+    guint8 interpreted_unit; // enum
     struct udisksa* next;
 } udisksa;
 

--- a/modules/devices/storage.c
+++ b/modules/devices/storage.c
@@ -317,7 +317,7 @@ gboolean __scan_udisks2_devices(void) {
 
             if (disk->smart_attributes != NULL) {
                 moreinfo = h_strdup_cprintf(_("[S.M.A.R.T. Attributes]\n"
-                                            "Attribute=Value / Normalized / Worst / Threshold\n"),
+                                            "Attribute=<tt>Value      / Normalized / Worst / Threshold</tt>\n"),
                                             moreinfo);
 
                 attrib = disk->smart_attributes;
@@ -347,20 +347,24 @@ gboolean __scan_udisks2_devices(void) {
                             break;
                     }
 
+                    // pad spaces to next col
+                    j = g_utf8_strlen(tmp, -1);
+                    if (j < 13) tmp = h_strdup_cprintf("%*c", tmp, 13 - j, ' ');
+
                     if (attrib->value != -1)
-                        tmp = h_strdup_cprintf(" / %3d", tmp, attrib->value);
+                        tmp = h_strdup_cprintf("%-13d", tmp, attrib->value);
                     else
-                        tmp = h_strdup_cprintf(" / ???", tmp);
+                        tmp = h_strdup_cprintf("%-13s", tmp, "???");
 
                     if (attrib->worst != -1)
-                        tmp = h_strdup_cprintf(" / %3d", tmp, attrib->worst);
+                        tmp = h_strdup_cprintf("%-8d", tmp, attrib->worst);
                     else
-                        tmp = h_strdup_cprintf(" / ???", tmp);
+                        tmp = h_strdup_cprintf("%-8s", tmp, "???");
 
                     if (attrib->threshold != -1)
-                        tmp = h_strdup_cprintf(" / %3d", tmp, attrib->threshold);
+                        tmp = h_strdup_cprintf("%d", tmp, attrib->threshold);
                     else
-                        tmp = h_strdup_cprintf(" / ???", tmp);
+                        tmp = h_strdup_cprintf("???", tmp);
 
 
                     alabel = attrib->identifier;
@@ -371,7 +375,7 @@ gboolean __scan_udisks2_devices(void) {
                         }
                     }
 
-                    moreinfo = h_strdup_cprintf(_("(%d) %s=%s\n"),
+                    moreinfo = h_strdup_cprintf(_("(%d) %s=<tt>%s</tt>\n"),
                                             moreinfo,
                                             attrib->id, alabel, tmp);
                     g_free(tmp);

--- a/modules/devices/storage.c
+++ b/modules/devices/storage.c
@@ -186,6 +186,10 @@ gboolean __scan_udisks2_devices(void) {
         { "read-error-retry-rate",        _("Read Error Retry Rate") },
         { "total-lbas-written",           _("Total LBAs Written") },
         { "total-lbas-read",              _("Total LBAs Read") },
+        { "wear-leveling-count",          _("Wear leveling Count") },
+        { "used-reserved-blocks-total",   _("Total Used Reserved Block Count") },
+        { "program-fail-count-total",     _("Total Program Fail Count") },
+        { "erase-fail-count-total",       _("Total Erase Fail Count") },
         { NULL, NULL }
     };
 

--- a/modules/devices/storage.c
+++ b/modules/devices/storage.c
@@ -317,17 +317,40 @@ gboolean __scan_udisks2_devices(void) {
 
             if (disk->smart_attributes != NULL) {
                 moreinfo = h_strdup_cprintf(_("[S.M.A.R.T. Attributes]\n"
-                                            "Attribute=Normalized Value / Worst / Threshold\n"),
+                                            "Attribute=Value / Normalized / Worst / Threshold\n"),
                                             moreinfo);
 
                 attrib = disk->smart_attributes;
 
                 while (attrib != NULL){
                     tmp = g_strdup("");
+
+                    switch (attrib->interpreted_unit){
+                        case UDSK_INTPVAL_SKIP:
+                            tmp = h_strdup_cprintf("-", tmp);
+                            break;
+                        case UDSK_INTPVAL_MILISECONDS:
+                            tmp = h_strdup_cprintf("%ld ms", tmp, attrib->interpreted);
+                            break;
+                        case UDSK_INTPVAL_HOURS:
+                            tmp = h_strdup_cprintf("%ld h", tmp, attrib->interpreted);
+                            break;
+                        case UDSK_INTPVAL_CELSIUS:
+                            tmp = h_strdup_cprintf("%ld°C", tmp, attrib->interpreted);
+                            break;
+                        case UDSK_INTPVAL_SECTORS:
+                            tmp = h_strdup_cprintf(ngettext("%ld sector", "%ld sectors", attrib->interpreted), tmp, attrib->interpreted);
+                            break;
+                        case UDSK_INTPVAL_DIMENSIONLESS:
+                        default:
+                            tmp = h_strdup_cprintf("%ld", tmp, attrib->interpreted);
+                            break;
+                    }
+
                     if (attrib->value != -1)
-                        tmp = h_strdup_cprintf("%3d", tmp, attrib->value);
+                        tmp = h_strdup_cprintf(" / %3d", tmp, attrib->value);
                     else
-                        tmp = h_strdup_cprintf("???", tmp);
+                        tmp = h_strdup_cprintf(" / ???", tmp);
 
                     if (attrib->worst != -1)
                         tmp = h_strdup_cprintf(" / %3d", tmp, attrib->worst);


### PR DESCRIPTION
 - Added interpreted S.M.A.R.T. attribute values
 - The values from the S.M.A.R.T are now printed in monotype font and aligned to the columns
 - Added more S.M.A.R.T. attribute labels (found on Samsung SSD)
 - I have also added myself to the AUTHORS file

![smart](https://user-images.githubusercontent.com/10187350/101986175-ba15a200-3c8c-11eb-9011-09561deb6513.png)
