### PR TITLE
Fix module loading order

### DIFF
--- a/hardinfo/util.c
+++ b/hardinfo/util.c
@@ -963,15 +963,28 @@ static GSList *modules_load(gchar ** module_list)
     g_free(filename);
 
     if (dir) {
-	while ((filename = (gchar *) g_dir_read_name(dir))) {
-	    if (g_strrstr(filename, "." G_MODULE_SUFFIX) &&
-		module_in_module_list(filename, module_list) &&
-		((module = module_load(filename)))) {
-		modules = g_slist_prepend(modules, module);
-	    }
-	}
+        GList *filenames = NULL;
+        while ((filename = (gchar *)g_dir_read_name(dir))) {
+            if (g_strrstr(filename, "." G_MODULE_SUFFIX) &&
+                module_in_module_list(filename, module_list)) {
+                if (g_strrstr(filename, "devices." G_MODULE_SUFFIX)) {
+                    filenames = g_list_prepend(filenames, filename);
+                }
+                else {
+                    filenames = g_list_append(filenames, filename);
+                }
+            }
+        }
 
-	g_dir_close(dir);
+        GList* item = NULL;
+        while (item = g_list_first(filenames)) {
+            if (module = module_load((gchar *)item->data)) {
+                modules = g_slist_prepend(modules, module);
+            }
+            filenames = g_list_delete_link(filenames, item);
+        }
+        g_list_free_full (g_steal_pointer (&filenames), g_object_unref);
+        g_dir_close(dir);
     }
 
     modules = modules_check_deps(modules);


### PR DESCRIPTION
I'm running Manjaro Linux (Plasma). Hardinfo didn't load the benchmarks for me, so I did a little digging, and found a ticket for it already. Since the issue didn't look too difficult, I decided to give it a shot, so here goes!

Loading `benchmark.so` before `devices.so` fails, so make sure we load `devices.so` first:

- Open the modules dir
- Create empty filenames list
- Read the directory contents (in arbitrary order) to filenames list
  - Prepend `devices.so` so it's always first
  - Append any other module to the list
- Load the modules from the filenames list in order

The terminal output was similar to the linked issue below. With this PR, I'm able to see and run benchmarks using the GUI, with terminal output now looking like this:

```
*** /home/matti/.cache/yay/hardinfo-git/src/hardinfo/hardinfo/util.c:744 (module_load) *** gmodule resource for ``/usr/lib/hardinfo/modules/devices.so'' is 0x604000015310 ((null))
*** /home/matti/.cache/yay/hardinfo-git/src/hardinfo/hardinfo/util.c:762 (module_load) *** initializing module ``devices.so''
*** /home/matti/.cache/yay/hardinfo-git/src/hardinfo/shell/syncmanager.c:105 (sync_manager_add_entry) *** registering syncmanager entry ''Update PCI ID listing''
*** /home/matti/.cache/yay/hardinfo-git/src/hardinfo/shell/syncmanager.c:105 (sync_manager_add_entry) *** registering syncmanager entry ''Update USB ID listing''
*** /home/matti/.cache/yay/hardinfo-git/src/hardinfo/shell/syncmanager.c:105 (sync_manager_add_entry) *** registering syncmanager entry ''Update EDID vendor codes''
*** /home/matti/.cache/yay/hardinfo-git/src/hardinfo/shell/syncmanager.c:105 (sync_manager_add_entry) *** registering syncmanager entry ''Update IEEE OUI vendor codes''
*** /home/matti/.cache/yay/hardinfo-git/src/hardinfo/shell/syncmanager.c:105 (sync_manager_add_entry) *** registering syncmanager entry ''Update SD card manufacturer information''
*** /home/matti/.cache/yay/hardinfo-git/src/hardinfo/shell/syncmanager.c:105 (sync_manager_add_entry) *** registering syncmanager entry ''Update CPU flags database''
*** /home/matti/.cache/yay/hardinfo-git/src/hardinfo/hardinfo/util.c:808 (module_load) *** registering methods for module ``devices.so''
*** /home/matti/.cache/yay/hardinfo-git/src/hardinfo/hardinfo/util.c:744 (module_load) *** gmodule resource for ``/usr/lib/hardinfo/modules/benchmark.so'' is 0x60400001e610 ((null))
*** /home/matti/.cache/yay/hardinfo-git/src/hardinfo/hardinfo/util.c:762 (module_load) *** initializing module ``benchmark.so''
*** /home/matti/.cache/yay/hardinfo-git/src/hardinfo/shell/syncmanager.c:105 (sync_manager_add_entry) *** registering syncmanager entry ''Send benchmark results''
*** /home/matti/.cache/yay/hardinfo-git/src/hardinfo/shell/syncmanager.c:105 (sync_manager_add_entry) *** registering syncmanager entry ''Receive benchmark results''
*** /home/matti/.cache/yay/hardinfo-git/src/hardinfo/hardinfo/util.c:808 (module_load) *** registering methods for module ``benchmark.so''
*** /home/matti/.cache/yay/hardinfo-git/src/hardinfo/hardinfo/util.c:744 (module_load) *** gmodule resource for ``/usr/lib/hardinfo/modules/computer.so'' is 0x60400001e890 ((null))
*** /home/matti/.cache/yay/hardinfo-git/src/hardinfo/hardinfo/util.c:762 (module_load) *** initializing module ``computer.so''
*** /home/matti/.cache/yay/hardinfo-git/src/hardinfo/hardinfo/util.c:808 (module_load) *** registering methods for module ``computer.so''
*** /home/matti/.cache/yay/hardinfo-git/src/hardinfo/hardinfo/util.c:744 (module_load) *** gmodule resource for ``/usr/lib/hardinfo/modules/network.so'' is 0x60400001ed10 ((null))
*** /home/matti/.cache/yay/hardinfo-git/src/hardinfo/hardinfo/util.c:762 (module_load) *** initializing module ``network.so''
*** /home/matti/.cache/yay/hardinfo-git/src/hardinfo/hardinfo/util.c:808 (module_load) *** registering methods for module ``network.so''
```

The downside of this approach is that it's only possible to have one module loaded before all the rest, and the rest will still be in arbitrary order. Module priority list (or dependency lists) would solve this but this works fine, as long as none of the other modules depend on a module other than `devices.so`.

Fixes #676

PS. This is my first contact with GLib, but at least the compiler is happy :smile: 