### PR TITLE
Update loongarch architecture processor information

### DIFF
--- a/includes/loongarch64/processor-platform.h
+++ b/includes/loongarch64/processor-platform.h
@@ -20,9 +20,12 @@
 #define __PROCESSOR_PLATFORM_H__
 
 struct _Processor {
-    gchar *model_name;
     gchar *vendor_id;
-    gfloat bogomips, cpu_mhz;
+    gchar *family;
+    gchar *model_name;
+    gint   revision;
+    gfloat cpu_mhz, bogomips;
+    gchar *features;
 };
 
 #endif	/* __PROCESSOR_PLATFORM_H__ */

--- a/modules/devices/loongarch64/processor.c
+++ b/modules/devices/loongarch64/processor.c
@@ -40,9 +40,12 @@ processor_scan(void)
             tmp[1] = g_strstrip(tmp[1]);
 
             get_str("system type", processor->vendor_id);
-            get_str("model name", processor->model_name);
+            get_str("CPU Family", processor->family);
+            get_str("Model Name", processor->model_name);
+            get_int("CPU Revision", processor->revision);
             get_float("CPU MHz", processor->cpu_mhz);
             get_float("BogoMIPS", processor->bogomips);
+            get_str("Features", processor->features);
         }
         g_strfreev(tmp);
     }
@@ -66,16 +69,22 @@ processor_get_info(GSList *processors)
     Processor *processor = (Processor *)processors->data;
 
     return g_strdup_printf("[%s]\n"
-                        "%s=%s\n"
-                        "%s=%s\n"
+                        "%s=%s\n"      /* vendor */
+                        "%s=%s\n"      /* family */
+                        "%s=%s\n"      /* name */
+                        "%s=%d\n"      /* revision */
                         "%s=%.2f %s\n" /* frequency */
                         "%s=%.2f\n"    /* bogoMIPS */
+                        "%s=%s\n"      /* features */
                         "%s=%s\n",     /* byte order */
                     _("Processor"),
-                    _("Model"), processor->model_name,
                     _("System Type"), processor->vendor_id,
+                    _("Family"), processor->family,
+                    _("Model"), processor->model_name,
+                    _("Revision"), processor->revision,
                     _("Frequency"), processor->cpu_mhz, _("MHz"),
                     _("BogoMIPS"), processor->bogomips,
+                    _("Features"), processor->features,
                     _("Byte Order"), byte_order_str()
                    );
 }


### PR DESCRIPTION
Update ```loongarch``` architecture processor information
The previous ```LoongArch``` support added in commit 56e590d was based on the kernel behavior before the official upstream merge. Stable cpuinfo: https://git.kernel.org/torvalds/c/7153c3c