### PR TITLE
computer/os - Fixed ubuntu codename and flavors

### DIFF
--- a/modules/computer/os.c
+++ b/modules/computer/os.c
@@ -540,7 +540,7 @@ computer_get_os(void)
 
     os->entropy_avail = computer_get_entropy_avail();
 
-    if (g_strcmp0(os->distrocode, "ubuntu") == 0) {
+    if (g_strcmp0(os->distroid, "ubuntu") == 0) {
         GSList *flavs = ubuntu_flavors_scan();
         if (flavs) {
             /* just use the first one */

--- a/modules/computer/os.c
+++ b/modules/computer/os.c
@@ -366,12 +366,13 @@ parse_os_release(void)
     for (line = split; *line; line++) {
         if (!strncmp(*line, "ID=", sizeof("ID=") - 1)) {
             id = g_strdup(*line + strlen("ID="));
-        } else if (!strncmp(*line, "CODENAME=", sizeof("CODENAME=") - 1)) {
+        } else if (!strncmp(*line, "CODENAME=", sizeof("CODENAME=") - 1) && codename == NULL) {
             codename = g_strdup(*line + strlen("CODENAME="));
         } else if (!strncmp(*line, "PRETTY_NAME=", sizeof("PRETTY_NAME=") - 1)) {
-            pretty_name = g_strdup(*line +
-                                   strlen("PRETTY_NAME=\""));
+            pretty_name = g_strdup(*line + strlen("PRETTY_NAME=\""));
             strend(pretty_name, '"');
+        } else if (!strncmp(*line, "VERSION_CODENAME=", sizeof("VERSION_CODENAME=") - 1) && codename == NULL) {
+            codename = g_strdup(*line + strlen("VERSION_CODENAME="));
         }
     }
 
@@ -392,7 +393,7 @@ parse_lsb_release(void)
     gchar *codename = NULL;
     gchar **split, *contents, **line;
 
-    if (!hardinfo_spawn_command_line_sync("/usr/bin/lsb_release -di", &contents, NULL, NULL, NULL))
+    if (!hardinfo_spawn_command_line_sync("/usr/bin/lsb_release -dic", &contents, NULL, NULL, NULL))
         return (Distro) {};
 
     split = g_strsplit(idle_free(contents), "\n", 0);

--- a/modules/computer/ubuntu_flavors.c
+++ b/modules/computer/ubuntu_flavors.c
@@ -25,7 +25,7 @@ static const UbuntuFlavor ubuntu_flavors[] = {
     { "Vanilla Server", "distros/ubuntu.svg", "https://ubuntu.org", "ubuntu-server" },
     { "Vanilla Desktop", "distros/ubuntu.svg", "https://ubuntu.org", "ubuntu-desktop" },
     { "Xubuntu", "distros/xubuntu.svg", "https://xubuntu.org", "xubuntu-desktop" },
-    { "Kubuntu", "distros/kubuntu.png", "https://kubuntu.org", "kubuntu-desktop" },
+    { "Kubuntu", "distros/kubuntu.svg", "https://kubuntu.org", "kubuntu-desktop" },
     { "Lubuntu", "distros/lubuntu.png", "https://lubuntu.me", "lubuntu-desktop" }, /* formerly or also lubuntu.net? */
     { "Ubuntu MATE", "distros/ubuntu-mate.png", "https://ubuntu-mate.org", "ubuntu-mate-desktop" },
     { "Ubuntu Budgie", "distros/ubuntu-budgie.png", "https://ubuntubudgie.org", "ubuntu-budgie-desktop" },

--- a/modules/computer/ubuntu_flavors.c
+++ b/modules/computer/ubuntu_flavors.c
@@ -48,7 +48,8 @@ static const UbuntuFlavor *_find_flavor(const gchar *pkg) {
 }
 
 /* items are const; free with g_slist_free() */
-GSList *ubuntu_flavors_scan(void) {
+/* this function may not work properly when using non-english locale */
+GSList *ubuntu_flavors_scan_aptcache(void) {
     GSList *ret = NULL;
     gboolean spawned;
     gchar *out, *err, *p, *next_nl;
@@ -86,5 +87,51 @@ GSList *ubuntu_flavors_scan(void) {
         g_free(err);
     }
     g_free(cmd_line);
+    return ret;
+}
+
+GSList *ubuntu_flavors_scan_dpkgq(void) {
+    gboolean spawned;
+    GSList *ret = NULL;
+    gchar *out, *err, *p, *next_nl;
+    const UbuntuFlavor *f = NULL;
+    gchar *cmd_line = g_strdup("dpkg-query -W -f '${db:Status-Status}=${Package}\n'");
+    int i;
+
+    for (i = 0; ubuntu_flavors[i].base.name; i++) {
+        cmd_line = appfsp(cmd_line, "%s", ubuntu_flavors[i].package);
+    }
+    if (i == 0) {
+        g_free(cmd_line);
+        return NULL;
+    }
+
+    spawned = hardinfo_spawn_command_line_sync(cmd_line, &out, &err, NULL, NULL);
+    if (spawned) {
+        p = out;
+        while(next_nl = strchr(p, '\n')) {
+            strend(p, '\n');
+            if (g_str_has_prefix(p, "installed=")) {
+                f = _find_flavor(p + sizeof("installed=") - 1);
+                if (f) {
+                    ret = g_slist_append(ret, (void*)f);
+                }
+            }
+        }
+        g_free(out);
+        g_free(err);
+    }
+    g_free(cmd_line);
+    return ret;
+}
+
+/* free with g_slist_free() */
+GSList *ubuntu_flavors_scan(void) {
+    GSList *ret;
+    ret = ubuntu_flavors_scan_dpkgq();
+
+    if (ret == NULL)
+        ret = ubuntu_flavors_scan_aptcache();
+
     return ret;
 }


### PR DESCRIPTION
This PR:
 * fixes parsing codenames from os-release / lsb_release
 * fixes condition for calling ubuntu_flavors_scan
 * adds language-independent function for detecting ubuntu flavors (old function is now used as fallback)
 * fixes path to kubuntu icon