### PR TITLE
Added value check for HAS_LIBSENSORS 

### DIFF
--- a/modules/devices/sensors.c
+++ b/modules/devices/sensors.c
@@ -24,7 +24,7 @@
 #include "socket.h"
 #include "udisks2_util.h"
 
-#ifdef HAS_LIBSENSORS
+#if defined(HAS_LIBSENSORS) && HAS_LIBSENSORS
 #include <sensors/sensors.h>
 #endif
 


### PR DESCRIPTION
Tried to compile on Fedora 33 and ran into the issue that sensors.h could not be found. It turned out that HAS_LIBSENSORS was correctly defined as 0 but since it was defined, the library was expected to be present.

Changed it according to similar occurrences in the project to first check if the variable is defined and then the value.