### PR TITLE
devices/dmi: Fixed DMI display when DMI is not available

### DIFF
--- a/modules/devices/dmi.c
+++ b/modules/devices/dmi.c
@@ -90,8 +90,11 @@ gboolean dmi_get_info(void)
         } else if (group && info->id_str) {
             int state = 3;
 
-            if (strcmp(info->id_str, "chassis-type") == 0)
+            if (strcmp(info->id_str, "chassis-type") == 0) {
                 value = dmi_chassis_type_str(-1, 1);
+                if (value == NULL)
+                    state = (getuid() == 0) ? 0 : 1;
+            }
             else {
                 switch (dmi_str_status(info->id_str)) {
                 case 0:


### PR DESCRIPTION
This PR fixes following issues when the DMI is not availble:
 - the 'DMI is not available' message is now properly displayed
 - errors in stderr are no longer printed 