### PR TITLE
hardinfo/udisks2_util.c : missing brackets

### DIFF
--- a/hardinfo/udisks2_util.c
+++ b/hardinfo/udisks2_util.c
@@ -345,7 +345,7 @@ gpointer get_udisks2_temp(const char *blockdev, GDBusProxy *block,
     v = get_dbus_property(drive, UDISKS2_DRIVE_ATA_INTERFACE, "SmartTemperature");
     if (v) {
         disk_temp = udiskt_new();
-        disk_temp->temperature = (gint32) g_variant_get_double(v) - 273.15;
+        disk_temp->temperature = (gint32) (g_variant_get_double(v) - 273.15);
         g_variant_unref(v);
     }
 


### PR DESCRIPTION
The brackets are missing.
Hardinfo shows the value 1 degree lower than in reality (udisksctl dump).