### PR TITLE
Here is the environment cinfiguration: cpu - atom, sd card as bootabl…

### DIFF
--- a/hardinfo/storage_util.c
+++ b/hardinfo/storage_util.c
@@ -100,7 +100,7 @@ void check_sdcard_vendor(u2driveext *e) {
     g_file_get_contents(oemid_path, &oemid, NULL, NULL);
     g_file_get_contents(manfid_path, &manfid, NULL, NULL);
 
-    unsigned int id = strtol(oemid, NULL, 16);
+    unsigned int id = oemid?strtol(oemid, NULL, 16):0;
     char c2 = id & 0xff, c1 = (id >> 8) & 0xff;
 
     qpath = g_strdup_printf("OEMID %02x%02x", (unsigned int)c1, (unsigned int)c2);
@@ -114,7 +114,7 @@ void check_sdcard_vendor(u2driveext *e) {
             isprint(c1) ? c1 : '.', isprint(c2) ? c2 : '.');
     g_free(qpath);
 
-    id = strtol(manfid, NULL, 16);
+    id = manfid?strtol(manfid, NULL, 16):0;
     qpath = g_strdup_printf("MANFID %06x", id);
     scan_ids_file(sdcard_ids_file, qpath, &result, -1);
     g_free(manfid);


### PR DESCRIPTION
…e disk, loist of devices:

/sys/block/zram0
/sys/block/mmcblk0boot0
/sys/block/mmcblk0boot1
/sys/block/mmcblk2
/sys/block/mmcblk0

Hardinfo got nex pathes for reading for the report:

1) # cat /sys/block/mmcblk0/device/oemid
0x0103
2) # cat /sys/block/mmcblk2/device/oemid
0x534d
3) # cat /sys/block/mmcblk0boot0/device/oemid
cat: /sys/block/mmcblk0boot0/device/oemid: No such file or directory 4) # cat /sys/block/mmcblk0boot1/device/oemid
cat: /sys/block/mmcblk0boot1/device/oemid: No such file or directory

In the code no checks if files from previous step for device was read and pointer not NULL:

gchar *oemid_path = g_strdup_printf("/sys/block/%s/device/oemid", e->d->block_dev); gchar *manfid_path = g_strdup_printf("/sys/block/%s/device/manfid", e->d->block_dev); gchar *oemid = NULL, *manfid = NULL;
g_file_get_contents(oemid_path, &oemid, NULL, NULL); g_file_get_contents(manfid_path, &manfid, NULL, NULL);

unsigned int id = strtol(oemid, NULL, 16);
...
id = strtol(manfid, NULL, 16);

Before srttol need check for NULL