### PR TITLE
update of vendor id

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 project(HardInfo)
-cmake_minimum_required(VERSION 2.6)
-cmake_policy(VERSION 2.6)
+cmake_minimum_required(VERSION 2.8.12)
+cmake_policy(VERSION 2.8.12)
 
 set(HARDINFO_VERSION "0.6-alpha")
 option(HARDINFO_GTK3 "Attempt to build for GTK3 (0/off for GTK2)" 0)

--- a/data/vendor.ids
+++ b/data/vendor.ids
@@ -314,7 +314,7 @@ name Crucial (Micron)
 
 name Cypress Semiconductor
     name_short Cypress
-    url cypress.com
+    url infineon.com
     wikipedia Cypress Semiconductor
     ansi_color 0;36;107
     match_string Cypress


### PR DESCRIPTION
I tested the freshly built software with a Cypress USB (to PS2) adapter {keyboard and mouse}. A random test just an old device near to hand. I use Cypress PSoC devices - BLE etc so was aware of the company name change {absorption into infineon}. I have changed the vendor name for that USB id. This reflects the info at top of the Wikipedia page for Cypress. 
I enjoy using diagnostic tools and like to have them as accurate as possible. I submit this as a pull request also partly to see if this system is being monitored. 
I ran the 'bash updatepo.sh' but after this pull request. I can submit with that later. 