### PR TITLE
Devices/SPD: Improved SPD decoding for DDR2

### DIFF
--- a/modules/devices/spd-decode.c
+++ b/modules/devices/spd-decode.c
@@ -757,7 +757,7 @@ static void decode_module_part_number(unsigned char *bytes, char *part_number) {
     if (part_number) {
         bytes += 8 + 64;
 
-        while (*bytes++ && *bytes >= 32 && *bytes < 127) { *part_number++ = *bytes; }
+        while (*++bytes && *bytes >= 32 && *bytes < 127) { *part_number++ = *bytes; }
         *part_number = '\0';
     }
 }


### PR DESCRIPTION
- First commit adds manufacturing date decoding for DDR2
  - also, the date decoding logic is put to one function as same logic is also used for DDR3/DDR4 RAM
- Second commit fixes part number decoding for DDR2 (and older) RAM.
  - As first valid part number location is at b. 73, the `*bytes` needs to be incremented to this value before `while` condition is being evaulated