### PR TITLE
devices/memory - Improved DDR2

### DIFF
--- a/modules/devices/dmi_memory.c
+++ b/modules/devices/dmi_memory.c
@@ -274,6 +274,10 @@ dmi_mem_socket *dmi_mem_socket_new(dmi_handle h) {
         STR_IGNORE(s->voltage_conf_str, "Unknown");
 
         s->partno = dmidecode_match("Part Number", &dtm, &h);
+        STR_IGNORE(s->partno, "PartNum0");
+        STR_IGNORE(s->partno, "PartNum1");
+        STR_IGNORE(s->partno, "PartNum2");
+        STR_IGNORE(s->partno, "PartNum3");
         null_if_empty(&s->partno);
 
         s->data_width = dmidecode_match("Data Width", &dtm, &h);
@@ -283,6 +287,10 @@ dmi_mem_socket *dmi_mem_socket_new(dmi_handle h) {
 
         s->mfgr = dmidecode_match("Manufacturer", &dtm, &h);
         STR_IGNORE(s->mfgr, unknown_mfgr_str);
+        STR_IGNORE(s->mfgr, "Manufacturer0");
+        STR_IGNORE(s->mfgr, "Manufacturer1");
+        STR_IGNORE(s->mfgr, "Manufacturer2");
+        STR_IGNORE(s->mfgr, "Manufacturer3");
         STR_IGNORE(s->mfgr, "Unknown");
         null_if_empty(&s->mfgr);
 

--- a/modules/devices/spd-decode.c
+++ b/modules/devices/spd-decode.c
@@ -443,9 +443,9 @@ static void decode_ddr2_module_size(unsigned char *bytes, dmi_mem_size *size) {
     k = ((bytes[5] & 0x7) + 1) * bytes[17];
 
     if (i > 0 && i <= 12 && k > 0) {
-        if (*size) { *size = ((1 << i) * k); }
+        if (size) { *size = ((1 << i) * k); }
     } else {
-        if (*size) { *size = 0; }
+        if (size) { *size = 0; }
     }
 }
 


### PR DESCRIPTION
 - The first commit fixes module size for DDR2 RAM
 - The second commit adds more DDR2 SPD information: voltage, module type and timings for alternative speeds
 - The third commit adds ignore command for DMI memory type for some placeholder strings (found on ASUS motherboard /w socket 775)