### PR TITLE
Add new dependency information from wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,10 @@ DEPENDENCIES
 ------------
 
 Required:
-- GTK+ 2.10 (or newer)
-- GLib 2.10 (or newer)
+- Cmake 3.1 (or newer)
+- GTK+ 2.20 (or newer)
+- GLib 2.24 (or newer)
+- GLib JSON (for benchmarks)
 - Zlib (for zlib benchmark)
 
 Optional (for synchronization/remote):


### PR DESCRIPTION
Add new dependency information from wiki.

Added from wiki page at https://github.com/lpereira/hardinfo/wiki