### PR TITLE
Correction for benchmarks not running on Arch

### DIFF
--- a/modules/benchmark.c
+++ b/modules/benchmark.c
@@ -620,9 +620,7 @@ static void do_benchmark(void (*benchmark_function)(void), int entry)
         return;
 
     if (params.gui_running) {
-        gchar *argv[] = {params.argv0, "-b",           entries[entry].name,
-                         "-m",         "benchmark.so", "-a",
-                         NULL};
+        gchar *argv[] = {params.argv0, "-b", entries[entry].name, "-m", "devices.so", "-m", "benchmark.so", "-a", NULL};
         GPid bench_pid;
         gint bench_stdout;
         GtkWidget *bench_dialog;


### PR DESCRIPTION
L.,

I went to run hardinfo on Arch and was unable to complete any benchmarks. High CPU usage was observed and the application would stay at the benchmarking dialog for as long as you'd let it.

Decided to check if others were having issues as well and stumbled into people in the [Arch User Repository](https://aur.archlinux.org/packages/hardinfo-git) commenting along with others here in the upstream. (#640, etc)

straced it down to a module dependency issue; as seen below.

I just wanted to push in at least a quick modification for Arch peeps and open dialog here. AUR is running a patch of the below for now as the maintainer there was able to confirm the ability to run benchmarks when patched.

I'll see about testing other distros, etc. Ideally checks would be added for this module issue. There were also some aberrations seen while testing that need to be debugged as well. Starting with something is better than nothing though!

Thanks for your time,
Weston